### PR TITLE
Add GraphQL body type

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -52,8 +52,19 @@ verified with a real CFE compile per working-agreement #4; the mTLS change also 
   `RequestKindMethodSelector` (url_bar), `TabChip`/`EmptyTabsPlaceholder` (main_screen),
   `EnvironmentListTile`/`EnvironmentEditor` (environments_dialog) into their own public files.
 
-Remaining: the big deferred features **H3** (OAuth2), **H4** (collection runner), **M8**
-(GraphQL body), **M9** (pre-request scripts).
+Remaining: the big deferred features **H3** (OAuth2), **H4** (collection runner),
+**M9** (pre-request scripts).
+
+## ✅ Done in the GraphQL pass (June 2026)
+Shipped on `feat/graphql-body` (TDD, one concern per commit, analyze/custom_lint/
+bloc_lint clean + full suite green):
+- **M8** — `graphql` `BodyType`: dual-pane QUERY + VARIABLES (JSON) editor; send posts
+  `{query,variables}` as `application/json` with `{{var}}` resolved in both panes;
+  invalid variables surface a status-0 error response (never silent). New
+  `graphqlVariables` field on the request config (entity + Hive model typeId 1
+  `@HiveField(15)`; query reuses `body`). Round-trips through code-gen (all 6 targets),
+  Postman import/export, and the git workspace mirror. Spec + plan under
+  `docs/superpowers/`.
 
 ## ✅ Done in the backlog+refactor pass (June 2026)
 Foundational refactors + all bugs + two perf items are shipped on `dev`:
@@ -162,10 +173,10 @@ cheap LOW wins to bank momentum, then features/refactors as scoped.
 - **Fix**: Prioritize `realtime_service` (mock Dio + a fake `WebSocketChannel`; assert frame logging, SSE cancel path, teardown). Repo-impl tests are quick (mock data source, assert exception→Failure). `request_rules_repository_impl` has an untested `rules.isEmpty → deleteRules` branch.
 - **Effort**: M.
 
-### M8 — GraphQL body type
-- **Files**: `body_type.dart:4`, `request_config_entity.dart`, `request_serializer.dart`, `request_editor_tabs.dart`.
-- **Fix**: Add a `graphql` `BodyType` (new wire string for back-compat); store query + variables JSON; serialize `{query,variables}` with `application/json` at send; dual-pane editor.
-- **Effort**: M.
+### ✅ M8 (DONE) — GraphQL body type
+- **Files**: `body_type.dart`, `request_config_entity.dart`, `request_config_model.dart` (`@HiveField(15)`), `request_serializer.dart`, `request_editor_tabs.dart`, `request_view.dart`, `body_type_utils.dart`, `code_gen_service.dart`, `postman_collection_mapper.dart`, `workspace_collection_serializer.dart`.
+- **Fix**: Added a `graphql` `BodyType` (wire `'graphql'`, back-compat); query reuses `body`, variables in a new `graphqlVariables` field; serializes `{query,variables}` as `application/json` at send; dual-pane editor; invalid variables → status-0 error response. Round-trips code-gen / Postman / workspace mirror.
+- **Effort**: M. Spec + plan under `docs/superpowers/`.
 
 ### M9 — Pre-request scripts (no-code)
 - **Files**: `lib/features/chaining/…` (post-response only today), send pipeline in `tabs_bloc.dart`.

--- a/docs/superpowers/plans/2026-06-19-graphql-body-type.md
+++ b/docs/superpowers/plans/2026-06-19-graphql-body-type.md
@@ -1,0 +1,770 @@
+# GraphQL Body Type Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `graphql` request body type that sends `{"query": ..., "variables": ...}` as JSON, edited through a dual-pane (query + variables) body editor.
+
+**Architecture:** Reuse the existing `body` field for the GraphQL query; add one new `graphqlVariables` String field to the request config (entity + Hive model typeId 1, `@HiveField(15)`). Adding `graphql` to the `BodyType` enum is compile-forced across every exhaustive `switch (BodyType)` — Task 1 handles all of them (send serializer, content-type, code-gen, Postman export/import, workspace mirror) and keeps the option hidden from the UI; Task 2 adds the editor and makes it user-visible.
+
+**Tech Stack:** Flutter, `flutter_bloc`, `hive_ce` + `hive_ce_generator`, `dio`, `re_editor` (`CodeLineEditingController`).
+
+## Global Constraints
+
+- Flutter SDK invoked as `fvm flutter ...` (pinned via `.fvmrc`) — never plain `flutter`.
+- Imports are `package:getman/...` everywhere (no relative imports).
+- Verification bar (all must pass before a task is "done"): `fvm flutter analyze` (0 issues), `fvm dart run custom_lint`, `fvm dart run bloc_tools:bloc lint lib`, `fvm dart format lib test` clean, `fvm flutter test` 100% green.
+- After any `@HiveType`/`@HiveField` change: `dart run build_runner build --delete-conflicting-outputs`, then re-run analyze + tests. The model change is compile-affecting — verify with `fvm flutter test` (real CFE compile), not just analyze.
+- Never renumber an existing Hive `typeId`/`HiveField`. Next free `HiveField` on `HttpRequestConfig` (typeId 1) is **15**.
+- Theme mandates (CLAUDE.md §4.8): no hardcoded sizes/colors/radii/weights in widgets — pull from `context.appLayout` / `appPalette` / `appShape` / `appTypography`.
+- One concern per commit; commit message format `type(scope): summary` (no Co-Authored-By line — per user). TDD: failing test first where practical.
+
+---
+
+### Task 1: GraphQL send + persistence + export foundation
+
+Adds the enum value, the `graphqlVariables` field, the send-path serialization (with the invalid-variables error), and satisfies every compile-forced exhaustive switch (content-type, code-gen, Postman export, Postman import record, workspace mirror). The GraphQL chip stays **hidden** from the body-type selector (no `_labels` entry) until Task 2, so no half-built UI ships between tasks.
+
+**Files:**
+- Modify: `lib/core/domain/entities/body_type.dart` — add `graphql` enum value.
+- Modify: `lib/core/domain/entities/request_config_entity.dart` — add `graphqlVariables` field (constructor, `copyWith`, `props`).
+- Modify: `lib/features/history/data/models/request_config_model.dart` — add `@HiveField(15)` + `fromEntity`/`toEntity`.
+- Regenerate: `lib/features/history/data/models/request_config_model.g.dart` (via build_runner).
+- Modify: `lib/core/error/exceptions.dart` — add `GraphqlVariablesException`.
+- Modify: `lib/features/tabs/data/request_serializer.dart` — `buildBody` graphql case.
+- Modify: `lib/features/tabs/data/repositories/tabs_repository_impl.dart` — map `GraphqlVariablesException` → status-0 `NetworkFailure`.
+- Modify: `lib/core/utils/body_type_utils.dart` — graphql content-type rule.
+- Modify: `lib/core/utils/code_gen_service.dart` — envelope normalizer + graphql case-label in all 6 target switches.
+- Modify: `lib/core/utils/postman/postman_collection_mapper.dart` — `_configToBody` export + `_parseBody`/`_requestToConfig` import.
+- Modify: `lib/core/utils/workspace/workspace_collection_serializer.dart` — persist `graphqlVariables`.
+- Modify: `lib/features/tabs/presentation/widgets/request_editor_tabs.dart` — `_editorFor` graphql compile-stub + selector skips labels it doesn't have.
+- Test: `test/features/tabs/data/request_serializer_test.dart` (extend), `test/core/utils/postman/postman_collection_mapper_test.dart` (extend), `test/core/utils/code_gen_service_test.dart` (extend), and a config entity↔model round-trip test (extend existing model test if present, else add `test/features/history/data/models/request_config_model_test.dart`).
+
+**Interfaces:**
+- Produces: `BodyType.graphql` (wire `'graphql'`); `HttpRequestConfigEntity.graphqlVariables` (String, default `''`) + `copyWith({String? graphqlVariables})`; `GraphqlVariablesException(String detail)`.
+- Consumes: existing `EnvironmentResolver.resolve`, `BodyTypeUtils.applyContentType`, `HeaderUtils.{setHeader,hasCustomContentType}`, `FileBodyException` mapping pattern.
+
+- [ ] **Step 1: Add the enum value**
+
+In `lib/core/domain/entities/body_type.dart`, add `graphql` to the enum:
+
+```dart
+enum BodyType {
+  none('none'),
+  raw('raw'),
+  urlencoded('urlencoded'),
+  multipart('multipart'),
+  binary('binary'),
+  graphql('graphql')
+  ;
+```
+
+- [ ] **Step 2: Add the entity field**
+
+In `lib/core/domain/entities/request_config_entity.dart`:
+- Add constructor param `this.graphqlVariables = ''` (place it right after `bodyFilePath`).
+- Add the field declaration: `final String graphqlVariables;` (after `bodyFilePath`).
+- Add `String? graphqlVariables,` to the `copyWith` signature and `graphqlVariables: graphqlVariables ?? this.graphqlVariables,` to its body.
+- Add `graphqlVariables,` to `props` (after `bodyFilePath`).
+
+- [ ] **Step 3: Add the Hive model field**
+
+In `lib/features/history/data/models/request_config_model.dart`:
+- Constructor: add `this.graphqlVariables = ''` after `bodyFilePath`.
+- `fromEntity`: add `graphqlVariables: entity.graphqlVariables,`.
+- Add the field after `kind`:
+
+```dart
+  @HiveField(15, defaultValue: '')
+  String graphqlVariables;
+```
+
+- `toEntity`: add `graphqlVariables: graphqlVariables,`.
+
+- [ ] **Step 4: Regenerate the adapter**
+
+Run: `fvm dart run build_runner build --delete-conflicting-outputs`
+Expected: regenerates `request_config_model.g.dart` with field 15; exits 0.
+
+- [ ] **Step 5: Write the failing serializer tests**
+
+In `test/features/tabs/data/request_serializer_test.dart`, add a group:
+
+```dart
+group('graphql body', () {
+  test('builds {query, variables} envelope and forces application/json', () async {
+    final config = HttpRequestConfigEntity(
+      id: 'g1',
+      bodyType: BodyType.graphql,
+      body: 'query { me { id } }',
+      graphqlVariables: '{"limit": 5}',
+      headers: const {},
+    );
+    final headers = <String, String>{};
+    final data = await RequestSerializer.buildBody(
+      config: config, headers: headers, envVars: const {},
+    );
+    expect(data, {'query': 'query { me { id } }', 'variables': {'limit': 5}});
+    expect(headers['Content-Type'], 'application/json');
+  });
+
+  test('blank variables become an empty object', () async {
+    final config = HttpRequestConfigEntity(
+      id: 'g2', bodyType: BodyType.graphql, body: 'query { x }',
+      graphqlVariables: '  ', headers: const {},
+    );
+    final data = await RequestSerializer.buildBody(
+      config: config, headers: <String, String>{}, envVars: const {},
+    );
+    expect(data, {'query': 'query { x }', 'variables': <String, dynamic>{}});
+  });
+
+  test('invalid variables JSON throws GraphqlVariablesException', () async {
+    final config = HttpRequestConfigEntity(
+      id: 'g3', bodyType: BodyType.graphql, body: 'query { x }',
+      graphqlVariables: '{not json', headers: const {},
+    );
+    expect(
+      () => RequestSerializer.buildBody(
+        config: config, headers: <String, String>{}, envVars: const {},
+      ),
+      throwsA(isA<GraphqlVariablesException>()),
+    );
+  });
+
+  test('resolves {{vars}} in query and variables', () async {
+    final config = HttpRequestConfigEntity(
+      id: 'g4', bodyType: BodyType.graphql,
+      body: 'query { u(id: "{{id}}") }',
+      graphqlVariables: '{"n": "{{name}}"}', headers: const {},
+    );
+    final data = await RequestSerializer.buildBody(
+      config: config, headers: <String, String>{},
+      envVars: const {'id': '42', 'name': 'ada'},
+    );
+    expect(data, {'query': 'query { u(id: "42") }', 'variables': {'n': 'ada'}});
+  });
+});
+```
+
+(Add `import 'package:getman/core/error/exceptions.dart';` if not already imported.)
+
+- [ ] **Step 6: Run the serializer tests — expect compile failure**
+
+Run: `fvm flutter test test/features/tabs/data/request_serializer_test.dart`
+Expected: FAIL to compile — `GraphqlVariablesException` undefined and `buildBody` has no `graphql` case (non-exhaustive switch).
+
+- [ ] **Step 7: Add the exception**
+
+In `lib/core/error/exceptions.dart`, append:
+
+```dart
+/// Thrown when a GraphQL request's variables pane holds non-empty text that is
+/// not valid JSON. Pure (no dart:io) so it can cross the data→network boundary;
+/// the repository maps it to a status-0 NetworkFailure so the user sees a real
+/// error response instead of an uncaught throw.
+class GraphqlVariablesException implements Exception {
+  GraphqlVariablesException(this.detail);
+  final String detail;
+
+  @override
+  String toString() => 'GraphQL variables are not valid JSON: $detail';
+}
+```
+
+- [ ] **Step 8: Implement the serializer graphql case**
+
+In `lib/features/tabs/data/request_serializer.dart`:
+- Add `import 'dart:convert';` at the top (with the other imports, alphabetically before the package imports).
+- Add `import 'package:getman/core/error/exceptions.dart' ...` — it already imports `exceptions.dart` for `FileBodyException`, so no new import needed.
+- Add this case to the `switch (config.bodyType)` in `buildBody`, after `BodyType.binary`:
+
+```dart
+      case BodyType.graphql:
+        if (!HeaderUtils.hasCustomContentType(headers)) {
+          BodyTypeUtils.applyContentType(headers, BodyType.graphql);
+        }
+        final varsText = r(config.graphqlVariables).trim();
+        Object? variables;
+        if (varsText.isEmpty) {
+          variables = const <String, dynamic>{};
+        } else {
+          try {
+            variables = jsonDecode(varsText);
+          } on FormatException catch (e) {
+            throw GraphqlVariablesException(e.message);
+          }
+        }
+        return <String, dynamic>{'query': r(config.body), 'variables': variables};
+```
+
+Note: `HeaderUtils` is imported transitively via `body_type_utils.dart`? No — add `import 'package:getman/core/utils/header_utils.dart';` if `HeaderUtils` is not already imported. (Check: if absent, the graphql content-type guard can instead call `BodyTypeUtils.applyContentType` unconditionally, since `applyContentType`'s graphql rule from Step 11 is itself skip-if-custom — in that case drop the `if (!HeaderUtils...)` wrapper here and just call `BodyTypeUtils.applyContentType(headers, BodyType.graphql);`.) Prefer the simpler form: call `BodyTypeUtils.applyContentType(headers, BodyType.graphql);` directly (the rule is skip-if-custom in Step 11), avoiding a new import:
+
+```dart
+      case BodyType.graphql:
+        BodyTypeUtils.applyContentType(headers, BodyType.graphql);
+        final varsText = r(config.graphqlVariables).trim();
+        Object? variables;
+        if (varsText.isEmpty) {
+          variables = const <String, dynamic>{};
+        } else {
+          try {
+            variables = jsonDecode(varsText);
+          } on FormatException catch (e) {
+            throw GraphqlVariablesException(e.message);
+          }
+        }
+        return <String, dynamic>{'query': r(config.body), 'variables': variables};
+```
+
+- [ ] **Step 9: Add the content-type rule**
+
+In `lib/core/utils/body_type_utils.dart`, add a `graphql` case to `applyContentType` (skip-if-custom, like binary), and remove `graphql` from the no-op `none/raw` group:
+
+```dart
+      case BodyType.graphql:
+        if (!HeaderUtils.hasCustomContentType(headers)) {
+          HeaderUtils.setHeader(headers, 'Content-Type', 'application/json');
+        }
+      case BodyType.none:
+      case BodyType.raw:
+        break;
+```
+
+- [ ] **Step 10: Map the exception in the repository**
+
+In `lib/features/tabs/data/repositories/tabs_repository_impl.dart`, add a second catch right after the `on FileBodyException` block:
+
+```dart
+    } on GraphqlVariablesException catch (e) {
+      // Invalid GraphQL variables are a real, user-visible error — surface as a
+      // status-0 NetworkFailure so the response panel + history show it.
+      throw NetworkFailure(
+        e.toString(),
+        type: NetworkFailureType.unknown,
+        statusCode: 0,
+      );
+```
+
+(Ensure `package:getman/core/error/exceptions.dart` is imported — it is, for `FileBodyException`.)
+
+- [ ] **Step 11: Run the serializer tests — expect pass**
+
+Run: `fvm flutter test test/features/tabs/data/request_serializer_test.dart`
+Expected: PASS (all 4 new cases). The build now compiles past the serializer; remaining exhaustive switches in code-gen / Postman still fail to compile — fixed next.
+
+- [ ] **Step 12: Code-gen — envelope normalizer + shared graphql label**
+
+In `lib/core/utils/code_gen_service.dart`:
+- Ensure `import 'dart:convert';` is present (add if missing).
+- Add a private helper:
+
+```dart
+  /// Builds the GraphQL wire body `{"query":...,"variables":...}` as a JSON
+  /// string. Lenient (code-gen never fails): invalid/blank variables → `{}`.
+  static String _graphqlEnvelope(String query, String variablesText) {
+    Object? variables = const <String, dynamic>{};
+    final t = variablesText.trim();
+    if (t.isNotEmpty) {
+      try {
+        variables = jsonDecode(t);
+      } on FormatException {
+        variables = const <String, dynamic>{};
+      }
+    }
+    return jsonEncode(<String, dynamic>{'query': query, 'variables': variables});
+  }
+```
+
+- In `_effective(...)`, change the `rawBody:` argument so GraphQL bodies carry the envelope:
+
+```dart
+      bodyType: config.bodyType,
+      rawBody: config.bodyType == BodyType.graphql
+          ? _graphqlEnvelope(resolve(config.body), resolve(config.graphqlVariables))
+          : resolve(config.body),
+```
+
+- In **each** of the 6 target switches (`_curl`, `_fetch`, `_python`, `_axios`/Node, `_go`, `_java` — search for `case BodyType.raw:`), add `case BodyType.graphql:` as a shared label immediately above the existing raw body so they share it:
+
+```dart
+      case BodyType.raw:
+      case BodyType.graphql:
+        // ... existing raw body, unchanged ...
+```
+
+Because `applyContentType` (called in `_effective`) now sets `application/json` for graphql, and `e.rawBody` carries the envelope, the raw formatter emits a correct GraphQL request with no further changes.
+
+- [ ] **Step 13: Add a code-gen test**
+
+In `test/core/utils/code_gen_service_test.dart`, add:
+
+```dart
+test('cURL emits the GraphQL JSON envelope with application/json', () {
+  final config = HttpRequestConfigEntity(
+    id: 'gq', method: 'POST', url: 'https://api.example.com/graphql',
+    bodyType: BodyType.graphql, body: 'query { me { id } }',
+    graphqlVariables: '{"x":1}', headers: const {},
+  );
+  final out = CodeGenService.generate(config, CodeGenTarget.curl);
+  expect(out, contains('application/json'));
+  expect(out, contains('"query"'));
+  expect(out, contains('query { me { id } }'));
+  expect(out, contains('"variables"'));
+});
+```
+
+(Match the actual `CodeGenService.generate` signature / `CodeGenTarget` member names in the test file — adjust `CodeGenTarget.curl` if the enum value differs.)
+
+- [ ] **Step 14: Postman export — `_configToBody` graphql case**
+
+In `lib/core/utils/postman/postman_collection_mapper.dart`, add to the `_configToBody` switch (after `BodyType.binary`):
+
+```dart
+      case BodyType.graphql:
+        return {
+          'mode': 'graphql',
+          'graphql': {
+            'query': config.body,
+            'variables': config.graphqlVariables,
+          },
+        };
+```
+
+- [ ] **Step 15: Postman import — record + `_parseBody` + `_requestToConfig`**
+
+In the same file:
+- Add `String graphqlVariables` to the `_parseBody` return record type.
+- Add `graphqlVariables: ''` to **every** existing `return (...)` in `_parseBody` (the `raw`, `urlencoded`, `formdata`, `file`, and the trailing fallback).
+- Add a `graphql` case to the `switch (body['mode'])`:
+
+```dart
+        case 'graphql':
+          final gql = body['graphql'];
+          final query = gql is Map ? gql['query'] : null;
+          final vars = gql is Map ? gql['variables'] : null;
+          return (
+            bodyType: BodyType.graphql,
+            body: query is String ? query : '',
+            graphqlVariables: vars is String ? vars : '',
+            formFields: const <MultipartFieldEntity>[],
+            bodyFilePath: null,
+          );
+```
+
+- In `_requestToConfig`, pass the new field to the entity:
+
+```dart
+      bodyType: body.bodyType,
+      formFields: body.formFields,
+      bodyFilePath: body.bodyFilePath,
+      graphqlVariables: body.graphqlVariables,
+```
+
+- [ ] **Step 16: Add a Postman round-trip test**
+
+In `test/core/utils/postman/postman_collection_mapper_test.dart`, add:
+
+```dart
+test('graphql body round-trips export -> import', () {
+  final node = CollectionNodeEntity(
+    id: 'n1', name: 'gql', isFolder: false,
+    config: HttpRequestConfigEntity(
+      id: 'c1', method: 'POST', url: 'https://api.example.com/graphql',
+      bodyType: BodyType.graphql, body: 'query { me { id } }',
+      graphqlVariables: '{"limit":5}',
+    ),
+  );
+  final exported = PostmanCollectionMapper.toPostman([node], name: 'C');
+  final imported = PostmanCollectionMapper.fromPostman(exported);
+  final cfg = imported.single.config!;
+  expect(cfg.bodyType, BodyType.graphql);
+  expect(cfg.body, 'query { me { id } }');
+  expect(cfg.graphqlVariables, '{"limit":5}');
+});
+```
+
+(Match the actual `PostmanCollectionMapper.toPostman` / `fromPostman` names + return shape used elsewhere in this test file; adjust accessors accordingly.)
+
+- [ ] **Step 17: Workspace mirror — persist the new field**
+
+In `lib/core/utils/workspace/workspace_collection_serializer.dart`:
+- In `_configToJson`, add after the `bodyType` line:
+
+```dart
+    if (c.graphqlVariables.isNotEmpty) 'graphqlVariables': c.graphqlVariables,
+```
+
+- In `_configFromJson`, add to the `HttpRequestConfigEntity(...)` args:
+
+```dart
+      graphqlVariables: (json['graphqlVariables'] as String?) ?? '',
+```
+
+- [ ] **Step 18: Editor compile-stub + selector tolerates missing labels**
+
+In `lib/features/tabs/presentation/widgets/request_editor_tabs.dart`:
+- In `BodyTabView._editorFor`, add a graphql branch that compiles but is unreachable from the UI (the chip is hidden this task):
+
+```dart
+      case BodyType.graphql:
+        // Real dual-pane editor + visible chip land in Task 2.
+        return _RawBodyEditor(controller: controller);
+```
+
+- In `_BodyTypeSelector.build`, guard the chip loop so a `BodyType` with no `_labels` entry is skipped (prevents the `_labels[type]!` null-bang from throwing now that `graphql` exists but is intentionally absent from `_labels`):
+
+```dart
+        children: [
+          for (final type in BodyType.values)
+            if (_labels.containsKey(type))
+              _BodyTypeChip(
+                // ... unchanged ...
+              ),
+        ],
+```
+
+Do **not** add `graphql` to `_labels` yet.
+
+- [ ] **Step 19: Add the entity↔model round-trip test**
+
+If `test/features/history/data/models/request_config_model_test.dart` exists, extend it; otherwise create it:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/core/domain/entities/body_type.dart';
+import 'package:getman/core/domain/entities/request_config_entity.dart';
+import 'package:getman/features/history/data/models/request_config_model.dart';
+
+void main() {
+  test('graphqlVariables survives entity -> model -> entity', () {
+    final entity = HttpRequestConfigEntity(
+      id: 'x', bodyType: BodyType.graphql,
+      body: 'query { x }', graphqlVariables: '{"a":1}',
+    );
+    final back = HttpRequestConfig.fromEntity(entity).toEntity();
+    expect(back.bodyType, BodyType.graphql);
+    expect(back.graphqlVariables, '{"a":1}');
+  });
+}
+```
+
+- [ ] **Step 20: Full verification**
+
+Run, in order:
+- `fvm flutter analyze` → Expected: `No issues found!`
+- `fvm dart run custom_lint` → Expected: no issues
+- `fvm dart run bloc_tools:bloc lint lib` → Expected: no issues
+- `fvm dart format lib test` → Expected: formats clean (0 changed, or commit the formatting)
+- `fvm flutter test` → Expected: all green
+
+- [ ] **Step 21: Commit**
+
+```bash
+git add lib test
+git commit -m "feat(graphql): send + persist + export GraphQL bodies (M8 foundation)"
+```
+
+---
+
+### Task 2: GraphQL dual-pane editor (make it user-visible)
+
+Adds the second (variables) code controller to `request_view.dart`, threads it to a new `_GraphqlBodyEditor`, and reveals the `GRAPHQL` chip.
+
+**Files:**
+- Modify: `lib/features/tabs/presentation/screens/request_view.dart` — second controller + sync.
+- Modify: `lib/features/tabs/presentation/widgets/request_config_section.dart` — accept + pass `variablesController`.
+- Modify: `lib/features/tabs/presentation/widgets/unified_request_panel.dart` — accept + pass `variablesController`.
+- Modify: `lib/features/tabs/presentation/widgets/request_editor_tabs.dart` — `BodyTabView.variablesController`, `_GraphqlBodyEditor`, `_labels` graphql entry, real `_editorFor` graphql branch.
+- Test: `test/features/tabs/presentation/widgets/body_tab_view_test.dart` (extend or create).
+
+**Interfaces:**
+- Consumes: `BodyType.graphql`, `HttpRequestConfigEntity.graphqlVariables` (from Task 1).
+- Produces: `BodyTabView({required CodeLineEditingController controller, required CodeLineEditingController variablesController, ...})`; `_GraphqlBodyEditor` (private).
+
+- [ ] **Step 1: Write the failing widget test**
+
+In `test/features/tabs/presentation/widgets/body_tab_view_test.dart`, add (or create following the existing test harness in this directory — pump `BodyTabView` inside a `BlocProvider<TabsBloc>`):
+
+```dart
+testWidgets('selecting GRAPHQL shows query + variables panes', (tester) async {
+  // ... pump BodyTabView with a tab whose bodyType is BodyType.graphql,
+  // passing both a controller and a variablesController ...
+  expect(find.text('QUERY'), findsOneWidget);
+  expect(find.text('VARIABLES (JSON)'), findsOneWidget);
+});
+```
+
+- [ ] **Step 2: Run it — expect failure**
+
+Run: `fvm flutter test test/features/tabs/presentation/widgets/body_tab_view_test.dart`
+Expected: FAIL — `BodyTabView` has no `variablesController` param / labels not found.
+
+- [ ] **Step 3: Add `variablesController` to `BodyTabView` + `_GraphqlBodyEditor` + label**
+
+In `lib/features/tabs/presentation/widgets/request_editor_tabs.dart`:
+- Add the field to `BodyTabView`:
+
+```dart
+class BodyTabView extends StatelessWidget {
+  const BodyTabView({
+    required this.tabId,
+    required this.controller,
+    required this.variablesController,
+    super.key,
+  });
+  final String tabId;
+  final CodeLineEditingController controller;
+  final CodeLineEditingController variablesController;
+```
+
+- Add `BodyType.graphql: 'GRAPHQL'` to `_BodyTypeSelector._labels`.
+- Replace the `_editorFor` graphql branch:
+
+```dart
+      case BodyType.graphql:
+        return _GraphqlBodyEditor(
+          queryController: controller,
+          variablesController: variablesController,
+        );
+```
+
+- Add the editor widget (after `_RawBodyEditor`):
+
+```dart
+/// Dual-pane GraphQL editor: QUERY on top (reuses the body controller),
+/// VARIABLES (JSON) below (its own controller + beautify, since variables
+/// are JSON).
+class _GraphqlBodyEditor extends StatelessWidget {
+  const _GraphqlBodyEditor({
+    required this.queryController,
+    required this.variablesController,
+  });
+  final CodeLineEditingController queryController;
+  final CodeLineEditingController variablesController;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Expanded(
+          flex: 3,
+          child: _GraphqlPane(
+            label: 'QUERY',
+            child: JsonCodeEditor(controller: queryController),
+          ),
+        ),
+        Expanded(
+          flex: 2,
+          child: _GraphqlPane(
+            label: 'VARIABLES (JSON)',
+            child: _RawBodyEditor(controller: variablesController),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _GraphqlPane extends StatelessWidget {
+  const _GraphqlPane({required this.label, required this.child});
+  final String label;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final layout = context.appLayout;
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Padding(
+          padding: EdgeInsets.symmetric(
+            horizontal: layout.pagePadding,
+            vertical: layout.isCompact ? 4 : 6,
+          ),
+          child: Text(
+            label,
+            style: TextStyle(
+              fontSize: layout.fontSizeSmall,
+              fontWeight: context.appTypography.displayWeight,
+              color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
+            ),
+          ),
+        ),
+        Expanded(child: child),
+      ],
+    );
+  }
+}
+```
+
+(`JsonCodeEditor` and `_RawBodyEditor` are already in this file / imported.)
+
+- [ ] **Step 4: Thread the controller through the two layout sections**
+
+In `lib/features/tabs/presentation/widgets/request_config_section.dart`:
+- Add `required this.variablesController` + `final CodeLineEditingController variablesController;` to `RequestConfigSection`.
+- Pass it: `BodyTabView(tabId: tabId, controller: bodyController, variablesController: variablesController)`.
+
+In `lib/features/tabs/presentation/widgets/unified_request_panel.dart`:
+- Add `required this.variablesController` + the field to `UnifiedRequestPanel`.
+- Pass it to the `BodyTabView(...)` call: `variablesController: widget.variablesController`.
+
+- [ ] **Step 5: Create + sync the variables controller in `request_view.dart`**
+
+In `lib/features/tabs/presentation/screens/request_view.dart`:
+- Add the field beside `_bodyController`:
+
+```dart
+  late final CodeLineEditingController _graphqlVarsController;
+```
+
+- In `initState`, after the body controller wiring:
+
+```dart
+    _graphqlVarsController = createJsonCodeController();
+    _graphqlVarsController.addListener(_onGraphqlVarsChanged);
+```
+
+- In `didChangeDependencies`, after the body sync:
+
+```dart
+    if (tab != null &&
+        _graphqlVarsController.text != tab.config.graphqlVariables) {
+      _graphqlVarsController.text = tab.config.graphqlVariables;
+    }
+```
+
+- Add the listener (mirror of `_onBodyChanged`):
+
+```dart
+  void _onGraphqlVarsChanged() {
+    final tabsBloc = context.read<TabsBloc>();
+    final tab = tabsBloc.state.tabs.byId(widget.tabId);
+    if (tab == null) return;
+    final newText = _graphqlVarsController.text;
+    if (tab.config.graphqlVariables == newText) return;
+    tabsBloc.add(
+      UpdateTab(
+        tab.copyWith(
+          config: tab.config.copyWith(graphqlVariables: newText),
+        ),
+      ),
+    );
+  }
+```
+
+- In `dispose`, before `super.dispose()`:
+
+```dart
+    _graphqlVarsController
+      ..removeListener(_onGraphqlVarsChanged)
+      ..dispose();
+```
+
+- Widen the `BlocConsumer` `listenWhen` to also fire on a variables change, and sync the controller in the `listener`:
+
+```dart
+          listenWhen: (prev, next) {
+            final p = prev.tabs.byId(widget.tabId);
+            final n = next.tabs.byId(widget.tabId);
+            return p?.config.body != n?.config.body ||
+                p?.config.graphqlVariables != n?.config.graphqlVariables;
+          },
+          listener: (context, state) {
+            final tab = state.tabs.byId(widget.tabId);
+            if (tab == null) return;
+            if (_bodyController.text != tab.config.body) {
+              _bodyController.text = tab.config.body;
+            }
+            if (_graphqlVarsController.text != tab.config.graphqlVariables) {
+              _graphqlVarsController.text = tab.config.graphqlVariables;
+            }
+          },
+```
+
+- Pass `_graphqlVarsController` into both `UnifiedRequestPanel(...)` and `RequestConfigSection(...)`:
+
+```dart
+                            ? UnifiedRequestPanel(
+                                tabId: widget.tabId,
+                                bodyController: _bodyController,
+                                variablesController: _graphqlVarsController,
+                                responseController: _responseController,
+                              )
+                            : // ...
+                                  final requestPane = RequestConfigSection(
+                                    tabId: widget.tabId,
+                                    bodyController: _bodyController,
+                                    variablesController: _graphqlVarsController,
+                                  );
+```
+
+- [ ] **Step 6: Run the widget test — expect pass**
+
+Run: `fvm flutter test test/features/tabs/presentation/widgets/body_tab_view_test.dart`
+Expected: PASS.
+
+- [ ] **Step 7: Full verification**
+
+Run: `fvm flutter analyze` (0 issues), `fvm dart run custom_lint`, `fvm dart run bloc_tools:bloc lint lib`, `fvm dart format lib test`, `fvm flutter test` (all green).
+
+- [ ] **Step 8: Manual smoke (optional but recommended)**
+
+Run: `fvm flutter run -d macos`, add a tab, BODY → GRAPHQL, type a query + variables, send to a public GraphQL endpoint (e.g. `https://countries.trevorblades.com/`), confirm a 200 response.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add lib test
+git commit -m "feat(graphql): dual-pane query + variables body editor"
+```
+
+---
+
+### Task 3: Wiki docs
+
+Update the user-facing wiki to document the GraphQL body type (CLAUDE.md §7 keep-the-wiki-in-sync mandate).
+
+**Files:**
+- Clone `https://github.com/thiagomiranda3/Getman.wiki.git` (separate repo).
+- Modify: the Body types page (e.g. `Request-Bodies.md` or equivalent — match the existing page name from `_Sidebar.md`).
+
+- [ ] **Step 1: Clone the wiki**
+
+Run: `git clone https://github.com/thiagomiranda3/Getman.wiki.git /tmp/getman-wiki`
+
+- [ ] **Step 2: Find the body-types page**
+
+Run: `ls /tmp/getman-wiki && cat /tmp/getman-wiki/_Sidebar.md`
+Identify the page that documents body types (RAW / FORM / MULTIPART / BINARY).
+
+- [ ] **Step 3: Add a GraphQL section**
+
+Document: select **BODY → GRAPHQL**; top pane is the **QUERY**, bottom pane is **VARIABLES (JSON)**; the request is sent as `{"query": ..., "variables": ...}` with `Content-Type: application/json`; `{{variables}}` resolve in both panes; invalid variables JSON shows a local error instead of sending. Use the verbatim UI labels (`GRAPHQL`, `QUERY`, `VARIABLES (JSON)`).
+
+- [ ] **Step 4: Commit + push the wiki**
+
+```bash
+cd /tmp/getman-wiki
+git add -A
+git commit -m "docs: document GraphQL body type"
+git push origin master
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §1 data model → Task 1 Steps 1–4 (enum, entity, model, build_runner). ✓
+- §2 send path (envelope, content-type, invalid-variables error + repo mapping) → Task 1 Steps 7–11. ✓
+- §3 editor UI (dual pane, second controller, threading) → Task 2. ✓
+- §4 integration (code-gen, Postman export+import, workspace mirror, cURL/OpenAPI out of scope, dedup unchanged) → Task 1 Steps 12–17. ✓
+- §5 tests (serializer, entity/model round-trip, Postman round-trip, code-gen, widget) → Task 1 Steps 5/13/16/19, Task 2 Step 1. ✓
+- §5 docs (wiki) → Task 3. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows the code. The two "match the actual signature" notes (code-gen test Step 13, Postman test Step 16) are real-codebase adapters, not placeholders — the surrounding test files already use those APIs.
+
+**Type consistency:** `graphqlVariables` (String) used identically in entity, model, copyWith, serializer, code-gen, Postman record, workspace, controller sync. `GraphqlVariablesException(String detail)` consistent between exceptions.dart, serializer throw, repo catch. `BodyType.graphql` wire `'graphql'` consistent across all surfaces. `_GraphqlBodyEditor({queryController, variablesController})` matches `_editorFor` call. ✓

--- a/docs/superpowers/specs/2026-06-19-graphql-body-type-design.md
+++ b/docs/superpowers/specs/2026-06-19-graphql-body-type-design.md
@@ -1,0 +1,120 @@
+# GraphQL body type (M8) — Design
+
+> Status: approved 2026-06-19. Adds a `graphql` request body type to Getman.
+> Backlog item **M8** in `docs/BACKLOG.md`.
+
+## Goal
+
+Let a request carry a GraphQL payload: a **query** and an optional **variables**
+JSON object, sent over HTTP as `{"query": ..., "variables": ...}` with
+`Content-Type: application/json`. Edited through a dual-pane body editor.
+
+## 1. Data model (storage)
+
+- Add `graphql('graphql')` to the `BodyType` enum
+  (`lib/core/domain/entities/body_type.dart`).
+- **Reuse the existing `body` field for the GraphQL query.** It is the primary
+  content, so the existing `_bodyController` ↔ `config.body` bidirectional sync
+  in `request_view.dart` is reused unchanged.
+- **Add one new field `graphqlVariables` (String, default `''`)** to:
+  - `HttpRequestConfigEntity` (`lib/core/domain/entities/request_config_entity.dart`)
+    — constructor field, `copyWith`, `props`.
+  - `HttpRequestConfig` Hive model
+    (`lib/features/history/data/models/request_config_model.dart`, typeId 1):
+    **`@HiveField(15, defaultValue: '')`** (next free field), plus `fromEntity`
+    / `toEntity`.
+  - Run `dart run build_runner build --delete-conflicting-outputs` to regenerate
+    the adapter, then re-run analyze + tests.
+- Rationale for a separate field rather than packing query+variables into one
+  JSON envelope inside `body`: the editor needs two independent live text
+  controllers; packing would force JSON-escaping the query on every keystroke and
+  break on half-typed variables. Legacy records read back `graphqlVariables` as
+  `''` → no migration required.
+
+## 2. Send path (serialization)
+
+- `BodyTypeUtils.applyContentType` (`lib/core/utils/body_type_utils.dart`) gains
+  a `graphql` case → forces `Content-Type: application/json`, skip-if-custom
+  (same shape as the binary rule).
+- `RequestSerializer.buildBody`
+  (`lib/features/tabs/data/request_serializer.dart`) gains a `graphql` case:
+  - Resolve `{{vars}}` in both the query (`config.body`) and the variables text
+    (`config.graphqlVariables`) via `EnvironmentResolver`.
+  - Build and return `{'query': <resolvedQuery>, 'variables': <vars>}` as a
+    `Map<String, dynamic>` (Dio JSON-encodes Maps).
+  - `vars`: blank variables → `{}`. Non-blank → `jsonDecode(resolvedVariables)`.
+- **Invalid variables** (non-blank text that does not `jsonDecode`): throw a new
+  pure-Dart `GraphqlVariablesException` (mirrors `FileBodyException` in
+  `lib/core/error/exceptions.dart`). The repository maps it to a synthetic
+  status-0 error response carrying a clear message
+  (`GraphQL variables are not valid JSON: <detail>`) — surfaced in the response
+  panel, never silent. Mirror the existing `FileBodyException` mapping path.
+
+## 3. Editor UI (dual pane)
+
+- `_BodyTypeSelector._labels` gains `BodyType.graphql: 'GRAPHQL'`
+  (`lib/features/tabs/presentation/widgets/request_editor_tabs.dart`).
+- `BodyTabView._editorFor` returns a new `_GraphqlBodyEditor` for
+  `BodyType.graphql`.
+- Layout: a vertical split — **QUERY** pane on top (reuses the existing
+  `_bodyController` bound to `config.body`), **VARIABLES** pane below (a new
+  dedicated JSON code controller + beautify affordance, since variables are
+  JSON). Each pane gets a small header label. The same widget feeds both the
+  split-pane (`RequestConfigSection`) and unified-phone (`UnifiedRequestPanel`)
+  layouts.
+- The variables controller is created/owned in `request_view.dart` beside
+  `_bodyController`, synced bidirectionally to `config.graphqlVariables` — an
+  exact mirror of the existing `_onBodyChanged` listener (controller → bloc) and
+  the `BlocConsumer` listener (bloc → controller). It is threaded down through
+  `RequestConfigSection` / `UnifiedRequestPanel` → `BodyTabView` →
+  `_GraphqlBodyEditor`.
+- GraphQL query syntax highlighting is out of scope; the query pane uses the
+  existing controller (JSON-oriented highlighting falls back to base color on
+  non-JSON lines, which is acceptable).
+
+## 4. Integration surfaces
+
+- **Code generation** (`lib/core/utils/code_gen_service.dart`) — compiler-forced
+  across all 6 targets (cURL, fetch, axios, requests, net/http, OkHttp). GraphQL
+  is emitted as the `{query,variables}` JSON envelope string with
+  `application/json`. Normalize the envelope once (in the `_Effective` body
+  computation) so each target reuses its existing raw-JSON-body formatter.
+- **Postman export** (`lib/core/utils/postman/postman_collection_mapper.dart`
+  `_configToRequest` switch — compiler-forced) **and import** (`_parseBody`,
+  cheap and symmetric): round-trip Postman's `graphql` body mode —
+  `{ "mode": "graphql", "graphql": { "query": <str>, "variables": <str> } }`
+  (Postman stores variables as a string).
+- **Workspace git-mirror serializer**
+  (`lib/core/utils/workspace/workspace_collection_serializer.dart`): add
+  `graphqlVariables` to the emitted JSON and read it back, so the new field
+  survives the mirror.
+- **cURL import** and **OpenAPI import**: out of scope. A GraphQL `curl --data`
+  command already imports cleanly as a raw JSON body.
+- **History dedup** unchanged (`method + url + body`): two requests differing
+  only in variables dedupe together, consistent with the existing rule and the
+  `HttpRequestConfig.==` signature.
+
+## 5. Tests + docs
+
+Tests:
+- Serializer: GraphQL build produces the correct envelope Map + forces
+  `application/json`; blank variables → `{}`; invalid variables → throws
+  `GraphqlVariablesException`.
+- Entity ↔ model round-trip: `graphqlVariables` persists through
+  `fromEntity`/`toEntity`.
+- Postman: export→import round-trip for a GraphQL request preserves query +
+  variables + body type.
+- Code-gen: one target (cURL) emits the GraphQL JSON envelope.
+- Widget: selecting GRAPHQL renders the dual pane; editing the variables pane
+  dispatches `UpdateTab` with the new `graphqlVariables`.
+
+Docs:
+- Update the GitHub wiki Body types page to document the GraphQL body type
+  (per the keep-the-wiki-in-sync mandate in CLAUDE.md §7).
+
+## Verification bar (per CLAUDE.md §5)
+
+`fvm flutter analyze` (0 issues), `fvm dart run custom_lint`,
+`fvm dart run bloc_tools:bloc lint lib`, `fvm dart format` clean, and
+`fvm flutter test` 100% green. For the Hive-model change, verify with a real
+compile (`fvm flutter test`), not just analyze.

--- a/lib/core/domain/entities/body_type.dart
+++ b/lib/core/domain/entities/body_type.dart
@@ -6,7 +6,8 @@ enum BodyType {
   raw('raw'),
   urlencoded('urlencoded'),
   multipart('multipart'),
-  binary('binary')
+  binary('binary'),
+  graphql('graphql')
   ;
 
   const BodyType(this.wire);

--- a/lib/core/domain/entities/request_config_entity.dart
+++ b/lib/core/domain/entities/request_config_entity.dart
@@ -24,6 +24,7 @@ class HttpRequestConfigEntity extends Equatable {
     this.bodyType = BodyType.raw,
     this.formFields = const [],
     this.bodyFilePath,
+    this.graphqlVariables = '',
     this.kind = RequestKind.http,
     this.responseBody,
     this.responseHeaders,
@@ -45,6 +46,10 @@ class HttpRequestConfigEntity extends Equatable {
 
   /// Filesystem path for a `binary` body (desktop/mobile only).
   final String? bodyFilePath;
+
+  /// Variables JSON text for a `graphql` body. Empty for other body types.
+  /// The query itself reuses [body].
+  final String graphqlVariables;
 
   /// The protocol this request speaks (HTTP / WebSocket / SSE).
   final RequestKind kind;
@@ -75,6 +80,7 @@ class HttpRequestConfigEntity extends Equatable {
     BodyType? bodyType,
     List<MultipartFieldEntity>? formFields,
     Object? bodyFilePath = _unset,
+    String? graphqlVariables,
     RequestKind? kind,
     Object? responseBody = _unset,
     Object? responseHeaders = _unset,
@@ -98,6 +104,7 @@ class HttpRequestConfigEntity extends Equatable {
       bodyFilePath: identical(bodyFilePath, _unset)
           ? this.bodyFilePath
           : bodyFilePath as String?,
+      graphqlVariables: graphqlVariables ?? this.graphqlVariables,
       kind: kind ?? this.kind,
       responseBody: identical(responseBody, _unset)
           ? this.responseBody
@@ -125,6 +132,7 @@ class HttpRequestConfigEntity extends Equatable {
     bodyType,
     formFields,
     bodyFilePath,
+    graphqlVariables,
     kind,
     responseBody,
     responseHeaders,

--- a/lib/core/error/exceptions.dart
+++ b/lib/core/error/exceptions.dart
@@ -21,3 +21,15 @@ class FileBodyException implements Exception {
   String toString() =>
       'Could not read file: $path${cause != null ? ' ($cause)' : ''}';
 }
+
+/// Thrown when a GraphQL request's variables pane holds non-empty text that is
+/// not valid JSON. Pure (no dart:io) so it can cross the data→network boundary;
+/// the repository maps it to a status-0 NetworkFailure so the user sees a real
+/// error response instead of an uncaught throw.
+class GraphqlVariablesException implements Exception {
+  GraphqlVariablesException(this.detail);
+  final String detail;
+
+  @override
+  String toString() => 'GraphQL variables are not valid JSON: $detail';
+}

--- a/lib/core/utils/body_type_utils.dart
+++ b/lib/core/utils/body_type_utils.dart
@@ -29,6 +29,10 @@ class BodyTypeUtils {
             'application/octet-stream',
           );
         }
+      case BodyType.graphql:
+        if (!HeaderUtils.hasCustomContentType(headers)) {
+          HeaderUtils.setHeader(headers, 'Content-Type', 'application/json');
+        }
       case BodyType.none:
       case BodyType.raw:
         break;

--- a/lib/core/utils/code_gen_service.dart
+++ b/lib/core/utils/code_gen_service.dart
@@ -96,7 +96,12 @@ class CodeGenService {
       url: url,
       headers: headers,
       bodyType: config.bodyType,
-      rawBody: resolve(config.body),
+      rawBody: config.bodyType == BodyType.graphql
+          ? _graphqlEnvelope(
+              resolve(config.body),
+              resolve(config.graphqlVariables),
+            )
+          : resolve(config.body),
       formFields: formFields,
       binaryPath: config.bodyFilePath,
     );
@@ -104,6 +109,24 @@ class CodeGenService {
 
   /// Default resolver: pass `{{vars}}` through verbatim (template output).
   static String _identity(String value) => value;
+
+  /// Builds the GraphQL wire body `{"query":...,"variables":...}` as a JSON
+  /// string. Lenient (code-gen never fails): invalid/blank variables → `{}`.
+  static String _graphqlEnvelope(String query, String variablesText) {
+    Object? variables = const <String, dynamic>{};
+    final t = variablesText.trim();
+    if (t.isNotEmpty) {
+      try {
+        variables = jsonDecode(t);
+      } on FormatException {
+        variables = const <String, dynamic>{};
+      }
+    }
+    return jsonEncode(<String, dynamic>{
+      'query': query,
+      'variables': variables,
+    });
+  }
 
   // ---- cURL ----
 
@@ -117,6 +140,7 @@ class CodeGenService {
       case BodyType.none:
         break;
       case BodyType.raw:
+      case BodyType.graphql:
         if (e.rawBody.isNotEmpty) {
           b.write(" \\\n  --data '${_shellSq(e.rawBody)}'");
         }
@@ -148,6 +172,7 @@ class CodeGenService {
       case BodyType.none:
         break;
       case BodyType.raw:
+      case BodyType.graphql:
         if (e.rawBody.isNotEmpty) {
           opts.write('  body: ${_jsString(e.rawBody)},\n');
         }
@@ -194,6 +219,7 @@ class CodeGenService {
       case BodyType.none:
         break;
       case BodyType.raw:
+      case BodyType.graphql:
         if (e.rawBody.isNotEmpty) {
           b.write('data = ${_pyString(e.rawBody)}\n');
           extra.add('data=data');
@@ -248,6 +274,7 @@ class CodeGenService {
       case BodyType.none:
         break;
       case BodyType.raw:
+      case BodyType.graphql:
         if (e.rawBody.isNotEmpty) {
           opts.write('  data: ${_jsString(e.rawBody)},\n');
         }
@@ -309,6 +336,7 @@ class CodeGenService {
       case BodyType.none:
         break;
       case BodyType.raw:
+      case BodyType.graphql:
         if (e.rawBody.isNotEmpty) {
           imports.add('strings');
           body.write(
@@ -373,6 +401,7 @@ class CodeGenService {
       case BodyType.none:
         break;
       case BodyType.raw:
+      case BodyType.graphql:
         if (e.rawBody.isNotEmpty) {
           final ct = _contentTypeOf(e.headers, 'application/json');
           final rawLiteral = _dqString(e.rawBody);

--- a/lib/core/utils/postman/postman_collection_mapper.dart
+++ b/lib/core/utils/postman/postman_collection_mapper.dart
@@ -198,6 +198,14 @@ class PostmanCollectionMapper {
           'mode': 'file',
           'file': {'src': path},
         };
+      case BodyType.graphql:
+        return {
+          'mode': 'graphql',
+          'graphql': {
+            'query': config.body,
+            'variables': config.graphqlVariables,
+          },
+        };
     }
   }
 
@@ -271,6 +279,7 @@ class PostmanCollectionMapper {
       bodyType: body.bodyType,
       formFields: body.formFields,
       bodyFilePath: body.bodyFilePath,
+      graphqlVariables: body.graphqlVariables,
     );
   }
 
@@ -349,6 +358,7 @@ class PostmanCollectionMapper {
   static ({
     BodyType bodyType,
     String body,
+    String graphqlVariables,
     List<MultipartFieldEntity> formFields,
     String? bodyFilePath,
   })
@@ -360,6 +370,7 @@ class PostmanCollectionMapper {
           return (
             bodyType: BodyType.raw,
             body: raw is String ? raw : '',
+            graphqlVariables: '',
             formFields: const [],
             bodyFilePath: null,
           );
@@ -367,6 +378,7 @@ class PostmanCollectionMapper {
           return (
             bodyType: BodyType.urlencoded,
             body: '',
+            graphqlVariables: '',
             formFields: _parseFormList(body['urlencoded'], multipart: false),
             bodyFilePath: null,
           );
@@ -374,6 +386,7 @@ class PostmanCollectionMapper {
           return (
             bodyType: BodyType.multipart,
             body: '',
+            graphqlVariables: '',
             formFields: _parseFormList(body['formdata'], multipart: true),
             bodyFilePath: null,
           );
@@ -383,14 +396,27 @@ class PostmanCollectionMapper {
           return (
             bodyType: BodyType.binary,
             body: '',
+            graphqlVariables: '',
             formFields: const [],
             bodyFilePath: src is String && src.isNotEmpty ? src : null,
+          );
+        case 'graphql':
+          final gql = body['graphql'];
+          final query = gql is Map ? gql['query'] : null;
+          final vars = gql is Map ? gql['variables'] : null;
+          return (
+            bodyType: BodyType.graphql,
+            body: query is String ? query : '',
+            graphqlVariables: vars is String ? vars : '',
+            formFields: const [],
+            bodyFilePath: null,
           );
       }
     }
     return (
       bodyType: BodyType.raw,
       body: '',
+      graphqlVariables: '',
       formFields: const [],
       bodyFilePath: null,
     );

--- a/lib/core/utils/workspace/workspace_collection_serializer.dart
+++ b/lib/core/utils/workspace/workspace_collection_serializer.dart
@@ -111,6 +111,7 @@ class WorkspaceCollectionSerializer {
     'headers': c.headers,
     'body': c.body,
     'bodyType': c.bodyType.wire,
+    if (c.graphqlVariables.isNotEmpty) 'graphqlVariables': c.graphqlVariables,
     'auth': c.auth,
     if (c.formFields.isNotEmpty)
       'formFields': [
@@ -134,6 +135,7 @@ class WorkspaceCollectionSerializer {
       headers: ((json['headers'] as Map?) ?? const {}).cast<String, String>(),
       body: (json['body'] as String?) ?? '',
       bodyType: BodyType.fromWire(json['bodyType'] as String?),
+      graphqlVariables: (json['graphqlVariables'] as String?) ?? '',
       auth: ((json['auth'] as Map?) ?? const {}).cast<String, String>(),
       formFields: [
         for (final Map<String, dynamic> m

--- a/lib/features/history/data/models/request_config_model.dart
+++ b/lib/features/history/data/models/request_config_model.dart
@@ -22,6 +22,7 @@ class HttpRequestConfig extends HiveObject {
     this.bodyType = 'raw',
     List<MultipartFieldModel>? formFields,
     this.bodyFilePath,
+    this.graphqlVariables = '',
     this.kind = 0,
     this.responseBody,
     this.responseHeaders,
@@ -53,6 +54,7 @@ class HttpRequestConfig extends HiveObject {
             .map(MultipartFieldModel.fromEntity)
             .toList(),
         bodyFilePath: entity.bodyFilePath,
+        graphqlVariables: entity.graphqlVariables,
         kind: entity.kind.wire,
         responseBody: entity.responseBody,
         responseHeaders: entity.responseHeaders,
@@ -110,6 +112,9 @@ class HttpRequestConfig extends HiveObject {
   @HiveField(14, defaultValue: 0)
   int kind;
 
+  @HiveField(15, defaultValue: '')
+  String graphqlVariables;
+
   HttpRequestConfigEntity toEntity() {
     // Lazy migration: if a legacy record stored params in the separate map,
     // merge them into the URL's query string. Next save writes params back
@@ -131,6 +136,7 @@ class HttpRequestConfig extends HiveObject {
       bodyType: BodyType.fromWire(bodyType),
       formFields: formFields.map((f) => f.toEntity()).toList(),
       bodyFilePath: bodyFilePath,
+      graphqlVariables: graphqlVariables,
       kind: RequestKind.fromWire(kind),
       responseBody: responseBody,
       responseHeaders: responseHeaders,

--- a/lib/features/history/data/models/request_config_model.g.dart
+++ b/lib/features/history/data/models/request_config_model.g.dart
@@ -27,6 +27,7 @@ class HttpRequestConfigAdapter extends TypeAdapter<HttpRequestConfig> {
       bodyType: fields[11] == null ? 'raw' : fields[11] as String,
       formFields: (fields[12] as List?)?.cast<MultipartFieldModel>(),
       bodyFilePath: fields[13] as String?,
+      graphqlVariables: fields[15] == null ? '' : fields[15] as String,
       kind: fields[14] == null ? 0 : (fields[14] as num).toInt(),
       responseBody: fields[7] as String?,
       responseHeaders: (fields[8] as Map?)?.cast<String, String>(),
@@ -38,7 +39,7 @@ class HttpRequestConfigAdapter extends TypeAdapter<HttpRequestConfig> {
   @override
   void write(BinaryWriter writer, HttpRequestConfig obj) {
     writer
-      ..writeByte(15)
+      ..writeByte(16)
       ..writeByte(0)
       ..write(obj.id)
       ..writeByte(1)
@@ -68,7 +69,9 @@ class HttpRequestConfigAdapter extends TypeAdapter<HttpRequestConfig> {
       ..writeByte(13)
       ..write(obj.bodyFilePath)
       ..writeByte(14)
-      ..write(obj.kind);
+      ..write(obj.kind)
+      ..writeByte(15)
+      ..write(obj.graphqlVariables);
   }
 
   @override

--- a/lib/features/tabs/data/repositories/tabs_repository_impl.dart
+++ b/lib/features/tabs/data/repositories/tabs_repository_impl.dart
@@ -177,6 +177,14 @@ class TabsRepositoryImpl implements TabsRepository {
         type: NetworkFailureType.unknown,
         statusCode: 0,
       );
+    } on GraphqlVariablesException catch (e) {
+      // Invalid GraphQL variables are a real, user-visible error — surface as a
+      // status-0 NetworkFailure so the response panel + history show it.
+      throw NetworkFailure(
+        e.toString(),
+        type: NetworkFailureType.unknown,
+        statusCode: 0,
+      );
     }
 
     return networkService.request(

--- a/lib/features/tabs/data/request_serializer.dart
+++ b/lib/features/tabs/data/request_serializer.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:dio/dio.dart';
 import 'package:getman/core/domain/auth_application.dart';
 import 'package:getman/core/domain/entities/auth_config.dart';
@@ -106,6 +108,23 @@ class RequestSerializer {
         if (path == null || path.isEmpty) return null;
         BodyTypeUtils.applyContentType(headers, BodyType.binary);
         return _readBytes(path);
+      case BodyType.graphql:
+        BodyTypeUtils.applyContentType(headers, BodyType.graphql);
+        final varsText = r(config.graphqlVariables).trim();
+        Object? variables;
+        if (varsText.isEmpty) {
+          variables = const <String, dynamic>{};
+        } else {
+          try {
+            variables = jsonDecode(varsText);
+          } on FormatException catch (e) {
+            throw GraphqlVariablesException(e.message);
+          }
+        }
+        return <String, dynamic>{
+          'query': r(config.body),
+          'variables': variables,
+        };
     }
   }
 

--- a/lib/features/tabs/presentation/screens/request_view.dart
+++ b/lib/features/tabs/presentation/screens/request_view.dart
@@ -44,6 +44,7 @@ class RequestView extends StatefulWidget {
 
 class _RequestViewState extends State<RequestView> {
   late final CodeLineEditingController _bodyController;
+  late final CodeLineEditingController _graphqlVarsController;
   late final CodeLineEditingController _responseController;
   // Live drag ratio. A ValueNotifier (not setState) so dragging the splitter
   // only re-runs the Flex layout — the captured request/response panes (and
@@ -56,8 +57,10 @@ class _RequestViewState extends State<RequestView> {
   void initState() {
     super.initState();
     _bodyController = createJsonCodeController();
+    _graphqlVarsController = createJsonCodeController();
     _responseController = createJsonCodeController();
     _bodyController.addListener(_onBodyChanged);
+    _graphqlVarsController.addListener(_onGraphqlVarsChanged);
   }
 
   @override
@@ -67,6 +70,24 @@ class _RequestViewState extends State<RequestView> {
     if (tab != null && _bodyController.text != tab.config.body) {
       _bodyController.text = tab.config.body;
     }
+    if (tab != null &&
+        _graphqlVarsController.text != tab.config.graphqlVariables) {
+      _graphqlVarsController.text = tab.config.graphqlVariables;
+    }
+  }
+
+  void _onGraphqlVarsChanged() {
+    final tabsBloc = context.read<TabsBloc>();
+    final tab = tabsBloc.state.tabs.byId(widget.tabId);
+    if (tab == null) return;
+    final newText = _graphqlVarsController.text;
+    if (tab.config.graphqlVariables == newText) return;
+
+    tabsBloc.add(
+      UpdateTab(
+        tab.copyWith(config: tab.config.copyWith(graphqlVariables: newText)),
+      ),
+    );
   }
 
   void _onBodyChanged() {
@@ -88,6 +109,9 @@ class _RequestViewState extends State<RequestView> {
     _bodyController
       ..removeListener(_onBodyChanged)
       ..dispose();
+    _graphqlVarsController
+      ..removeListener(_onGraphqlVarsChanged)
+      ..dispose();
     _responseController.dispose();
     _localSplitRatio.dispose();
     super.dispose();
@@ -107,12 +131,17 @@ class _RequestViewState extends State<RequestView> {
           listenWhen: (prev, next) {
             final p = prev.tabs.byId(widget.tabId);
             final n = next.tabs.byId(widget.tabId);
-            return p?.config.body != n?.config.body;
+            return p?.config.body != n?.config.body ||
+                p?.config.graphqlVariables != n?.config.graphqlVariables;
           },
           listener: (context, state) {
             final tab = state.tabs.byId(widget.tabId);
-            if (tab != null && _bodyController.text != tab.config.body) {
+            if (tab == null) return;
+            if (_bodyController.text != tab.config.body) {
               _bodyController.text = tab.config.body;
+            }
+            if (_graphqlVarsController.text != tab.config.graphqlVariables) {
+              _graphqlVarsController.text = tab.config.graphqlVariables;
             }
           },
           buildWhen: (prev, next) {
@@ -159,6 +188,7 @@ class _RequestViewState extends State<RequestView> {
                             ? UnifiedRequestPanel(
                                 tabId: widget.tabId,
                                 bodyController: _bodyController,
+                                variablesController: _graphqlVarsController,
                                 responseController: _responseController,
                               )
                             : LayoutBuilder(
@@ -172,6 +202,7 @@ class _RequestViewState extends State<RequestView> {
                                   final requestPane = RequestConfigSection(
                                     tabId: widget.tabId,
                                     bodyController: _bodyController,
+                                    variablesController: _graphqlVarsController,
                                   );
                                   final responsePane = ResponseArea(
                                     tabId: widget.tabId,

--- a/lib/features/tabs/presentation/widgets/request_config_section.dart
+++ b/lib/features/tabs/presentation/widgets/request_config_section.dart
@@ -14,10 +14,12 @@ class RequestConfigSection extends StatelessWidget {
   const RequestConfigSection({
     required this.tabId,
     required this.bodyController,
+    required this.variablesController,
     super.key,
   });
   final String tabId;
   final CodeLineEditingController bodyController;
+  final CodeLineEditingController variablesController;
 
   @override
   Widget build(BuildContext context) {
@@ -42,7 +44,11 @@ class RequestConfigSection extends StatelessWidget {
                     ParamsTabView(tabId: tabId),
                     AuthTabView(tabId: tabId),
                     HeadersTabView(tabId: tabId),
-                    BodyTabView(tabId: tabId, controller: bodyController),
+                    BodyTabView(
+                      tabId: tabId,
+                      controller: bodyController,
+                      variablesController: variablesController,
+                    ),
                     RulesTabView(key: ValueKey('rules_$tabId'), tabId: tabId),
                   ],
                 ),

--- a/lib/features/tabs/presentation/widgets/request_editor_tabs.dart
+++ b/lib/features/tabs/presentation/widgets/request_editor_tabs.dart
@@ -334,6 +334,10 @@ class BodyTabView extends StatelessWidget {
         return FormDataEditor(tabId: tabId, allowFiles: true);
       case BodyType.binary:
         return _BinaryBodyPicker(tabId: tabId);
+      case BodyType.graphql:
+        // Real dual-pane editor + visible chip land in the editor task; the
+        // chip is hidden for now (no _labels entry), so this is unreachable.
+        return _RawBodyEditor(controller: controller);
     }
   }
 }
@@ -364,21 +368,22 @@ class _BodyTypeSelector extends StatelessWidget {
         runSpacing: layout.tabSpacing,
         children: [
           for (final type in BodyType.values)
-            _BodyTypeChip(
-              key: ValueKey('bodytype_${_labels[type]!}'),
-              label: _labels[type]!,
-              active: type == active,
-              onTap: () {
-                final bloc = context.read<TabsBloc>();
-                final tab = bloc.state.tabs.byId(tabId);
-                if (tab == null || tab.config.bodyType == type) return;
-                bloc.add(
-                  UpdateTab(
-                    tab.copyWith(config: tab.config.copyWith(bodyType: type)),
-                  ),
-                );
-              },
-            ),
+            if (_labels.containsKey(type))
+              _BodyTypeChip(
+                key: ValueKey('bodytype_${_labels[type]!}'),
+                label: _labels[type]!,
+                active: type == active,
+                onTap: () {
+                  final bloc = context.read<TabsBloc>();
+                  final tab = bloc.state.tabs.byId(tabId);
+                  if (tab == null || tab.config.bodyType == type) return;
+                  bloc.add(
+                    UpdateTab(
+                      tab.copyWith(config: tab.config.copyWith(bodyType: type)),
+                    ),
+                  );
+                },
+              ),
         ],
       ),
     );

--- a/lib/features/tabs/presentation/widgets/request_editor_tabs.dart
+++ b/lib/features/tabs/presentation/widgets/request_editor_tabs.dart
@@ -297,9 +297,15 @@ class _HeadersTabViewState extends State<HeadersTabView> {
 /// [FormDataEditor]; binary picks a file. The selector + sub-editor are shared
 /// by both the split-pane and unified phone layouts.
 class BodyTabView extends StatelessWidget {
-  const BodyTabView({required this.tabId, required this.controller, super.key});
+  const BodyTabView({
+    required this.tabId,
+    required this.controller,
+    required this.variablesController,
+    super.key,
+  });
   final String tabId;
   final CodeLineEditingController controller;
+  final CodeLineEditingController variablesController;
 
   @override
   Widget build(BuildContext context) {
@@ -335,9 +341,10 @@ class BodyTabView extends StatelessWidget {
       case BodyType.binary:
         return _BinaryBodyPicker(tabId: tabId);
       case BodyType.graphql:
-        // Real dual-pane editor + visible chip land in the editor task; the
-        // chip is hidden for now (no _labels entry), so this is unreachable.
-        return _RawBodyEditor(controller: controller);
+        return _GraphqlBodyEditor(
+          queryController: controller,
+          variablesController: variablesController,
+        );
     }
   }
 }
@@ -353,6 +360,7 @@ class _BodyTypeSelector extends StatelessWidget {
     BodyType.urlencoded: 'FORM',
     BodyType.multipart: 'MULTIPART',
     BodyType.binary: 'BINARY',
+    BodyType.graphql: 'GRAPHQL',
   };
 
   @override
@@ -480,6 +488,73 @@ class _RawBodyEditor extends StatelessWidget {
             ),
           ),
         ),
+      ],
+    );
+  }
+}
+
+/// Dual-pane GraphQL editor: QUERY on top (reuses the body controller bound to
+/// `config.body`), VARIABLES (JSON) below (its own controller + beautify, since
+/// variables are JSON).
+class _GraphqlBodyEditor extends StatelessWidget {
+  const _GraphqlBodyEditor({
+    required this.queryController,
+    required this.variablesController,
+  });
+  final CodeLineEditingController queryController;
+  final CodeLineEditingController variablesController;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Expanded(
+          flex: 3,
+          child: _GraphqlPane(
+            label: 'QUERY',
+            child: JsonCodeEditor(controller: queryController),
+          ),
+        ),
+        Expanded(
+          flex: 2,
+          child: _GraphqlPane(
+            label: 'VARIABLES (JSON)',
+            child: _RawBodyEditor(controller: variablesController),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _GraphqlPane extends StatelessWidget {
+  const _GraphqlPane({required this.label, required this.child});
+  final String label;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final layout = context.appLayout;
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Padding(
+          padding: EdgeInsets.symmetric(
+            horizontal: layout.pagePadding,
+            vertical: layout.isCompact ? 4 : 6,
+          ),
+          child: Text(
+            label,
+            style: TextStyle(
+              fontSize: layout.fontSizeSmall,
+              fontWeight: context.appTypography.displayWeight,
+              color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
+            ),
+          ),
+        ),
+        Expanded(child: child),
       ],
     );
   }

--- a/lib/features/tabs/presentation/widgets/unified_request_panel.dart
+++ b/lib/features/tabs/presentation/widgets/unified_request_panel.dart
@@ -27,11 +27,13 @@ class UnifiedRequestPanel extends StatefulWidget {
   const UnifiedRequestPanel({
     required this.tabId,
     required this.bodyController,
+    required this.variablesController,
     required this.responseController,
     super.key,
   });
   final String tabId;
   final CodeLineEditingController bodyController;
+  final CodeLineEditingController variablesController;
   final CodeLineEditingController responseController;
 
   @override
@@ -103,6 +105,7 @@ class _UnifiedRequestPanelState extends State<UnifiedRequestPanel>
                     BodyTabView(
                       tabId: widget.tabId,
                       controller: widget.bodyController,
+                      variablesController: widget.variablesController,
                     ),
                     RulesTabView(
                       key: ValueKey('rules_${widget.tabId}'),

--- a/test/core/utils/code_gen_service_test.dart
+++ b/test/core/utils/code_gen_service_test.dart
@@ -353,4 +353,24 @@ void main() {
       expect(out, contains('.add("a", "1")'));
     });
   });
+
+  group('graphql body', () {
+    test('cURL emits the GraphQL JSON envelope with application/json', () {
+      const config = HttpRequestConfigEntity(
+        id: 'gq',
+        method: 'POST',
+        url: 'https://api.example.com/graphql',
+        bodyType: BodyType.graphql,
+        body: 'query { me { id } }',
+        graphqlVariables: '{"x":1}',
+        headers: {},
+      );
+      final out = CodeGenService.generate(config, CodeGenTarget.curl);
+      expect(out, contains('application/json'));
+      expect(out, contains('"query"'));
+      expect(out, contains('query { me { id } }'));
+      expect(out, contains('"variables"'));
+      expect(out, contains('"x":1'));
+    });
+  });
 }

--- a/test/core/utils/postman/postman_collection_mapper_test.dart
+++ b/test/core/utils/postman/postman_collection_mapper_test.dart
@@ -483,4 +483,36 @@ void main() {
       },
     );
   });
+
+  group('graphql body round-trip', () {
+    test('export -> import preserves query + variables + body type', () {
+      const leaf = CollectionNodeEntity(
+        id: 'leaf',
+        name: 'GQL',
+        isFolder: false,
+        config: HttpRequestConfigEntity(
+          id: 'cfg',
+          method: 'POST',
+          url: 'https://api.example.com/graphql',
+          bodyType: BodyType.graphql,
+          body: 'query { me { id } }',
+          graphqlVariables: '{"limit":5}',
+        ),
+      );
+      const root = CollectionNodeEntity(
+        id: 'root',
+        name: 'Coll',
+        children: [leaf],
+      );
+
+      final imported = PostmanCollectionMapper.fromJson(
+        PostmanCollectionMapper.toJson(root),
+      );
+      final reLeaf = imported.children.single;
+      expect(reLeaf.isFolder, isFalse);
+      expect(reLeaf.config!.bodyType, BodyType.graphql);
+      expect(reLeaf.config!.body, 'query { me { id } }');
+      expect(reLeaf.config!.graphqlVariables, '{"limit":5}');
+    });
+  });
 }

--- a/test/features/history/data/models/request_config_model_test.dart
+++ b/test/features/history/data/models/request_config_model_test.dart
@@ -136,4 +136,18 @@ void main() {
       expect(http == ws, isTrue);
     });
   });
+
+  group('graphql body', () {
+    test('graphqlVariables survives entity -> model -> entity', () {
+      const entity = HttpRequestConfigEntity(
+        id: 'x',
+        bodyType: BodyType.graphql,
+        body: 'query { x }',
+        graphqlVariables: '{"a":1}',
+      );
+      final back = HttpRequestConfig.fromEntity(entity).toEntity();
+      expect(back.bodyType, BodyType.graphql);
+      expect(back.graphqlVariables, '{"a":1}');
+    });
+  });
 }

--- a/test/features/tabs/data/request_serializer_test.dart
+++ b/test/features/tabs/data/request_serializer_test.dart
@@ -7,6 +7,7 @@ import 'package:getman/core/domain/entities/auth_config.dart';
 import 'package:getman/core/domain/entities/body_type.dart';
 import 'package:getman/core/domain/entities/multipart_field_entity.dart';
 import 'package:getman/core/domain/entities/request_config_entity.dart';
+import 'package:getman/core/error/exceptions.dart';
 import 'package:getman/features/tabs/data/request_serializer.dart';
 
 void main() {
@@ -323,6 +324,85 @@ void main() {
         headers.keys.any((k) => k.toLowerCase() == 'content-type'),
         isFalse,
       );
+    });
+  });
+
+  group('RequestSerializer.buildBody graphql', () {
+    test(
+      'builds {query, variables} envelope and forces application/json',
+      () async {
+        const config = HttpRequestConfigEntity(
+          id: 'g1',
+          bodyType: BodyType.graphql,
+          body: 'query { me { id } }',
+          graphqlVariables: '{"limit": 5}',
+          headers: {},
+        );
+        final headers = <String, String>{};
+        final data = await RequestSerializer.buildBody(
+          config: config,
+          headers: headers,
+          envVars: const {},
+        );
+        expect(data, {
+          'query': 'query { me { id } }',
+          'variables': {'limit': 5},
+        });
+        expect(headers['Content-Type'], 'application/json');
+      },
+    );
+
+    test('blank variables become an empty object', () async {
+      const config = HttpRequestConfigEntity(
+        id: 'g2',
+        bodyType: BodyType.graphql,
+        body: 'query { x }',
+        graphqlVariables: '  ',
+        headers: {},
+      );
+      final data = await RequestSerializer.buildBody(
+        config: config,
+        headers: <String, String>{},
+        envVars: const {},
+      );
+      expect(data, {'query': 'query { x }', 'variables': <String, dynamic>{}});
+    });
+
+    test('invalid variables JSON throws GraphqlVariablesException', () async {
+      const config = HttpRequestConfigEntity(
+        id: 'g3',
+        bodyType: BodyType.graphql,
+        body: 'query { x }',
+        graphqlVariables: '{not json',
+        headers: {},
+      );
+      await expectLater(
+        () => RequestSerializer.buildBody(
+          config: config,
+          headers: <String, String>{},
+          envVars: const {},
+        ),
+        throwsA(isA<GraphqlVariablesException>()),
+      );
+    });
+
+    test('resolves {{vars}} in query and variables', () async {
+      const config = HttpRequestConfigEntity(
+        id: 'g4',
+        bodyType: BodyType.graphql,
+        body: 'query { u(id: "{{id}}") }',
+        graphqlVariables: '{"n": "{{name}}"}',
+        headers: {},
+      );
+      final data = await RequestSerializer.buildBody(
+        config: config,
+        headers: <String, String>{},
+        envVars: const {'id': '42', 'name': 'ada'},
+      );
+      expect(data, {
+        'query': 'query { u(id: "42") }',
+        'variables': {'n': 'ada'},
+      });
     });
   });
 }

--- a/test/features/tabs/presentation/widgets/body_tab_view_test.dart
+++ b/test/features/tabs/presentation/widgets/body_tab_view_test.dart
@@ -55,13 +55,19 @@ Future<CodeLineEditingController> _pump(
   String tabId,
 ) async {
   final controller = CodeLineEditingController();
+  final variablesController = CodeLineEditingController();
+  addTearDown(variablesController.dispose);
   await tester.pumpWidget(
     MaterialApp(
       theme: brutalistTheme(Brightness.light),
       home: Scaffold(
         body: BlocProvider.value(
           value: bloc,
-          child: BodyTabView(tabId: tabId, controller: controller),
+          child: BodyTabView(
+            tabId: tabId,
+            controller: controller,
+            variablesController: variablesController,
+          ),
         ),
       ),
     ),
@@ -191,5 +197,23 @@ void main() {
 
     // multipart rows expose an attach-file toggle (urlencoded does not).
     expect(find.byIcon(Icons.attach_file), findsOneWidget);
+  });
+
+  testWidgets('GRAPHQL shows the query + variables panes', (tester) async {
+    final bloc = await _loadedBloc(
+      repository,
+      sendRequestUseCase,
+      tab(BodyType.graphql),
+    );
+    addTearDown(bloc.close);
+
+    final controller = await _pump(tester, bloc, 't');
+    addTearDown(controller.dispose);
+
+    expect(find.text('GRAPHQL'), findsOneWidget);
+    expect(find.text('QUERY'), findsOneWidget);
+    expect(find.text('VARIABLES (JSON)'), findsOneWidget);
+    // Two code editors: query + variables.
+    expect(find.byType(CodeEditor), findsNWidgets(2));
   });
 }


### PR DESCRIPTION
## GraphQL body type

Adds a `graphql` request body type — a dual-pane editor (QUERY + VARIABLES JSON) that sends `{"query": …, "variables": …}` as `application/json`.

### QA
[Gravação de tela de 19-06-2026 19:24:12.webm](https://github.com/user-attachments/assets/3001cf20-545c-4576-86f2-2655bd53b416)

### Behavior
- **Editor:** BODY → **GRAPHQL** chip → QUERY pane (top) + VARIABLES (JSON) pane (bottom, with the JSON beautify wand).
- **Send:** posts `{query, variables}` as JSON, forces `Content-Type: application/json` (skip-if-custom). `{{variables}}` resolve in both panes.
- **Invalid variables:** non-empty text that isn't valid JSON surfaces a clear  status-0 error response ("GraphQL variables are not valid JSON: …") instead of  hitting the network — consistent with the missing-multipart-file handling.
- **Persistence:** new `graphqlVariables` field on the request config (entity +  Hive model typeId 1, `@HiveField(15)`); query reuses the existing `body`.
- **Integrations:** code-gen (all 6 targets), Postman import/export, and the git workspace mirror all round-trip GraphQL bodies. History dedup unchanged.

### Tests
- Serializer (envelope / blank / invalid / `{{var}}` resolution), entity↔model round-trip, code-gen, Postman round-trip, and a dual-pane widget test.
- Full suite green (1162 tests); `flutter analyze`, `custom_lint`, `bloc_lint` all clean.

Design + plan included under `docs/superpowers/`.

### Wiki (apply to Building-Requests.md — separate wiki repo)
@thiagomiranda3 Bump "five body types" → "six", add `GRAPHQL` to the chip list, and add after BINARY:

> ### GRAPHQL (`application/json`)
> A dual-pane editor for a GraphQL request, split top-to-bottom:
> - **QUERY** — your GraphQL query or mutation (top pane).
> - **VARIABLES (JSON)** — an optional JSON object of variables (bottom pane), with the same JSON highlighting and **Beautify** wand as a RAW body.
> - At send time Getman posts `{ "query": …, "variables": … }` as JSON and sets `Content-Type: application/json` automatically (unless you set one explicitly).
> - `{{variables}}` are resolved at send time in **both** panes.
> - If the VARIABLES pane holds text that isn't valid JSON, Getman surfaces a clear error response ("GraphQL variables are not valid JSON: …") instead of sending a malformed request. Leave it empty to send `{}`.
> - GraphQL requests round-trip through Postman import/export and the git workspace mirror.