### PR TITLE
Add architectural fitness function tests

### DIFF
--- a/test/architecture_test.dart
+++ b/test/architecture_test.dart
@@ -1,0 +1,298 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+
+// Architectural fitness function tests.
+//
+// These tests enforce the clean-architecture rules documented in CLAUDE.md by
+// scanning the source tree at test time. They catch violations that would
+// otherwise slip through only during human code review.
+//
+// Rules verified:
+//  1. Domain layer (*/domain/*) must not import Hive, Dio, or Flutter UI.
+//  2. Domain layer must not reach into the data layer via relative imports.
+//  3. BLoC files must not import Hive, Dio, or repository implementations.
+//  4. BLoC files must not reach into the data layer via relative imports.
+//  5. GetIt must only be accessed from main.dart and injection_container.dart.
+
+List<File> _dartFilesUnder(String path) => Directory(path)
+    .listSync(recursive: true)
+    .whereType<File>()
+    .where((f) => f.path.endsWith('.dart'))
+    .toList();
+
+List<String> _importsOf(File file) => file
+    .readAsLinesSync()
+    .where((line) => line.trimLeft().startsWith('import '))
+    .toList();
+
+bool _isRelativeImportIntoData(String importLine) =>
+    !importLine.contains("'package:") &&
+    !importLine.contains("'dart:") &&
+    importLine.contains('/data/');
+
+void main() {
+  group('Domain layer must not depend on infrastructure', () {
+    late List<File> domainFiles;
+
+    setUpAll(() {
+      domainFiles = _dartFilesUnder('lib')
+          .where((f) => f.path.contains('/domain/'))
+          .toList();
+    });
+
+    test('domain files exist', () => expect(domainFiles, isNotEmpty));
+
+    test('no Hive imports', () {
+      final violations = [
+        for (final file in domainFiles)
+          for (final imp in _importsOf(file))
+            if (imp.contains('package:hive')) '  ${file.path}\n    $imp',
+      ];
+      expect(
+        violations,
+        isEmpty,
+        reason: 'Domain layer must not import Hive:\n${violations.join('\n')}',
+      );
+    });
+
+    test('no Dio imports', () {
+      final violations = [
+        for (final file in domainFiles)
+          for (final imp in _importsOf(file))
+            if (imp.contains('package:dio')) '  ${file.path}\n    $imp',
+      ];
+      expect(
+        violations,
+        isEmpty,
+        reason: 'Domain layer must not import Dio:\n${violations.join('\n')}',
+      );
+    });
+
+    test('no Flutter UI imports (material / widgets / cupertino)', () {
+      const uiPackages = [
+        'package:flutter/material',
+        'package:flutter/widgets',
+        'package:flutter/cupertino',
+        'package:flutter/rendering',
+        'package:flutter/painting',
+      ];
+      final violations = [
+        for (final file in domainFiles)
+          for (final imp in _importsOf(file))
+            if (uiPackages.any(imp.contains)) '  ${file.path}\n    $imp',
+      ];
+      expect(
+        violations,
+        isEmpty,
+        reason:
+            'Domain layer must not import Flutter UI packages:\n${violations.join('\n')}',
+      );
+    });
+
+    test('no imports from the data layer', () {
+      final violations = [
+        for (final file in domainFiles)
+          for (final imp in _importsOf(file))
+            if (_isRelativeImportIntoData(imp)) '  ${file.path}\n    $imp',
+      ];
+      expect(
+        violations,
+        isEmpty,
+        reason:
+            'Domain layer must not import from data/:\n${violations.join('\n')}',
+      );
+    });
+  });
+
+  group('BLoC files must not bypass abstraction', () {
+    late List<File> blocFiles;
+
+    setUpAll(() {
+      blocFiles = _dartFilesUnder('lib')
+          .where(
+            (f) =>
+                f.path.contains('/presentation/bloc/') &&
+                f.path.endsWith('_bloc.dart'),
+          )
+          .toList();
+    });
+
+    test('BLoC files exist', () => expect(blocFiles, isNotEmpty));
+
+    test('no Hive imports', () {
+      final violations = [
+        for (final file in blocFiles)
+          for (final imp in _importsOf(file))
+            if (imp.contains('package:hive')) '  ${file.path}\n    $imp',
+      ];
+      expect(
+        violations,
+        isEmpty,
+        reason: 'BLoCs must not import Hive:\n${violations.join('\n')}',
+      );
+    });
+
+    test('no Dio imports', () {
+      final violations = [
+        for (final file in blocFiles)
+          for (final imp in _importsOf(file))
+            if (imp.contains('package:dio')) '  ${file.path}\n    $imp',
+      ];
+      expect(
+        violations,
+        isEmpty,
+        reason: 'BLoCs must not import Dio:\n${violations.join('\n')}',
+      );
+    });
+
+    test('no repository implementation imports (_impl.dart)', () {
+      final violations = [
+        for (final file in blocFiles)
+          for (final imp in _importsOf(file))
+            if (imp.contains('_impl.dart')) '  ${file.path}\n    $imp',
+      ];
+      expect(
+        violations,
+        isEmpty,
+        reason:
+            'BLoCs must depend on abstract repositories only, not _impl files:\n${violations.join('\n')}',
+      );
+    });
+
+    test('no imports from the data layer', () {
+      final violations = [
+        for (final file in blocFiles)
+          for (final imp in _importsOf(file))
+            if (_isRelativeImportIntoData(imp)) '  ${file.path}\n    $imp',
+      ];
+      expect(
+        violations,
+        isEmpty,
+        reason:
+            'BLoCs must not import from data/:\n${violations.join('\n')}',
+      );
+    });
+  });
+
+  group('GetIt must only be used in DI setup files', () {
+    test('no GetIt access outside main.dart and injection_container.dart', () {
+      const diFiles = {'main.dart', 'injection_container.dart'};
+
+      final violations = <String>[];
+      for (final file in _dartFilesUnder('lib')) {
+        if (diFiles.any((name) => file.path.endsWith(name))) continue;
+        final content = file.readAsStringSync();
+        if (content.contains('GetIt.instance') ||
+            content.contains('sl<') ||
+            content.contains('locator<')) {
+          violations.add('  ${file.path}');
+        }
+      }
+
+      expect(
+        violations,
+        isEmpty,
+        reason:
+            'GetIt must only be accessed from DI setup files:\n${violations.join('\n')}',
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Canary tests — verify that each detection rule actually catches violations.
+  // Each test points at a committed fixture file under
+  // test/fixtures/arch_violations/ that contains an intentional violation.
+  // The fixture files are NOT compiled; they exist purely as text to be scanned.
+  // ---------------------------------------------------------------------------
+  group('Canary: detection rules catch real violations', () {
+    const fixtures = 'test/fixtures/arch_violations';
+
+    test('detects Hive import in a domain file', () {
+      final file = File('$fixtures/domain_with_hive/domain/fake_entity.dart');
+      final violations = [
+        for (final imp in _importsOf(file))
+          if (imp.contains('package:hive')) imp,
+      ];
+      expect(violations, isNotEmpty);
+    });
+
+    test('detects Dio import in a domain file', () {
+      final file = File('$fixtures/domain_with_dio/domain/fake_usecase.dart');
+      final violations = [
+        for (final imp in _importsOf(file))
+          if (imp.contains('package:dio')) imp,
+      ];
+      expect(violations, isNotEmpty);
+    });
+
+    test('detects Flutter UI import in a domain file', () {
+      final file = File('$fixtures/domain_with_flutter_ui/domain/fake_entity.dart');
+      const uiPackages = [
+        'package:flutter/material',
+        'package:flutter/widgets',
+        'package:flutter/cupertino',
+        'package:flutter/rendering',
+        'package:flutter/painting',
+      ];
+      final violations = [
+        for (final imp in _importsOf(file))
+          if (uiPackages.any(imp.contains)) imp,
+      ];
+      expect(violations, isNotEmpty);
+    });
+
+    test('detects relative import into data/ from a domain file', () {
+      final file = File('$fixtures/domain_imports_data/domain/fake_usecase.dart');
+      final violations = [
+        for (final imp in _importsOf(file))
+          if (_isRelativeImportIntoData(imp)) imp,
+      ];
+      expect(violations, isNotEmpty);
+    });
+
+    test('detects Hive import in a BLoC file', () {
+      final file = File('$fixtures/bloc_with_hive/presentation/bloc/fake_bloc.dart');
+      final violations = [
+        for (final imp in _importsOf(file))
+          if (imp.contains('package:hive')) imp,
+      ];
+      expect(violations, isNotEmpty);
+    });
+
+    test('detects Dio import in a BLoC file', () {
+      final file = File('$fixtures/bloc_with_dio/presentation/bloc/fake_bloc.dart');
+      final violations = [
+        for (final imp in _importsOf(file))
+          if (imp.contains('package:dio')) imp,
+      ];
+      expect(violations, isNotEmpty);
+    });
+
+    test('detects _impl.dart import in a BLoC file', () {
+      final file = File('$fixtures/bloc_with_impl/presentation/bloc/fake_bloc.dart');
+      final violations = [
+        for (final imp in _importsOf(file))
+          if (imp.contains('_impl.dart')) imp,
+      ];
+      expect(violations, isNotEmpty);
+    });
+
+    test('detects relative import into data/ from a BLoC file', () {
+      final file = File('$fixtures/bloc_imports_data/presentation/bloc/fake_bloc.dart');
+      final violations = [
+        for (final imp in _importsOf(file))
+          if (_isRelativeImportIntoData(imp)) imp,
+      ];
+      expect(violations, isNotEmpty);
+    });
+
+    test('detects GetIt usage outside DI files', () {
+      final file = File('$fixtures/widget_with_getit/presentation/widgets/fake_widget.dart');
+      final content = file.readAsStringSync();
+      final found = content.contains('GetIt.instance') ||
+          content.contains('sl<') ||
+          content.contains('locator<');
+      expect(found, isTrue);
+    });
+  });
+}

--- a/test/fixtures/arch_violations/bloc_imports_data/presentation/bloc/fake_bloc.dart
+++ b/test/fixtures/arch_violations/bloc_imports_data/presentation/bloc/fake_bloc.dart
@@ -1,0 +1,5 @@
+// ignore_for_file: unused_import, uri_does_not_exist
+// FIXTURE — intentional architecture violation: BLoC importing from the data layer.
+// This file exists solely to prove that the architecture tests detect this violation.
+import '../../data/datasources/fake_data_source.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';

--- a/test/fixtures/arch_violations/bloc_with_dio/presentation/bloc/fake_bloc.dart
+++ b/test/fixtures/arch_violations/bloc_with_dio/presentation/bloc/fake_bloc.dart
@@ -1,0 +1,5 @@
+// ignore_for_file: unused_import
+// FIXTURE — intentional architecture violation: BLoC importing Dio.
+// This file exists solely to prove that the architecture tests detect this violation.
+import 'package:dio/dio.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';

--- a/test/fixtures/arch_violations/bloc_with_hive/presentation/bloc/fake_bloc.dart
+++ b/test/fixtures/arch_violations/bloc_with_hive/presentation/bloc/fake_bloc.dart
@@ -1,0 +1,5 @@
+// ignore_for_file: unused_import
+// FIXTURE — intentional architecture violation: BLoC importing Hive.
+// This file exists solely to prove that the architecture tests detect this violation.
+import 'package:hive/hive.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';

--- a/test/fixtures/arch_violations/bloc_with_impl/presentation/bloc/fake_bloc.dart
+++ b/test/fixtures/arch_violations/bloc_with_impl/presentation/bloc/fake_bloc.dart
@@ -1,0 +1,5 @@
+// ignore_for_file: unused_import, uri_does_not_exist
+// FIXTURE — intentional architecture violation: BLoC importing a repository implementation.
+// This file exists solely to prove that the architecture tests detect this violation.
+import '../../data/repositories/fake_repository_impl.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';

--- a/test/fixtures/arch_violations/domain_imports_data/domain/fake_usecase.dart
+++ b/test/fixtures/arch_violations/domain_imports_data/domain/fake_usecase.dart
@@ -1,0 +1,5 @@
+// ignore_for_file: unused_import, uri_does_not_exist
+// FIXTURE — intentional architecture violation: domain importing from data layer.
+// This file exists solely to prove that the architecture tests detect this violation.
+import '../../data/models/fake_model.dart';
+import 'package:equatable/equatable.dart';

--- a/test/fixtures/arch_violations/domain_with_dio/domain/fake_usecase.dart
+++ b/test/fixtures/arch_violations/domain_with_dio/domain/fake_usecase.dart
@@ -1,0 +1,5 @@
+// ignore_for_file: unused_import
+// FIXTURE — intentional architecture violation: domain importing Dio.
+// This file exists solely to prove that the architecture tests detect this violation.
+import 'package:dio/dio.dart';
+import 'package:equatable/equatable.dart';

--- a/test/fixtures/arch_violations/domain_with_flutter_ui/domain/fake_entity.dart
+++ b/test/fixtures/arch_violations/domain_with_flutter_ui/domain/fake_entity.dart
@@ -1,0 +1,5 @@
+// ignore_for_file: unused_import
+// FIXTURE — intentional architecture violation: domain importing Flutter UI.
+// This file exists solely to prove that the architecture tests detect this violation.
+import 'package:flutter/material.dart';
+import 'package:equatable/equatable.dart';

--- a/test/fixtures/arch_violations/domain_with_hive/domain/fake_entity.dart
+++ b/test/fixtures/arch_violations/domain_with_hive/domain/fake_entity.dart
@@ -1,0 +1,5 @@
+// ignore_for_file: unused_import
+// FIXTURE — intentional architecture violation: domain importing Hive.
+// This file exists solely to prove that the architecture tests detect this violation.
+import 'package:hive/hive.dart';
+import 'package:equatable/equatable.dart';

--- a/test/fixtures/arch_violations/widget_with_getit/presentation/widgets/fake_widget.dart
+++ b/test/fixtures/arch_violations/widget_with_getit/presentation/widgets/fake_widget.dart
@@ -1,0 +1,4 @@
+// ignore_for_file: unused_import, unused_local_variable, undefined_function, undefined_identifier
+// FIXTURE — intentional architecture violation: widget accessing GetIt directly.
+// This file exists solely to prove that the architecture tests detect this violation.
+final repo = sl<String>();


### PR DESCRIPTION
## Summary
  - Add `test/architecture_test.dart` with 11 rules that enforce the clean
    architecture constraints documented in `CLAUDE.md` (domain layer isolation,
    BLoC abstraction, GetIt confinement to DI setup files)
  - Add 9 canary tests that point at committed fixture files under
    `test/fixtures/arch_violations/` to prove each detection rule actually
    catches a real violation

## Why
  Architecture rules were enforced only by human code review. Any contributor
  could accidentally import Hive into a domain file or call `sl<>` from a widget
  without the CI catching it. These tests run on every `fvm flutter test` and
  fail with a clear message showing the offending file and import.

## Test plan
  - [ ] `fvm flutter test test/architecture_test.dart` — 20 tests, all green
  - [ ] `fvm flutter analyze` — no new issues introduced