### PR TITLE
{{var}} autocomplete, highlight & hover on body, auth & form-data

### DIFF
--- a/docs/superpowers/plans/2026-06-19-variable-autocomplete-body-auth-formdata.md
+++ b/docs/superpowers/plans/2026-06-19-variable-autocomplete-body-auth-formdata.md
@@ -1,0 +1,1502 @@
+# Variable Autocomplete on Body, Auth & Form-Data — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring `{{var}}` autocomplete, color highlighting, and hover preview to the request body (raw/JSON), auth fields, and form-data values — sourcing env + collection + dynamic variables everywhere, and aligning params/headers to that same source set.
+
+**Architecture:** Introduce one variable-source value object (`LayeredVariableContext`) and one builder widget (`TabVariableContextBuilder`) that feeds it from live bloc state. A new `VariableTextField` atom bundles the existing highlight-controller + autocomplete-overlay + hover wiring for every plain `TextField` (auth, form-data, kv editor). The `re_editor` body uses the package's built-in `CodeAutocomplete` with a custom prompts-builder + a variable-aware JSON span builder + a hover overlay.
+
+**Tech Stack:** Flutter, `flutter_bloc`, `re_editor 0.9.0` (built-in `CodeAutocomplete`), `re_highlight`, existing Getman variable utilities.
+
+## Global Constraints
+
+- Flutter SDK is pinned via `.fvmrc` — invoke every command as `fvm flutter ...` / `fvm dart ...`, never plain `flutter`/`dart`.
+- All imports are `package:getman/...` (no relative imports; enforced by `always_use_package_imports` + `directives_ordering`).
+- No hardcoded sizes/colors/radii/weights — pull from `context.appLayout` / `appPalette` / `appShape` / `appTypography` / `appDecoration`. Variable token colors are `appPalette.variableResolved` / `variableUnresolved`.
+- Do **not** reach `sl<T>()`/`GetIt` from widgets (custom_lint `avoid_get_it_in_widgets`); read services/blocs via `context.read`/`BlocBuilder`/`RepositoryProvider`.
+- Do **not** set `CodeEditorStyle.codeTheme` on the body editor — JSON coloring stays in the span builder (CLAUDE.md gotcha).
+- Domain layer stays pure; this is all presentation/util layer — no Hive/Dio/bloc/event/state changes, no new `@HiveType`.
+- Done-bar before any task is "complete": `fvm flutter analyze` (0 issues), `fvm dart run custom_lint` (0 issues), `fvm dart run bloc_tools:bloc lint lib` (0 issues), `fvm dart format lib test tools` clean, `fvm flutter test` green. The three analysis passes are independent.
+- Reference spec: `docs/superpowers/specs/2026-06-19-variable-autocomplete-body-auth-formdata-design.md`.
+
+---
+
+## File Structure
+
+**Create:**
+- `lib/core/utils/layered_variable_context.dart` — `LayeredVariableContext` value object (env+collection layers + dynamics; `classify`, merged getters).
+- `lib/core/ui/widgets/tab_variable_context_builder.dart` — `TabVariableContextBuilder` widget (builds the context from blocs for a tab).
+- `lib/core/ui/widgets/variable_text_field.dart` — `VariableTextField` atom (highlight + autocomplete + hover over a caller-owned controller).
+- `lib/features/tabs/presentation/widgets/variable_code_autocomplete.dart` — body editor: `VariablePromptsBuilder`, `_VariableCodePrompt`, `variableAutocompleteViewBuilder`, `wrapBodyWithVariableAutocomplete(...)`.
+- `lib/features/tabs/presentation/widgets/variable_json_span_builder.dart` — variable-aware JSON span builder (flat-run merge).
+- Tests mirroring each (under `test/...` following the existing test tree).
+
+**Modify:**
+- `lib/core/ui/widgets/key_value_list_editor.dart` — swap `VariableHoverContext?` → `LayeredVariableContext?`, render value field via `VariableTextField`, delete inline wiring.
+- `lib/features/tabs/presentation/widgets/request_editor_tabs.dart` — replace private `_VariableContextBuilder` usage with the shared `TabVariableContextBuilder`; pass `LayeredVariableContext`.
+- `lib/features/tabs/presentation/widgets/auth_tab_view.dart` — `_field` uses `VariableTextField`; wrap field list in `TabVariableContextBuilder`.
+- `lib/features/tabs/presentation/widgets/form_data_editor.dart` — value field uses `VariableTextField`; wrap in `TabVariableContextBuilder`.
+- `lib/features/tabs/presentation/widgets/json_code_editor.dart` — accept an optional variables source; use the variable-aware span builder.
+- `lib/features/tabs/presentation/widgets/request_view.dart` (+ `request_editor_tabs.dart` `BodyTabView`/`_RawBodyEditor`) — wrap the raw body `CodeEditor` in the variable autocomplete + feed it the tab context.
+
+---
+
+## Task 1: `LayeredVariableContext` value object
+
+**Files:**
+- Create: `lib/core/utils/layered_variable_context.dart`
+- Test: `test/core/utils/layered_variable_context_test.dart`
+
+**Interfaces:**
+- Consumes: `VariableResolutionHelper.classifyLayered` + `ResolvedVariable` (`lib/core/utils/variable_resolution_helper.dart`), `EnvironmentResolver.isDynamic`.
+- Produces:
+  - `class LayeredVariableContext` with const ctor `({Map<String,String> environmentVariables, Set<String> environmentSecrets, Map<String,String> collectionVariables, Set<String> collectionSecrets, String? environmentName})` (all default to empty/null).
+  - `Map<String,String> get allVariables` — collection overlaid by env (env wins).
+  - `Set<String> get allSecretKeys` — union of both secret sets.
+  - `bool get isEmpty` — true when `allVariables` is empty.
+  - `ResolvedVariable classify(String name)` — delegates to `classifyLayered`.
+  - `static const empty = LayeredVariableContext()`.
+  - Equatable.
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+// test/core/utils/layered_variable_context_test.dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/core/utils/layered_variable_context.dart';
+import 'package:getman/core/utils/variable_resolution_helper.dart';
+
+void main() {
+  group('LayeredVariableContext', () {
+    const ctx = LayeredVariableContext(
+      environmentVariables: {'host': 'env.example.com', 'token': 'secret'},
+      environmentSecrets: {'token'},
+      collectionVariables: {'host': 'col.example.com', 'path': '/v1'},
+      collectionSecrets: {},
+      environmentName: 'Staging',
+    );
+
+    test('allVariables merges with environment winning', () {
+      expect(ctx.allVariables['host'], 'env.example.com'); // env wins
+      expect(ctx.allVariables['path'], '/v1'); // collection-only kept
+      expect(ctx.allVariables.keys, containsAll(['host', 'token', 'path']));
+    });
+
+    test('allSecretKeys unions both layers', () {
+      expect(ctx.allSecretKeys, contains('token'));
+    });
+
+    test('classify reports environment source and secret kind', () {
+      final t = ctx.classify('token');
+      expect(t.kind, VariableValueKind.secret);
+      expect(t.environmentName, 'Staging');
+    });
+
+    test('classify reports Collection source for collection-only var', () {
+      final p = ctx.classify('path');
+      expect(p.kind, VariableValueKind.resolved);
+      expect(p.environmentName, 'Collection');
+    });
+
+    test('classify resolves dynamics and marks unknown unresolved', () {
+      expect(ctx.classify(r'$guid').kind, VariableValueKind.dynamicValue);
+      expect(ctx.classify('nope').kind, VariableValueKind.unresolved);
+    });
+
+    test('empty context isEmpty', () {
+      expect(LayeredVariableContext.empty.isEmpty, isTrue);
+      expect(ctx.isEmpty, isFalse);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `fvm flutter test test/core/utils/layered_variable_context_test.dart`
+Expected: FAIL — `layered_variable_context.dart` does not exist (compile error).
+
+- [ ] **Step 3: Write minimal implementation**
+
+```dart
+// lib/core/utils/layered_variable_context.dart
+import 'package:equatable/equatable.dart';
+import 'package:getman/core/utils/variable_resolution_helper.dart';
+
+/// The full set of variables available to a request field: the active
+/// environment layered over the request's inherited collection variables
+/// (environment wins on conflict), plus dynamic built-ins via [classify].
+/// Pure Dart — the single currency passed to every variable-aware field.
+class LayeredVariableContext extends Equatable {
+  const LayeredVariableContext({
+    this.environmentVariables = const {},
+    this.environmentSecrets = const {},
+    this.collectionVariables = const {},
+    this.collectionSecrets = const {},
+    this.environmentName,
+  });
+
+  static const LayeredVariableContext empty = LayeredVariableContext();
+
+  final Map<String, String> environmentVariables;
+  final Set<String> environmentSecrets;
+  final Map<String, String> collectionVariables;
+  final Set<String> collectionSecrets;
+  final String? environmentName;
+
+  /// Collection overlaid by environment (environment wins). Used for token
+  /// highlighting (resolved-vs-not) and as the autocomplete candidate set.
+  Map<String, String> get allVariables => {
+    ...collectionVariables,
+    ...environmentVariables,
+  };
+
+  Set<String> get allSecretKeys => {...collectionSecrets, ...environmentSecrets};
+
+  bool get isEmpty => allVariables.isEmpty;
+
+  ResolvedVariable classify(String name) =>
+      VariableResolutionHelper.classifyLayered(
+        name: name,
+        collectionVariables: collectionVariables,
+        collectionSecrets: collectionSecrets,
+        environmentVariables: environmentVariables,
+        environmentSecrets: environmentSecrets,
+        environmentName: environmentName,
+      );
+
+  @override
+  List<Object?> get props => [
+    environmentVariables,
+    environmentSecrets,
+    collectionVariables,
+    collectionSecrets,
+    environmentName,
+  ];
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `fvm flutter test test/core/utils/layered_variable_context_test.dart`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Analyze + format + commit**
+
+```bash
+fvm flutter analyze lib/core/utils/layered_variable_context.dart
+fvm dart format lib/core/utils/layered_variable_context.dart test/core/utils/layered_variable_context_test.dart
+git add lib/core/utils/layered_variable_context.dart test/core/utils/layered_variable_context_test.dart
+git commit -m "feat(variables): add LayeredVariableContext value object"
+```
+
+---
+
+## Task 2: `TabVariableContextBuilder` widget
+
+Builds a `LayeredVariableContext` for a given tab from live `EnvironmentsBloc` + `SettingsBloc` + `CollectionsBloc` + `TabsBloc` state, rebuilding when the env set / active-env id / collection tree change. This is the shared replacement for the private env-only `_VariableContextBuilder` in `request_editor_tabs.dart`.
+
+**Files:**
+- Create: `lib/core/ui/widgets/tab_variable_context_builder.dart`
+- Test: `test/core/ui/widgets/tab_variable_context_builder_test.dart`
+
+**Interfaces:**
+- Consumes: `LayeredVariableContext` (Task 1); `ActiveEnvironmentHelper.activeEnvironment`; `CollectionsTreeHelper.collectVariables`; blocs `EnvironmentsBloc`/`EnvironmentsState`, `SettingsBloc`/`SettingsState`, `CollectionsBloc`/`CollectionsState`, `TabsBloc`/`TabsState` (+ `TabsState.tabs.byId`).
+- Produces: `class TabVariableContextBuilder extends StatelessWidget` with ctor `({required String tabId, required Widget Function(BuildContext, LayeredVariableContext) builder, Key? key})`.
+
+> Mirror the existing `_layeredContext()` reads in `url_bar.dart:129` exactly (env active environment + `tab.collectionNodeId` → `CollectionsTreeHelper.collectVariables`). Wrap in nested `BlocBuilder`s with narrow `buildWhen`: SettingsBloc on `activeEnvironmentId`, EnvironmentsBloc on `environments`, CollectionsBloc on `collections`, TabsBloc on the tab's `collectionNodeId`.
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+// test/core/ui/widgets/tab_variable_context_builder_test.dart
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/core/ui/widgets/tab_variable_context_builder.dart';
+import 'package:getman/core/utils/layered_variable_context.dart';
+// Import the project's blocs + states + entities and the test helpers used by
+// the existing url_bar/request_editor_tabs widget tests. Reuse those fakes.
+
+void main() {
+  testWidgets('exposes env + collection layered context for the tab', (
+    tester,
+  ) async {
+    // Arrange: pump TabVariableContextBuilder under MultiBlocProvider with
+    //   - an active environment {host: env} (id selected in settings)
+    //   - a collection node (tab.collectionNodeId) carrying {path: /v1}
+    // Capture the LayeredVariableContext yielded to the builder.
+    late LayeredVariableContext captured;
+    // ... pump with fakes (see existing request_editor_tabs_test.dart setup) ...
+    // builder: (_, ctx) { captured = ctx; return const SizedBox(); }
+
+    expect(captured.environmentVariables['host'], isNotNull);
+    expect(captured.collectionVariables['path'], '/v1');
+    expect(captured.allVariables.keys, containsAll(['host', 'path']));
+  });
+}
+```
+
+> **Implementer note:** copy the bloc/fake setup from the nearest existing widget test that already provides EnvironmentsBloc + SettingsBloc + CollectionsBloc + TabsBloc (search `test/` for `_VariableContextBuilder` coverage or `request_editor_tabs_test`). Do not invent a new harness.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `fvm flutter test test/core/ui/widgets/tab_variable_context_builder_test.dart`
+Expected: FAIL — `tab_variable_context_builder.dart` does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```dart
+// lib/core/ui/widgets/tab_variable_context_builder.dart
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:getman/core/utils/layered_variable_context.dart';
+import 'package:getman/features/collections/domain/logic/collections_tree_helper.dart';
+import 'package:getman/features/collections/presentation/bloc/collections_bloc.dart';
+import 'package:getman/features/collections/presentation/bloc/collections_state.dart';
+import 'package:getman/features/environments/domain/logic/active_environment_helper.dart';
+import 'package:getman/features/environments/presentation/bloc/environments_bloc.dart';
+import 'package:getman/features/environments/presentation/bloc/environments_state.dart';
+import 'package:getman/features/settings/presentation/bloc/settings_bloc.dart';
+import 'package:getman/features/settings/presentation/bloc/settings_state.dart';
+import 'package:getman/features/tabs/presentation/bloc/tabs_bloc.dart';
+import 'package:getman/features/tabs/presentation/bloc/tabs_state.dart';
+
+/// Builds the layered (environment + collection + dynamic) variable context
+/// for [tabId] from live bloc state, rebuilding when the active environment,
+/// the environment set, the collection tree, or the tab's linked node change.
+/// Shared by params, headers, auth, form-data, and the body editor so every
+/// field offers identical suggestions.
+class TabVariableContextBuilder extends StatelessWidget {
+  const TabVariableContextBuilder({
+    required this.tabId,
+    required this.builder,
+    super.key,
+  });
+
+  final String tabId;
+  final Widget Function(BuildContext, LayeredVariableContext) builder;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<SettingsBloc, SettingsState>(
+      buildWhen: (p, n) =>
+          p.settings.activeEnvironmentId != n.settings.activeEnvironmentId,
+      builder: (context, settingsState) {
+        return BlocBuilder<EnvironmentsBloc, EnvironmentsState>(
+          buildWhen: (p, n) => p.environments != n.environments,
+          builder: (context, envState) {
+            return BlocBuilder<TabsBloc, TabsState>(
+              buildWhen: (p, n) =>
+                  p.tabs.byId(tabId)?.collectionNodeId !=
+                  n.tabs.byId(tabId)?.collectionNodeId,
+              builder: (context, tabsState) {
+                return BlocBuilder<CollectionsBloc, CollectionsState>(
+                  buildWhen: (p, n) => p.collections != n.collections,
+                  builder: (context, collectionsState) {
+                    final env = ActiveEnvironmentHelper.activeEnvironment(
+                      envState.environments,
+                      settingsState.settings.activeEnvironmentId,
+                    );
+                    final nodeId = tabsState.tabs.byId(tabId)?.collectionNodeId;
+                    final collected = nodeId == null
+                        ? (
+                            variables: const <String, String>{},
+                            secretKeys: const <String>{},
+                          )
+                        : CollectionsTreeHelper.collectVariables(
+                            collectionsState.collections,
+                            nodeId,
+                          );
+                    return builder(
+                      context,
+                      LayeredVariableContext(
+                        environmentVariables: env?.variables ?? const {},
+                        environmentSecrets: env?.secretKeys ?? const {},
+                        collectionVariables: collected.variables,
+                        collectionSecrets: collected.secretKeys,
+                        environmentName: env?.name,
+                      ),
+                    );
+                  },
+                );
+              },
+            );
+          },
+        );
+      },
+    );
+  }
+}
+```
+
+> Verify `CollectionsTreeHelper.collectVariables` returns a record with `.variables` and `.secretKeys` (it does — see `url_bar.dart:139`). Verify `TabsState.tabs.byId(...)` exists (it does — `url_bar.dart:137`).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `fvm flutter test test/core/ui/widgets/tab_variable_context_builder_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Analyze + format + commit**
+
+```bash
+fvm flutter analyze lib/core/ui/widgets/tab_variable_context_builder.dart
+fvm dart format lib/core/ui/widgets/tab_variable_context_builder.dart test/core/ui/widgets/tab_variable_context_builder_test.dart
+git add lib/core/ui/widgets/tab_variable_context_builder.dart test/core/ui/widgets/tab_variable_context_builder_test.dart
+git commit -m "feat(variables): add shared TabVariableContextBuilder"
+```
+
+---
+
+## Task 3: `VariableTextField` atom
+
+A drop-in `TextField` that highlights `{{var}}`, shows the `{{`-autocomplete overlay, and shows the hover popover — given a `LayeredVariableContext` and a caller-owned `VariableHighlightController`. This is the extraction of the wiring currently inlined in `KeyValueListEditor` (`key_value_list_editor.dart:181-206`, `:352-360`).
+
+**Files:**
+- Create: `lib/core/ui/widgets/variable_text_field.dart`
+- Test: `test/core/ui/widgets/variable_text_field_test.dart`
+
+**Interfaces:**
+- Consumes: `LayeredVariableContext` (Task 1); `VariableHighlightController`, `VariableAutocomplete`, `VariableHoverController`, `buildVariableSuggestions`.
+- Produces: `class VariableTextField extends StatefulWidget` with ctor:
+  ```dart
+  const VariableTextField({
+    required this.context_, // LayeredVariableContext  (named `variables` below)
+    required this.controller,        // VariableHighlightController (caller-owned)
+    required this.focusNode,         // FocusNode (caller-owned)
+    required this.onChanged,         // ValueChanged<String>
+    this.decoration,                 // InputDecoration?
+    this.obscureText = false,
+    this.fieldKey,                   // Key? applied to the inner TextField
+    super.key,
+  });
+  ```
+  (Use a clean param name — `variables` of type `LayeredVariableContext` — not `context_`. The owner keeps the controller so existing echo-suppression keeps working.)
+
+> **Why caller-owned controller:** auth/form-data/kv all hold their own controllers and suppress echoes across the bloc round-trip; the atom only decorates. Assert/require a `VariableHighlightController` so `buildTextSpan` highlighting works.
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+// test/core/ui/widgets/variable_text_field_test.dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/core/theme/theme_registry.dart';
+import 'package:getman/core/ui/widgets/variable_highlight_controller.dart';
+import 'package:getman/core/ui/widgets/variable_text_field.dart';
+import 'package:getman/core/utils/layered_variable_context.dart';
+
+Widget _host(Widget child) => MaterialApp(
+  theme: resolveTheme('brutalist')(Brightness.light, false),
+  home: Scaffold(body: child),
+);
+
+void main() {
+  const ctx = LayeredVariableContext(
+    environmentVariables: {'host': 'example.com', 'token': 'abc'},
+    environmentName: 'Staging',
+  );
+
+  testWidgets('typing {{ opens the suggestion overlay', (tester) async {
+    final controller = VariableHighlightController();
+    final focus = FocusNode();
+    await tester.pumpWidget(
+      _host(
+        VariableTextField(
+          variables: ctx,
+          controller: controller,
+          focusNode: focus,
+          onChanged: (_) {},
+        ),
+      ),
+    );
+    await tester.tap(find.byType(TextField));
+    await tester.enterText(find.byType(TextField), '{{');
+    await tester.pumpAndSettle();
+
+    expect(find.text('host'), findsOneWidget);
+    expect(find.text('token'), findsOneWidget);
+  });
+
+  testWidgets('accepting a suggestion inserts {{name}}', (tester) async {
+    final controller = VariableHighlightController();
+    final focus = FocusNode();
+    await tester.pumpWidget(
+      _host(
+        VariableTextField(
+          variables: ctx,
+          controller: controller,
+          focusNode: focus,
+          onChanged: (_) {},
+        ),
+      ),
+    );
+    await tester.tap(find.byType(TextField));
+    await tester.enterText(find.byType(TextField), '{{ho');
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('host'));
+    await tester.pumpAndSettle();
+
+    expect(controller.text, '{{host}}');
+  });
+
+  testWidgets('empty context renders a plain field with no overlay', (
+    tester,
+  ) async {
+    final controller = VariableHighlightController();
+    final focus = FocusNode();
+    await tester.pumpWidget(
+      _host(
+        VariableTextField(
+          variables: LayeredVariableContext.empty,
+          controller: controller,
+          focusNode: focus,
+          onChanged: (_) {},
+        ),
+      ),
+    );
+    await tester.tap(find.byType(TextField));
+    await tester.enterText(find.byType(TextField), '{{');
+    await tester.pumpAndSettle();
+    // No suggestions to show.
+    expect(find.byType(ListView), findsNothing);
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `fvm flutter test test/core/ui/widgets/variable_text_field_test.dart`
+Expected: FAIL — `variable_text_field.dart` does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```dart
+// lib/core/ui/widgets/variable_text_field.dart
+import 'package:flutter/material.dart';
+import 'package:getman/core/theme/app_theme.dart';
+import 'package:getman/core/ui/widgets/variable_autocomplete.dart';
+import 'package:getman/core/ui/widgets/variable_highlight_controller.dart';
+import 'package:getman/core/ui/widgets/variable_hover_popover.dart';
+import 'package:getman/core/utils/variable_suggestions.dart';
+import 'package:getman/core/utils/layered_variable_context.dart';
+
+/// A [TextField] that highlights `{{var}}` tokens, offers a `{{`-triggered
+/// autocomplete overlay, and shows a hover popover resolving each token —
+/// given a [variables] context and a caller-owned [VariableHighlightController]
+/// (kept by the owner so its echo-suppression survives the bloc round-trip).
+/// When [variables] is empty it degrades to a plain styled field.
+class VariableTextField extends StatefulWidget {
+  const VariableTextField({
+    required this.variables,
+    required this.controller,
+    required this.focusNode,
+    required this.onChanged,
+    this.decoration,
+    this.obscureText = false,
+    this.fieldKey,
+    super.key,
+  });
+
+  final LayeredVariableContext variables;
+  final VariableHighlightController controller;
+  final FocusNode focusNode;
+  final ValueChanged<String> onChanged;
+  final InputDecoration? decoration;
+  final bool obscureText;
+  final Key? fieldKey;
+
+  @override
+  State<VariableTextField> createState() => _VariableTextFieldState();
+}
+
+class _VariableTextFieldState extends State<VariableTextField> {
+  final VariableHoverController _hover = VariableHoverController();
+
+  @override
+  void dispose() {
+    _hover.dispose();
+    super.dispose();
+  }
+
+  void _showPopover(String name, Offset globalPosition) {
+    if (!mounted) return;
+    _hover.showFor(context, widget.variables.classify(name), globalPosition);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.appPalette;
+    final ctx = widget.variables;
+
+    // Wire highlight colors + variable map + hover sinks onto the controller.
+    widget.controller
+      ..updateColors(
+        resolved: palette.variableResolved,
+        unresolved: palette.variableUnresolved,
+      )
+      ..updateVariables(ctx.allVariables)
+      ..onVariableEnter = ctx.isEmpty
+          ? null
+          : (name, pos) {
+              _showPopover(name, pos);
+            }
+      ..onVariableExit = ctx.isEmpty ? null : _hover.scheduleHide;
+
+    final field = TextField(
+      key: widget.fieldKey,
+      controller: widget.controller,
+      focusNode: widget.focusNode,
+      decoration: widget.decoration,
+      obscureText: widget.obscureText,
+      autocorrect: false,
+      enableSuggestions: false,
+      onChanged: widget.onChanged,
+    );
+
+    if (ctx.isEmpty) return field;
+
+    return VariableAutocomplete(
+      controller: widget.controller,
+      focusNode: widget.focusNode,
+      suggestionsFor: (query) => buildVariableSuggestions(
+        query: query,
+        userVariableNames: ctx.allVariables.keys,
+        classify: ctx.classify,
+      ),
+      onAccepted: widget.onChanged,
+      child: field,
+    );
+  }
+}
+```
+
+> `obscureText: true` + a `VariableHighlightController` still shows the overlay; the field obscures characters but the menu works (matches the design's "password autocompletes while obscured"). Note `enableSuggestions/autocorrect` are forced off, as elsewhere.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `fvm flutter test test/core/ui/widgets/variable_text_field_test.dart`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Analyze + format + commit**
+
+```bash
+fvm flutter analyze lib/core/ui/widgets/variable_text_field.dart
+fvm dart format lib/core/ui/widgets/variable_text_field.dart test/core/ui/widgets/variable_text_field_test.dart
+git add lib/core/ui/widgets/variable_text_field.dart test/core/ui/widgets/variable_text_field_test.dart
+git commit -m "feat(variables): add VariableTextField atom"
+```
+
+---
+
+## Task 4: Migrate `KeyValueListEditor` + params/headers to the layered context
+
+Switch the kv editor's `variableContext` from `VariableHoverContext?` to `LayeredVariableContext?`, render the value field via `VariableTextField`, and delete the inline highlight/hover/suggestion wiring. Update `request_editor_tabs.dart` to feed params/headers through `TabVariableContextBuilder` (so they gain collection + dynamic suggestions — the approved behavior change). Remove the now-unused private `_VariableContextBuilder` and, if it becomes unreferenced, `VariableHoverContext`.
+
+**Files:**
+- Modify: `lib/core/ui/widgets/key_value_list_editor.dart`
+- Modify: `lib/features/tabs/presentation/widgets/request_editor_tabs.dart`
+- Test: `test/core/ui/widgets/key_value_list_editor_test.dart` (existing — extend), `test/features/tabs/presentation/widgets/request_editor_tabs_test.dart` (existing — adjust)
+
+**Interfaces:**
+- Consumes: `VariableTextField` (Task 3), `LayeredVariableContext` (Task 1), `TabVariableContextBuilder` (Task 2).
+- Produces: `KeyValueListEditor<T>` now takes `LayeredVariableContext? variableContext`. The `_KeyValueRow` value field becomes a `VariableTextField` when context is non-empty; the prior `valueSuggestionsFor` / inline `VariableHighlightController` wiring is removed.
+
+- [ ] **Step 1: Update the existing kv editor test to the new type**
+
+In `test/core/ui/widgets/key_value_list_editor_test.dart`, change any `VariableHoverContext(...)` passed as `variableContext:` to `LayeredVariableContext(environmentVariables: {...}, environmentName: ...)`. Add an assertion that a `{{` in a value field opens the overlay (find a suggestion name), mirroring Task 3's first test. Keep all existing non-variable kv tests unchanged.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `fvm flutter test test/core/ui/widgets/key_value_list_editor_test.dart`
+Expected: FAIL — `KeyValueListEditor.variableContext` still typed `VariableHoverContext?` (compile error on the new `LayeredVariableContext`).
+
+- [ ] **Step 3: Implement — kv editor**
+
+In `key_value_list_editor.dart`:
+1. Change the field + ctor param:
+   ```dart
+   final LayeredVariableContext? variableContext;
+   ```
+   Update the doc comment to say "the layered (env + collection + dynamic) context".
+2. `_newValueController` keeps returning `VariableHighlightController` when `variableContext != null` (a non-null but empty context still gets a highlight controller; `VariableTextField` degrades gracefully).
+3. In `build`, delete the whole `if (varContext != null && valController is VariableHighlightController) { ... }` block (the inline `updateColors`/`updateVariables`/`onVariableEnter`/`valueSuggestionsFor` setup) and the `_showVariablePopover`/`_hoverController` machinery if now unused — `VariableTextField` owns all of it.
+4. Pass the context down to the row instead of `valueSuggestionsFor`:
+   ```dart
+   return _KeyValueRow(
+     ...,
+     variableContext: widget.variableContext,
+     ...,
+   );
+   ```
+5. In `_KeyValueRow`, replace `valueSuggestionsFor` with `final LayeredVariableContext? variableContext;` and build the value field as:
+   ```dart
+   final valController = widget.valController;
+   final ctx = widget.variableContext;
+   final valueFieldWithAutocomplete =
+       (ctx == null || ctx.isEmpty || valController is! VariableHighlightController)
+       ? valueField
+       : VariableTextField(
+           variables: ctx,
+           controller: valController,
+           focusNode: _valueFocusNode,
+           onChanged: widget.onValChanged,
+           decoration: /* the existing valueField decoration */,
+           fieldKey: /* existing ValueKey('<prefix>_val_<index>') if any */,
+         );
+   ```
+   Simplest: keep `valueField` for the plain case and only wrap with `VariableTextField` for the variable case. To avoid building the field twice, factor the `InputDecoration` into a local and pass it to `VariableTextField`. (The reveal/secret toggle suffix logic stays on the plain `valueField`; secret rows are env-editor-only and pass a null `variableContext`, so the two never combine.)
+
+> Keep `import 'variable_text_field.dart'`; drop now-unused imports (`variable_autocomplete.dart`, `variable_hover_popover.dart`, `variable_suggestions.dart`, `variable_resolution_helper.dart`) if no longer referenced — `fvm flutter analyze` will flag leftovers.
+
+- [ ] **Step 4: Implement — params/headers wiring**
+
+In `request_editor_tabs.dart`:
+1. Replace the private `_VariableContextBuilder` (lines ~37-71) — delete it.
+2. At the params usage (~line 194) and headers usage (~line 275), wrap with the shared builder:
+   ```dart
+   TabVariableContextBuilder(
+     tabId: tab.tabId, // or the tabId in scope
+     builder: (context, varContext) => KeyValueListEditor<...>(
+       items: ...,
+       variableContext: varContext,
+       fieldPrefix: 'param', // 'header' for headers
+       decode: ...,
+       encode: ...,
+       equals: ...,
+       onChanged: emit,
+     ),
+   )
+   ```
+3. Remove the now-unused imports that only `_VariableContextBuilder` needed (`active_environment_helper`, `variable_hover_popover`'s `VariableHoverContext`, the env/settings bloc imports if unused elsewhere in the file). Add the `tab_variable_context_builder.dart` + `layered_variable_context.dart` imports.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `fvm flutter test test/core/ui/widgets/key_value_list_editor_test.dart test/features/tabs/presentation/widgets/request_editor_tabs_test.dart`
+Expected: PASS. Fix any test that asserted env-only suggestions to also accept collection/dynamic names.
+
+- [ ] **Step 6: Full analyze (dead-code check) + format + commit**
+
+```bash
+fvm flutter analyze
+fvm dart run custom_lint
+fvm dart format lib test
+git add lib/core/ui/widgets/key_value_list_editor.dart lib/features/tabs/presentation/widgets/request_editor_tabs.dart test/core/ui/widgets/key_value_list_editor_test.dart test/features/tabs/presentation/widgets/request_editor_tabs_test.dart
+git commit -m "refactor(variables): kv editor + params/headers use layered context via VariableTextField"
+```
+
+> If `VariableHoverContext` is now unreferenced anywhere, delete it from `variable_hover_popover.dart` in this commit (analyze will confirm). If still referenced, leave it.
+
+---
+
+## Task 5: Auth fields
+
+Wrap the auth field list in `TabVariableContextBuilder` and render each field via `VariableTextField`. Field controllers become `VariableHighlightController` (still caller-owned, echo-suppression unchanged).
+
+**Files:**
+- Modify: `lib/features/tabs/presentation/widgets/auth_tab_view.dart`
+- Test: `test/features/tabs/presentation/widgets/auth_tab_view_test.dart` (create if absent)
+
+**Interfaces:**
+- Consumes: `VariableTextField`, `LayeredVariableContext`, `TabVariableContextBuilder`.
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+// test/features/tabs/presentation/widgets/auth_tab_view_test.dart
+// Pump AuthTabView(tabId: ...) under the bloc harness used by other tabs
+// widget tests (provides TabsBloc/EnvironmentsBloc/SettingsBloc/CollectionsBloc),
+// with an active environment {host: example.com} and the tab's auth = bearer.
+//
+// 1. Tap the TOKEN field, enterText '{{ho', pumpAndSettle.
+// 2. expect(find.text('host'), findsOneWidget);  // suggestion overlay
+// 3. tap it; expect the token field controller text == '{{host}}'.
+```
+
+> Reuse the existing tabs widget-test harness (search `test/features/tabs/.../*auth*` or the request panel tests for the provider setup).
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `fvm flutter test test/features/tabs/presentation/widgets/auth_tab_view_test.dart`
+Expected: FAIL — no overlay (auth fields are plain `TextField`s).
+
+- [ ] **Step 3: Implement**
+
+In `auth_tab_view.dart`:
+1. Change the five controllers to `VariableHighlightController`:
+   ```dart
+   late final VariableHighlightController _token;
+   // ...same for _username, _password, _apiKeyName, _apiKeyValue
+   _token = VariableHighlightController(text: auth.token);
+   ```
+2. Add a `FocusNode` per field (auth currently has none) — `late final FocusNode _tokenFocus; ...` created in `initState`, disposed in `dispose`. (Or a `Map<TextEditingController, FocusNode>`.)
+3. Wrap the built field column in `build` with the context builder. Since `_fieldsFor`/`_field` need the context, thread it in:
+   ```dart
+   @override
+   Widget build(BuildContext context) {
+     return TabVariableContextBuilder(
+       tabId: widget.tabId,
+       builder: (context, varContext) => Column(
+         crossAxisAlignment: CrossAxisAlignment.start,
+         children: [
+           // ... existing type selector ...
+           ..._fieldsFor(context, varContext),
+         ],
+       ),
+     );
+   }
+   ```
+4. `_field(...)` gains a `LayeredVariableContext` + `FocusNode` and returns a `VariableTextField`:
+   ```dart
+   Widget _field(
+     BuildContext context,
+     String label,
+     VariableHighlightController controller,
+     FocusNode focusNode,
+     LayeredVariableContext variables, {
+     bool obscure = false,
+   }) {
+     return Padding(
+       // keep the existing label + spacing layout around it
+       child: VariableTextField(
+         fieldKey: ValueKey('auth_field_$label'),
+         variables: variables,
+         controller: controller,
+         focusNode: focusNode,
+         obscureText: obscure,
+         onChanged: (_) => _emit(),
+         decoration: /* the existing auth field InputDecoration */,
+       ),
+     );
+   }
+   ```
+   Preserve the existing label widget and `InputDecoration` exactly; only the inner `TextField` becomes `VariableTextField`. Keep `_setIfChanged`/`_lastEmitted` echo-suppression and `_emit` unchanged.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `fvm flutter test test/features/tabs/presentation/widgets/auth_tab_view_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Analyze + bloc-lint + format + commit**
+
+```bash
+fvm flutter analyze
+fvm dart run custom_lint
+fvm dart format lib test
+git add lib/features/tabs/presentation/widgets/auth_tab_view.dart test/features/tabs/presentation/widgets/auth_tab_view_test.dart
+git commit -m "feat(variables): variable autocomplete on auth fields"
+```
+
+---
+
+## Task 6: Form-data values
+
+Wrap the form-data editor in `TabVariableContextBuilder`; the non-file value field becomes a `VariableTextField` over a `VariableHighlightController` value controller.
+
+**Files:**
+- Modify: `lib/features/tabs/presentation/widgets/form_data_editor.dart`
+- Test: `test/features/tabs/presentation/widgets/form_data_editor_test.dart` (create if absent)
+
+**Interfaces:**
+- Consumes: `VariableTextField`, `LayeredVariableContext`, `TabVariableContextBuilder`.
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+// Pump FormDataEditor(tabId: ..., allowFiles: true) under the tabs harness
+// with active environment {host: example.com} and one urlencoded/multipart row.
+// 1. enterText '{{ho' into the value field of a non-file row; pumpAndSettle.
+// 2. expect(find.text('host'), findsOneWidget);
+// 3. tap it; expect that row's valueController text == '{{host}}'.
+// 4. (negative) the NAME field shows no overlay for '{{'.
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `fvm flutter test test/features/tabs/presentation/widgets/form_data_editor_test.dart`
+Expected: FAIL — value field is a plain `TextField`.
+
+- [ ] **Step 3: Implement**
+
+In `form_data_editor.dart`:
+1. Change `_RowState.valueController` to `VariableHighlightController` (both factory constructors at lines ~303-313). Add a `FocusNode valueFocus` per row (created in the row factories, disposed in `_RowState.dispose` alongside `valueController.dispose()`).
+2. Wrap the editor body (`build`, ~line 112) in `TabVariableContextBuilder(tabId: widget.tabId, builder: (context, varContext) => ...)` and thread `varContext` to the row builder.
+3. Replace the non-file value `TextField` (~line 175) with:
+   ```dart
+   : VariableTextField(
+       fieldKey: ValueKey('val_${row.id}'),
+       variables: varContext,
+       controller: row.valueController, // VariableHighlightController
+       focusNode: row.valueFocus,
+       onChanged: (_) => _emit(),
+       decoration: /* the existing value-field InputDecoration */,
+     )
+   ```
+   File rows (`_FilePickButton`) and the name `TextField` are unchanged. `_emit` flow unchanged.
+
+> If `_emit` reads `valueController.text`, it still works — `VariableHighlightController` is a `TextEditingController`.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `fvm flutter test test/features/tabs/presentation/widgets/form_data_editor_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Analyze + format + commit**
+
+```bash
+fvm flutter analyze
+fvm dart run custom_lint
+fvm dart format lib test
+git add lib/features/tabs/presentation/widgets/form_data_editor.dart test/features/tabs/presentation/widgets/form_data_editor_test.dart
+git commit -m "feat(variables): variable autocomplete on form-data values"
+```
+
+---
+
+## Task 7: Body editor — autocomplete via `re_editor` `CodeAutocomplete`
+
+Add a `{{`-triggered variable autocomplete to the raw/JSON body editor using `re_editor 0.9.0`'s built-in `CodeAutocomplete`, reusing `detectActiveVariableQuery` + `buildVariableSuggestions`.
+
+**Files:**
+- Create: `lib/features/tabs/presentation/widgets/variable_code_autocomplete.dart`
+- Modify: `lib/features/tabs/presentation/widgets/json_code_editor.dart` (optional wrap), `lib/features/tabs/presentation/widgets/request_editor_tabs.dart` (`_RawBodyEditor`), and `request_view.dart` (provide the tab context to the body editor)
+- Test: `test/features/tabs/presentation/widgets/variable_code_autocomplete_test.dart`
+
+**Interfaces:**
+- Consumes: `re_editor` (`CodeAutocomplete`, `CodeAutocompletePromptsBuilder`, `CodeAutocompleteEditingValue`, `CodePrompt`, `CodeAutocompleteResult`, `CodeLine`, `CodeLineSelection`); `detectActiveVariableQuery`/`ActiveVariableQuery`; `buildVariableSuggestions`/`VariableSuggestion`; `LayeredVariableContext`.
+- Produces:
+  - `class VariablePromptsBuilder implements CodeAutocompletePromptsBuilder` — ctor `(LayeredVariableContext Function() contextProvider)` (read live so env switches apply). `build(context, codeLine, selection)` → `CodeAutocompleteEditingValue?`.
+  - `Widget wrapBodyWithVariableAutocomplete({required LayeredVariableContext Function() contextProvider, required Widget child})` returning a `CodeAutocomplete` (returns `child` unchanged when the context provider yields empty, to avoid an empty overlay).
+  - `CodeAutocompleteWidgetBuilder variableAutocompleteViewBuilder` — the themed suggestion list.
+
+**Verified `re_editor` mechanics (from lib source):**
+- `_updateAutoCompleteState` calls `promptsBuilder.build(...)` on every line-changing keystroke when the selection is collapsed.
+- On select, the editor runs `controller.replaceSelection(word, range=[caret - input.length, caret])` then moves the caret by `word.length - input.length`. So set `input = query.query` (chars after `{{`) and `word = name` (+ `}}` when `!hasClosingBraces`); the `{{` stays, caret lands after the insert.
+- Nav ↑/↓ + Enter are handled by the package's actions; Tab is **not** wired (documented divergence).
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+// test/features/tabs/presentation/widgets/variable_code_autocomplete_test.dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:re_editor/re_editor.dart';
+import 'package:getman/core/utils/layered_variable_context.dart';
+import 'package:getman/features/tabs/presentation/widgets/variable_code_autocomplete.dart';
+
+void main() {
+  const ctx = LayeredVariableContext(
+    environmentVariables: {'host': 'example.com', 'token': 'abc'},
+    environmentName: 'Staging',
+  );
+
+  group('VariablePromptsBuilder.build', () {
+    final builder = VariablePromptsBuilder(() => ctx);
+
+    CodeAutocompleteEditingValue? run(String line, int caret) => builder.build(
+      // A minimal BuildContext is not needed by build(); pass a dummy via a
+      // pumped widget if the impl reads context. If it doesn't, refactor build
+      // to not require context and test directly. Prefer a pumped Builder.
+      _ctx!,
+      CodeLine(line),
+      CodeLineSelection.collapsed(index: 0, offset: caret),
+    );
+
+    // Implementer: if build needs BuildContext only for theme, keep detection
+    // logic in a pure helper and unit-test THAT helper here instead:
+    //   variablePromptsFor(ctx, line, caret) -> ({String input, List<VariableSuggestion> suggestions})?
+    test('returns suggestions for an open {{ token', () {
+      final r = variablePromptsFor(ctx, '{{ho', 4);
+      expect(r, isNotNull);
+      expect(r!.input, 'ho');
+      expect(r.suggestions.map((s) => s.name), contains('host'));
+    });
+
+    test('returns null when caret is not in a {{ token', () {
+      expect(variablePromptsFor(ctx, 'plain text', 5), isNull);
+    });
+
+    test('word includes closing braces when not already present', () {
+      // For query 'ho' with no following }}, accepting 'host' must yield
+      // an insertion word of 'host}}'.
+      final word = variableInsertionWord('host', hasClosingBraces: false);
+      expect(word, 'host}}');
+      expect(variableInsertionWord('host', hasClosingBraces: true), 'host');
+    });
+  });
+}
+
+CodeAutocompleteEditingValue? _placeholder; // remove
+const BuildContext? _ctx = null; // replaced by pumped context in real test
+```
+
+> **Implementer:** factor the detection into pure top-level helpers so they're unit-testable without a `BuildContext`:
+> - `({String input, List<VariableSuggestion> suggestions})? variablePromptsFor(LayeredVariableContext ctx, String line, int caret)` — runs `detectActiveVariableQuery` + `buildVariableSuggestions`.
+> - `String variableInsertionWord(String name, {required bool hasClosingBraces})` — `hasClosingBraces ? name : '$name}}'`.
+> `VariablePromptsBuilder.build` and the `CodePrompt` subclass are thin wrappers over these. Test the pure helpers (above) plus one pumped-widget test that the overlay appears (below).
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `fvm flutter test test/features/tabs/presentation/widgets/variable_code_autocomplete_test.dart`
+Expected: FAIL — file/helpers do not exist.
+
+- [ ] **Step 3: Implement**
+
+```dart
+// lib/features/tabs/presentation/widgets/variable_code_autocomplete.dart
+import 'dart:math' as math;
+import 'package:flutter/material.dart';
+import 'package:getman/core/theme/app_theme.dart';
+import 'package:getman/core/utils/layered_variable_context.dart';
+import 'package:getman/core/utils/variable_autocomplete_query.dart';
+import 'package:getman/core/utils/variable_resolution_helper.dart';
+import 'package:getman/core/utils/variable_suggestions.dart';
+import 'package:re_editor/re_editor.dart';
+
+/// Pure detection: the active `{{` query at [caret] in [line] and its ranked
+/// suggestions, or null when the caret is not inside an open `{{name` token.
+({String input, bool hasClosingBraces, List<VariableSuggestion> suggestions})?
+variablePromptsFor(LayeredVariableContext ctx, String line, int caret) {
+  final query = detectActiveVariableQuery(line, caret);
+  if (query == null) return null;
+  final suggestions = buildVariableSuggestions(
+    query: query.query,
+    userVariableNames: ctx.allVariables.keys,
+    classify: ctx.classify,
+  );
+  if (suggestions.isEmpty) return null;
+  return (
+    input: query.query,
+    hasClosingBraces: query.hasClosingBraces,
+    suggestions: suggestions,
+  );
+}
+
+String variableInsertionWord(String name, {required bool hasClosingBraces}) =>
+    hasClosingBraces ? name : '$name}}';
+
+/// A single variable suggestion as a re_editor [CodePrompt]. Carries the
+/// resolved closing-brace decision so `.autocomplete` inserts `name` or
+/// `name}}` correctly.
+class _VariableCodePrompt extends CodePrompt {
+  const _VariableCodePrompt({
+    required super.word, // the variable name (display + match key)
+    required this.hasClosingBraces,
+    required this.classification,
+  });
+
+  final bool hasClosingBraces;
+  final ResolvedVariable classification;
+
+  @override
+  bool match(String input) =>
+      word.toLowerCase().contains(input.toLowerCase());
+
+  @override
+  CodeAutocompleteResult get autocomplete {
+    final insert = variableInsertionWord(word, hasClosingBraces: hasClosingBraces);
+    return CodeAutocompleteResult(
+      input: '', // editing-value.input carries the typed query; see note
+      word: insert,
+      selection: TextSelection.collapsed(offset: insert.length),
+    );
+  }
+}
+
+/// re_editor prompts builder backed by the live [LayeredVariableContext].
+class VariablePromptsBuilder implements CodeAutocompletePromptsBuilder {
+  VariablePromptsBuilder(this.contextProvider);
+  final LayeredVariableContext Function() contextProvider;
+
+  @override
+  CodeAutocompleteEditingValue? build(
+    BuildContext context,
+    CodeLine codeLine,
+    CodeLineSelection selection,
+  ) {
+    if (!selection.isCollapsed) return null;
+    final found = variablePromptsFor(
+      contextProvider(),
+      codeLine.text,
+      selection.extentOffset,
+    );
+    if (found == null) return null;
+    return CodeAutocompleteEditingValue(
+      input: found.input,
+      prompts: [
+        for (final s in found.suggestions)
+          _VariableCodePrompt(
+            word: s.name,
+            hasClosingBraces: found.hasClosingBraces,
+            classification: s.classification,
+          ),
+      ],
+      index: 0,
+    );
+  }
+}
+
+/// Themed suggestion list for the body editor — mirrors the rows used by the
+/// TextField overlay (name + source + resolved preview).
+PreferredSizeWidget Function(
+  BuildContext,
+  ValueNotifier<CodeAutocompleteEditingValue>,
+  ValueChanged<CodeAutocompleteResult>,
+)
+get variableAutocompleteViewBuilder => _buildView;
+
+PreferredSizeWidget _buildView(
+  BuildContext context,
+  ValueNotifier<CodeAutocompleteEditingValue> notifier,
+  ValueChanged<CodeAutocompleteResult> onSelected,
+) => _VariableCodeAutocompleteList(notifier: notifier, onSelected: onSelected);
+
+const double _kRowHeight = 32;
+const double _kMenuWidth = 280;
+const double _kMaxMenuHeight = 240;
+
+class _VariableCodeAutocompleteList extends StatelessWidget
+    implements PreferredSizeWidget {
+  const _VariableCodeAutocompleteList({
+    required this.notifier,
+    required this.onSelected,
+  });
+
+  final ValueNotifier<CodeAutocompleteEditingValue> notifier;
+  final ValueChanged<CodeAutocompleteResult> onSelected;
+
+  @override
+  Size get preferredSize => Size(
+    _kMenuWidth,
+    math.min(_kRowHeight * notifier.value.prompts.length, _kMaxMenuHeight),
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<CodeAutocompleteEditingValue>(
+      valueListenable: notifier,
+      builder: (context, value, _) {
+        final palette = context.appPalette;
+        final layout = context.appLayout;
+        final theme = Theme.of(context);
+        return Container(
+          width: _kMenuWidth,
+          constraints: const BoxConstraints(maxHeight: _kMaxMenuHeight),
+          decoration: context.appDecoration.panelBox(context),
+          clipBehavior: Clip.antiAlias,
+          child: ListView.builder(
+            padding: EdgeInsets.zero,
+            shrinkWrap: true,
+            itemCount: value.prompts.length,
+            itemBuilder: (context, i) {
+              final prompt = value.prompts[i] as _VariableCodePrompt;
+              final c = prompt.classification;
+              final isSecret = c.kind == VariableValueKind.secret;
+              final isDynamic = c.kind == VariableValueKind.dynamicValue;
+              final preview = isSecret ? '••••' : (c.value ?? '');
+              final source = isDynamic ? 'dynamic' : (c.environmentName ?? '');
+              final muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+              return InkWell(
+                onTap: () => onSelected(
+                  value.copyWith(index: i).autocomplete,
+                ),
+                child: Container(
+                  height: _kRowHeight,
+                  color: i == value.index
+                      ? theme.colorScheme.primary.withValues(alpha: 0.12)
+                      : null,
+                  padding: const EdgeInsets.symmetric(horizontal: 12),
+                  child: Row(
+                    children: [
+                      Flexible(
+                        child: Text(
+                          prompt.word,
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(
+                            fontSize: layout.fontSizeNormal,
+                            fontWeight: context.appTypography.titleWeight,
+                            color: isDynamic
+                                ? palette.variableResolved
+                                : theme.colorScheme.onSurface,
+                          ),
+                        ),
+                      ),
+                      if (source.isNotEmpty) ...[
+                        const SizedBox(width: 8),
+                        Text(
+                          source,
+                          style: TextStyle(
+                            fontSize: layout.fontSizeNormal,
+                            color: muted,
+                          ),
+                        ),
+                      ],
+                      if (preview.isNotEmpty) ...[
+                        const SizedBox(width: 12),
+                        Flexible(
+                          child: Text(
+                            preview,
+                            textAlign: TextAlign.right,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(
+                              fontSize: layout.fontSizeNormal,
+                              color: muted,
+                              fontStyle:
+                                  isDynamic ? FontStyle.italic : FontStyle.normal,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+              );
+            },
+          ),
+        );
+      },
+    );
+  }
+}
+
+/// Wraps a body [child] (a `CodeEditor`) with variable autocomplete. Returns
+/// [child] unchanged when there are no variables (no empty overlay).
+Widget wrapBodyWithVariableAutocomplete({
+  required LayeredVariableContext Function() contextProvider,
+  required Widget child,
+}) {
+  return CodeAutocomplete(
+    viewBuilder: variableAutocompleteViewBuilder,
+    promptsBuilder: VariablePromptsBuilder(contextProvider),
+    child: child,
+  );
+}
+```
+
+> **Note on `input`/`word`:** `CodeAutocompleteEditingValue.autocomplete` (lib) subtracts `editingValue.input.length` from the prompt result's selection offsets, and the editor deletes `[caret - input.length, caret]` before inserting `word`. Because we set `editingValue.input = query.query` and the prompt's `CodeAutocompleteResult.input = ''`, the net effect deletes exactly the typed query and inserts `word`, caret after it. Verify with the pumped test below; if the offset math needs a tweak, adjust the prompt's `selection` offset (this is the one place to validate against the running editor).
+
+Then wire it in:
+- In `request_editor_tabs.dart` `_RawBodyEditor`, wrap the `JsonCodeEditor` (the `CodeEditor`) with `wrapBodyWithVariableAutocomplete(contextProvider: ..., child: JsonCodeEditor(...))`. The Beautify button overlay in the `Stack` stays outside the wrap.
+- The `contextProvider` must read the **current** `LayeredVariableContext`. Provide it from `request_view.dart`/`BodyTabView` by wrapping the body subtree in `TabVariableContextBuilder` and capturing the latest context into a closure (e.g. store it in a field updated each build, and pass `() => _latestBodyVarContext`). Keep it a closure (not a captured snapshot) so env switches mid-edit take effect on the next keystroke.
+
+- [ ] **Step 4: Add a pumped-widget test that the overlay appears + inserts**
+
+```dart
+// In the same test file: pump a CodeEditor wrapped via
+// wrapBodyWithVariableAutocomplete(contextProvider: () => ctx, child: CodeEditor(controller: c)),
+// inside a MaterialApp with a brutalist theme and a real Overlay.
+// 1. focus the editor; set controller text to '{{ho' with caret at offset 4.
+//    (Use the controller API: c.text = '{{ho'; c.selection = CodeLineSelection.collapsed(index:0, offset:4);)
+// 2. pumpAndSettle; expect(find.text('host'), findsOneWidget).
+// 3. tap 'host'; pumpAndSettle; expect(c.text, '{{host}}').
+```
+
+> If driving the overlay purely via controller mutation doesn't trigger `show()` (it keys off keystroke-driven value changes), use `tester.enterText`-style input or send a key via `tester.sendKeyEvent` after positioning the caret. The pure-helper tests in Step 1 are the primary guarantee; this widget test is the integration check.
+
+- [ ] **Step 5: Run tests**
+
+Run: `fvm flutter test test/features/tabs/presentation/widgets/variable_code_autocomplete_test.dart`
+Expected: PASS.
+
+- [ ] **Step 6: Analyze + format + commit**
+
+```bash
+fvm flutter analyze
+fvm dart run custom_lint
+fvm dart format lib test
+git add lib/features/tabs/presentation/widgets/variable_code_autocomplete.dart lib/features/tabs/presentation/widgets/request_editor_tabs.dart lib/features/tabs/presentation/widgets/request_view.dart test/features/tabs/presentation/widgets/variable_code_autocomplete_test.dart
+git commit -m "feat(variables): {{var}} autocomplete in the request body editor"
+```
+
+---
+
+## Task 8: Body editor — `{{var}}` highlighting (flat-run merge)
+
+Color `{{var}}` tokens on top of JSON highlighting in the body editor by extending the span builder. The active variable map decides resolved (`variableResolved`) vs unresolved (`variableUnresolved`).
+
+**Files:**
+- Create: `lib/features/tabs/presentation/widgets/variable_json_span_builder.dart`
+- Modify: `lib/features/tabs/presentation/widgets/json_code_editor.dart` (use the new builder; pass a variables source)
+- Modify: `request_editor_tabs.dart`/`request_view.dart` to feed the body controller the current variable map
+- Test: `test/features/tabs/presentation/widgets/variable_json_span_builder_test.dart`
+
+**Interfaces:**
+- Consumes: existing `jsonHighlightSpanBuilder` (`json_code_editor.dart`), `EnvironmentResolver.findVariables` + `isDynamic`, `LayeredVariableContext`.
+- Produces:
+  - `TextSpan variableAwareJsonSpan({required BuildContext context, required int index, required CodeLine codeLine, required TextSpan textSpan, required TextStyle style, required Map<String,String> variables, required Color resolvedColor, required Color unresolvedColor})` — JSON-highlights the line, then recolors `{{var}}` ranges.
+  - `CodeLineEditingController createJsonCodeController({Map<String,String> Function()? variablesProvider, Color Function()? resolvedColor, Color Function()? unresolvedColor})` — extend the existing factory (keep the zero-arg call sites working via defaults).
+
+**Approach (flat-run merge):** Produce a flat list of styled runs for the line by walking the JSON-highlighted `TextSpan` into `(start, end, style)` segments, then overlay each `{{var}}` character range with the variable color (variable wins). Emit a flat `TextSpan(children: [...])`. This avoids editing a nested span tree.
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+// test/features/tabs/presentation/widgets/variable_json_span_builder_test.dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:re_editor/re_editor.dart';
+import 'package:getman/features/tabs/presentation/widgets/variable_json_span_builder.dart';
+
+void main() {
+  testWidgets('colors a {{var}} token inside a JSON string', (tester) async {
+    late TextSpan span;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) {
+            span = variableAwareJsonSpan(
+              context: context,
+              index: 0,
+              codeLine: const CodeLine('{"url": "{{host}}/v1"}'),
+              textSpan: const TextSpan(text: '{"url": "{{host}}/v1"}'),
+              style: const TextStyle(color: Colors.black),
+              variables: const {'host': 'example.com'},
+              resolvedColor: const Color(0xFF00FF00),
+              unresolvedColor: const Color(0xFFFF0000),
+            );
+            return const SizedBox();
+          },
+        ),
+      ),
+    );
+
+    // Flatten the span text and assert a child run carrying '{{host}}' uses the
+    // resolved color.
+    final resolvedRun = _findRun(span, '{{host}}');
+    expect(resolvedRun?.style?.color, const Color(0xFF00FF00));
+  });
+
+  testWidgets('a JSON line with no variables is unchanged vs base highlighter', (
+    tester,
+  ) async {
+    // Assert variableAwareJsonSpan with empty variables produces the same
+    // visible text as jsonHighlightSpanBuilder (no regression to JSON coloring).
+  });
+
+  testWidgets('unknown variable uses the unresolved color', (tester) async {
+    // {{nope}} with variables {} -> run colored unresolvedColor.
+  });
+}
+
+// Helper: depth-first search the span tree for the child whose text == needle.
+TextSpan? _findRun(InlineSpan span, String needle) {
+  // implement: walk span.children; return the TextSpan with .text == needle.
+  return null; // implementer fills in
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `fvm flutter test test/features/tabs/presentation/widgets/variable_json_span_builder_test.dart`
+Expected: FAIL — file/function do not exist.
+
+- [ ] **Step 3: Implement**
+
+```dart
+// lib/features/tabs/presentation/widgets/variable_json_span_builder.dart
+import 'package:flutter/material.dart';
+import 'package:getman/core/utils/environment_resolver.dart';
+import 'package:getman/features/tabs/presentation/widgets/json_code_editor.dart'
+    show jsonHighlightSpanBuilder;
+import 'package:re_editor/re_editor.dart';
+
+/// JSON-highlights [codeLine], then recolors every `{{var}}` token: resolved
+/// (in [variables] or a dynamic built-in) -> [resolvedColor], else
+/// [unresolvedColor]. Variable color wins inside `{{…}}`. Implemented as a flat
+/// run merge so it never mutates a nested span tree.
+TextSpan variableAwareJsonSpan({
+  required BuildContext context,
+  required int index,
+  required CodeLine codeLine,
+  required TextSpan textSpan,
+  required TextStyle style,
+  required Map<String, String> variables,
+  required Color resolvedColor,
+  required Color unresolvedColor,
+}) {
+  final base = jsonHighlightSpanBuilder(
+    context: context,
+    index: index,
+    codeLine: codeLine,
+    textSpan: textSpan,
+    style: style,
+  );
+  final text = codeLine.text;
+  final matches = EnvironmentResolver.findVariables(text).toList();
+  if (matches.isEmpty) return base;
+
+  // 1. Flatten `base` into runs: List of (start, end, style).
+  final runs = <({int start, int end, TextStyle style})>[];
+  var cursor = 0;
+  void visit(InlineSpan span, TextStyle inherited) {
+    if (span is TextSpan) {
+      final s = span.style == null ? inherited : inherited.merge(span.style);
+      final t = span.text;
+      if (t != null && t.isNotEmpty) {
+        runs.add((start: cursor, end: cursor + t.length, style: s));
+        cursor += t.length;
+      }
+      for (final child in span.children ?? const <InlineSpan>[]) {
+        visit(child, s);
+      }
+    }
+  }
+
+  visit(base, style);
+  if (cursor == 0) {
+    // base had no leaf text (shouldn't happen) — fall back to whole-line style.
+    runs.add((start: 0, end: text.length, style: style));
+  }
+
+  // 2. Build a per-character color override for variable ranges.
+  Color? overrideAt(int i) {
+    for (final m in matches) {
+      if (i >= m.start && i < m.end) {
+        final resolved =
+            variables.containsKey(m.name) || EnvironmentResolver.isDynamic(m.name);
+        return resolved ? resolvedColor : unresolvedColor;
+      }
+    }
+    return null;
+  }
+
+  // 3. Re-emit runs, splitting where the variable override changes the color.
+  final children = <InlineSpan>[];
+  for (final run in runs) {
+    var i = run.start;
+    while (i < run.end) {
+      final color = overrideAt(i);
+      var j = i + 1;
+      while (j < run.end && overrideAt(j) == color) {
+        j++;
+      }
+      final segStyle = color == null
+          ? run.style
+          : run.style.copyWith(color: color, fontWeight: FontWeight.w800);
+      children.add(TextSpan(text: text.substring(i, j), style: segStyle));
+      i = j;
+    }
+  }
+  return TextSpan(style: style, children: children);
+}
+```
+
+Then:
+- Extend `createJsonCodeController` in `json_code_editor.dart` to accept optional `variablesProvider`/`resolvedColor`/`unresolvedColor`; when provided, set the controller's `spanBuilder` to a closure calling `variableAwareJsonSpan(... variables: variablesProvider(), resolvedColor: resolvedColor(), ...)`. Keep the zero-arg form (no variable coloring) for non-body editors (response viewer).
+- In `request_view.dart`, build the body controller with the providers reading the current `LayeredVariableContext.allVariables` and `context.appPalette.variableResolved/Unresolved` (read at span-build time, so theme/env changes apply). After an env change, call `_bodyController.notifyListeners()`/force a repaint isn't needed — re_editor rebuilds visible-line spans on text change; to refresh on env change without a text edit, the `TabVariableContextBuilder` rebuild can re-create or `markNeedsBuild` the editor. Acceptable simplification: variable recolor refreshes on the next keystroke/scroll. Document this.
+
+> Avoid import cycles: `variable_json_span_builder.dart` imports `jsonHighlightSpanBuilder` from `json_code_editor.dart`; `json_code_editor.dart`'s extended factory imports `variable_json_span_builder.dart`. If that cycles, move `jsonHighlightSpanBuilder` into `variable_json_span_builder.dart` (or a shared `json_span.dart`) and have `json_code_editor.dart` import it. Resolve at implementation time; `fvm flutter analyze` will reveal a cycle.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `fvm flutter test test/features/tabs/presentation/widgets/variable_json_span_builder_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Analyze + format + commit**
+
+```bash
+fvm flutter analyze
+fvm dart run custom_lint
+fvm dart format lib test
+git add lib/features/tabs/presentation/widgets/variable_json_span_builder.dart lib/features/tabs/presentation/widgets/json_code_editor.dart lib/features/tabs/presentation/widgets/request_view.dart lib/features/tabs/presentation/widgets/request_editor_tabs.dart test/features/tabs/presentation/widgets/variable_json_span_builder_test.dart
+git commit -m "feat(variables): highlight {{var}} tokens in the body editor"
+```
+
+---
+
+## Task 9: Body editor — hover preview ⚠️ (spike-gated)
+
+Add the hover popover over the body editor's `{{var}}` tokens. **This is the flagged risk.** Spike feasibility first; if it requires forking `re_editor` internals, stop and deliver autocomplete + highlight only (Tasks 7–8), and record the deferral.
+
+**Files:**
+- Modify: `lib/features/tabs/presentation/widgets/request_editor_tabs.dart` / `request_view.dart` (the body subtree)
+- Possibly create: `lib/features/tabs/presentation/widgets/body_variable_hover.dart`
+- Test: `test/features/tabs/presentation/widgets/body_variable_hover_test.dart` (only if feasible)
+
+- [ ] **Step 1: Spike — can a pointer position map to a text offset?**
+
+Investigate `re_editor 0.9.0` for a public API mapping a global/local pointer position to a `CodeLineSelection`/offset (the inverse of `calculateTextPositionScreenOffset`). Check `CodeLineEditingController`, the `CodeEditor` render object, and any exposed `selectionAt`/`positionAt`. Write a throwaway widget that, on `MouseRegion.onHover`, prints the mapped offset. Time-box to ~30 min.
+
+Decision gate:
+- **Feasible** (a usable position→offset exists, or token rects are derivable) → proceed to Step 2.
+- **Not feasible without forking** → skip Steps 2-4. Update the spec + wiki note + PR description to state body hover is deferred (autocomplete + highlight shipped). Commit the docs change. Done with this task.
+
+- [ ] **Step 2: Write the failing test (if feasible)**
+
+```dart
+// Pump the body editor with text '{{host}}' and variables {host: example.com}.
+// Simulate a hover over the {{host}} token's screen rect.
+// Expect a VariableHoverPopover (find by type) to appear showing 'example.com'.
+```
+
+- [ ] **Step 3: Implement (if feasible)**
+
+Wrap the editor in a `MouseRegion`; on hover, map the pointer to a line+offset, find the `{{var}}` token (`EnvironmentResolver.findVariables` on that line) containing it, and drive a `VariableHoverController.showFor(context, ctx.classify(name), event.position)`. On exit / off-token, `scheduleHide()`.
+
+- [ ] **Step 4: Run + analyze + format + commit (if feasible)**
+
+```bash
+fvm flutter test test/features/tabs/presentation/widgets/body_variable_hover_test.dart
+fvm flutter analyze
+fvm dart format lib test
+git add -A
+git commit -m "feat(variables): hover preview for {{var}} in the body editor"
+```
+
+---
+
+## Task 10: Wiki sync + full done-bar
+
+**Files:**
+- The separate `Getman.wiki.git` repo (clone `https://github.com/thiagomiranda3/Getman.wiki.git`), the variables page.
+- No app code (verification only).
+
+- [ ] **Step 1: Run the full verification stack**
+
+```bash
+fvm flutter analyze
+fvm dart run custom_lint
+fvm dart run bloc_tools:bloc lint lib
+fvm dart format lib test tools
+fvm flutter test
+```
+Expected: 0 issues from each analysis pass, format clean, all tests green. Fix anything that isn't.
+
+- [ ] **Step 2: Update the wiki**
+
+Clone the wiki repo, edit the variables page to state that `{{var}}` **autocomplete and highlighting** now apply to the **request body (raw/JSON), auth fields, and form-data values** — not just URL/params/headers — and that suggestions include **collection-scoped and dynamic** variables in every field. Add **hover preview** to the list of body capabilities **only if Task 9 shipped** (otherwise state hover applies to URL/params/headers/auth/form-data). Use verbatim UI labels. Commit + push to `master`.
+
+```bash
+# in the wiki clone
+git add Variables.md _Sidebar.md
+git commit -m "docs: variable autocomplete now covers body, auth & form-data"
+git push origin master
+```
+
+- [ ] **Step 3: Final app-repo commit (if any verification fixes were made)**
+
+```bash
+git add -A
+git commit -m "chore(variables): verification fixes for body/auth/form-data autocomplete"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Auth autocomplete+highlight+hover → Task 5 (atom from Task 3 bundles all three). ✓
+- Form-data autocomplete+highlight+hover → Task 6. ✓
+- Body autocomplete → Task 7. ✓
+- Body highlighting → Task 8. ✓
+- Body hover (risk + fallback) → Task 9, spike-gated, fallback documented. ✓
+- Env + collection + dynamic everywhere; align params/headers → Tasks 1, 2, 4. ✓
+- Shared `VariableTextField` atom + shared context builder → Tasks 2, 3. ✓
+- Testing per field → each task's tests. ✓
+- Wiki sync → Task 10. ✓
+- No new blocs/events/persistence; presentation/util only → honored throughout. ✓
+
+**Placeholder scan:** Test bodies for the bloc-harness-dependent widget tests (Tasks 2, 5, 6) intentionally reference "reuse the existing harness" because the exact fake/provider setup must match the current test tree, which the implementer reads at execution time — the assertions and arrange steps are concrete. The body-editor tests note one offset-math validation point (Task 7) flagged for live verification. No "TBD"/"add error handling"/"similar to Task N" placeholders.
+
+**Type consistency:** `LayeredVariableContext` (Task 1) — `allVariables`, `allSecretKeys`, `classify`, `isEmpty`, `empty` — used consistently in Tasks 2-8. `VariableTextField(variables:, controller:, focusNode:, onChanged:, decoration:, obscureText:, fieldKey:)` consistent in Tasks 3, 5, 6. `variablePromptsFor` / `variableInsertionWord` / `VariablePromptsBuilder` / `wrapBodyWithVariableAutocomplete` consistent across Task 7 impl + tests. `variableAwareJsonSpan` signature consistent in Task 8 impl + test + the `createJsonCodeController` extension.

--- a/docs/superpowers/specs/2026-06-19-variable-autocomplete-body-auth-formdata-design.md
+++ b/docs/superpowers/specs/2026-06-19-variable-autocomplete-body-auth-formdata-design.md
@@ -1,0 +1,254 @@
+# Variable autocomplete + highlight + hover for body, auth & form-data
+
+**Date:** 2026-06-19
+**Status:** Approved design, pending implementation plan
+**Extends:** `2026-06-17-variable-autocomplete-design.md` (original URL/params/headers work)
+
+## Goal
+
+Bring the full URL-bar variable experience to every place a user can type a
+`{{var}}`:
+
+- **`{{`-triggered autocomplete dropdown**
+- **`{{var}}` color highlighting** (resolved vs. unresolved)
+- **hover preview popover** (variable value / source / secret masking)
+
+Target fields that currently lack it:
+
+1. **Auth** — bearer token, basic auth username/password, API-key name/value
+2. **Form-data values** — multipart & urlencoded value fields
+3. **Raw / JSON body** — the `re_editor` code editor
+
+Variable source set, applied **everywhere** (including aligning the existing
+params/headers fields): **active environment vars → inherited collection
+folder vars → dynamic built-ins** (`$guid`, `$timestamp`, …), matching what the
+URL bar already does.
+
+## Non-goals
+
+- Highlighting/autocomplete on **keys** (param/header/form-data names, auth
+  field labels) — only values, matching current behavior and send-time
+  resolution scope.
+- Resolving variables anywhere new at send time — resolution plumbing is
+  unchanged; this is purely an editing-UX feature.
+
+## Existing building blocks (reused, not rebuilt)
+
+| Piece | Location | Role |
+|---|---|---|
+| `VariableAutocomplete` | `lib/core/ui/widgets/variable_autocomplete.dart` | Overlay + `{{` trigger over a `TextEditingController` |
+| `VariableHighlightController` | `lib/core/ui/widgets/variable_highlight_controller.dart` | `TextEditingController` subclass: colors `{{var}}`, fires `onVariableEnter/Exit` |
+| `VariableHoverController` / `VariableHoverContext` | `lib/core/ui/widgets/variable_hover_popover.dart` | Hover popover overlay + its data |
+| `buildVariableSuggestions` | `lib/core/utils/variable_suggestions.dart` | Filter + rank suggestions |
+| `detectActiveVariableQuery` | `lib/core/utils/variable_autocomplete_query.dart` | `{{`-query detection at a caret offset |
+| `VariableResolutionHelper.classify(Layered)` | `lib/core/utils/variable_resolution_helper.dart` | Resolve a name → value/kind/source |
+| layered context logic | `_layeredContext` in `url_bar.dart` | env + collection vars for a tab |
+
+## Architecture
+
+### Component 1 — `VariableTextField` atom
+
+**New:** `lib/core/ui/widgets/variable_text_field.dart`.
+
+Bundles the wiring currently inlined inside `KeyValueListEditor` (lines ~181–206
++ 352–360) into one reusable widget:
+
+- owns a `VariableHighlightController` (seeded from `initialValue`/an external
+  controller),
+- pushes theme colors (`appPalette.variableResolved/Unresolved`) and the active
+  variable map in `didChangeDependencies` (diffed — only notifies on real
+  change, per the existing controller contract),
+- wires `onVariableEnter/Exit` to a `VariableHoverController`,
+- wraps its `TextField` in `VariableAutocomplete` with a `suggestionsFor`
+  closure built from the context's variables.
+
+**Props:** `VariableHoverContext context`, `TextEditingController controller`
+(caller-owned, so existing echo-suppression keeps working), `FocusNode?`,
+`ValueChanged<String> onChanged`, `bool obscure`, `String? hintText`, key knobs.
+When `context.variables` is empty it degrades to a plain styled field (no
+overlay, no highlight) — same as a null context today.
+
+**Adoption:** auth fields and form-data value fields use it directly.
+`KeyValueListEditor`'s value field is refactored to use it too, deleting the
+duplicated inline wiring (one behavior, one place). Param/header **name** fields
+and form-data file rows are untouched.
+
+> Note: `VariableTextField` must accept a **caller-owned controller** (not just
+> an initial string) because auth/form-data/kv all rely on holding their own
+> controllers for echo-suppression across the bloc round-trip. The atom adds
+> highlight/hover/autocomplete *around* that controller; it does not own value
+> lifecycle. The controller it's handed must be a `VariableHighlightController`
+> (the atom upgrades/asserts this) so `buildTextSpan` highlighting works.
+
+### Component 2 — shared tab-scoped layered context
+
+**Promote** the env-only `_VariableContextBuilder`
+(`request_editor_tabs.dart:40`) into a shared, **layered**
+`TabVariableContextBuilder` (new file in `lib/core/ui/widgets/` or a
+tabs-presentation shared file).
+
+It computes the same context the URL bar's `_layeredContext` does — active
+environment vars merged over the tab's inherited collection folder vars (env
+wins), plus the env name + merged secret keys — and rebuilds on env-set /
+active-env-id / collection-tree changes. It needs the tab's linked collection
+node id, so it takes the `tabId` (or reads `TabsBloc` for it) like the URL bar.
+
+`VariableHoverContext` gains nothing new structurally (it already carries
+`variables` + `secretKeys` + `environmentName`); the change is **what fills it**
+(layered, not env-only). All five consumers — params, headers, auth, form-data,
+body — read from this one builder, so suggestions are identical everywhere.
+
+> This intentionally changes params/headers behavior: they currently suggest
+> env-only and will now also suggest collection vars + dynamics. That is the
+> "align params/headers" decision, approved.
+
+### Component 3 — Auth integration
+
+`auth_tab_view.dart`: wrap the field column in `TabVariableContextBuilder` and
+replace `_field(...)`'s inner `TextField` with `VariableTextField` (passing the
+context, the existing per-field controller, the `obscure` flag for
+password/api-key value). Echo-suppression (`_lastEmitted`, `_setIfChanged`) is
+unchanged. `inherit`/`none` auth types render no fields → no context needed.
+
+### Component 4 — Form-data integration
+
+`form_data_editor.dart`: wrap in `TabVariableContextBuilder`; the value
+`TextField` (line ~175, non-file rows only) becomes a `VariableTextField` using
+the row's `valueController`. File rows and the name field are unchanged. `_emit`
+flow unchanged.
+
+### Component 5 — Body autocomplete (`CodeAutocomplete`)
+
+`re_editor 0.9.0` ships `CodeAutocomplete` (verified against the installed lib
+source). Wrap the body `CodeEditor` (in `json_code_editor.dart` /
+`request_view.dart`'s `_RawBodyEditor`) with it.
+
+- **`VariablePromptsBuilder implements CodeAutocompletePromptsBuilder`** (new):
+  `build(context, codeLine, selection)` runs our existing
+  `detectActiveVariableQuery(codeLine.text, selection.extentOffset)`. On a hit
+  it returns a `CodeAutocompleteEditingValue` with `input = query` and
+  `prompts` built from `buildVariableSuggestions(...)`. Each suggestion becomes
+  a small `CodePrompt` subclass whose `.autocomplete` yields a
+  `CodeAutocompleteResult` of `word = name` (+ `}}` when
+  `!hasClosingBraces`) and a collapsed selection at `word.length`.
+  - re_editor's apply path deletes `[caret - input.length, caret]` and inserts
+    `word`, leaving the `{{` intact and placing the caret after the inserted
+    text — replicating `VariableAutocomplete._acceptAt`'s `}}` logic.
+  - `build` is invoked on every line-changing keystroke (verified:
+    `_updateAutoCompleteState` → `show` in `_code_editable.dart`), so the menu
+    appears right after `{{`, exactly like the URL bar.
+- **`viewBuilder`** (new `PreferredSizeWidget`): renders the same
+  name + source-badge + resolved-preview rows as `VariableAutocomplete._row`,
+  themed via `context.app*`. Keyboard nav (↑/↓ + Enter) is handled by the
+  package's actions; **Tab-to-accept is not wired by re_editor** (minor
+  divergence from the `TextField` overlay — acceptable, noted).
+
+Feed the body controller the active variable map (needed by Component 6) — the
+controller stays the same `CodeLineEditingController` from
+`createJsonCodeController()`, just configured with a variable-aware span builder.
+
+### Component 6 — Body highlighting (flat-run merge)
+
+Extend the body's span building so `{{var}}` tokens are colored on top of JSON
+highlighting:
+
+- Produce JSON token runs for the line (today: `jsonHighlightSpanBuilder` via
+  `re_highlight`'s `TextSpanRenderer`).
+- Find `{{var}}` ranges in the line (`EnvironmentResolver.findVariables` /
+  `detectActiveVariableQuery`'s pattern) and **override** the color of those
+  character ranges with `variableResolved` / `variableUnresolved` (decided by
+  classifying the name against the active variable map). Variable color wins
+  inside `{{…}}`.
+- Implementation approach: render JSON into a **flat run list** `(start, end,
+  style)` instead of (or in addition to) the nested `TextSpan`, overlay the
+  variable ranges, then emit a flat `TextSpan` with children. This avoids
+  surgery on a nested span tree. Lines that don't parse as JSON still get
+  variable coloring over the base style.
+- The active variable map reaches this builder via the tab context (the
+  span builder is rebuilt / closes over the current map; on env change the
+  editor re-highlights visible lines).
+
+`createJsonCodeController()` gains an optional variables source (or a setter the
+body widget updates on context change). **Do not reinstate `codeTheme`** — the
+gotcha in CLAUDE.md still holds; coloring stays in the span builder.
+
+### Component 7 — Body hover ⚠️ (highest risk)
+
+`re_editor` paints lines through a custom render object, so Flutter's
+`TextSpan.onEnter/onExit` hover callbacks are not expected to fire (unlike the
+`RenderParagraph`-backed `TextField`). Plan:
+
+- Wrap the editor in a `MouseRegion`. On hover, map the pointer's global
+  position → a text offset using the editor's render object / public position
+  API, test whether that offset falls inside a `{{var}}` token on that line,
+  and drive the existing `VariableHoverController` to show the popover anchored
+  at the pointer.
+
+**Risk & fallback:** this depends on `re_editor` exposing a usable
+position↔offset mapping without forking internals (`_CodeFieldRender` has
+`calculateTextPositionScreenOffset` for offset→screen; the inverse used by
+selection/tap may not be public). The implementation plan will spike this
+first. **If it requires forking re_editor**, the fallback is to ship body
+**autocomplete + highlight** now and track body **hover** as a follow-up —
+auth, form-data, params, headers, and URL all retain full hover regardless.
+This is the one place the delivered scope may narrow; it will be surfaced
+during the plan's spike, not silently dropped.
+
+## Data flow
+
+```
+EnvironmentsBloc + SettingsBloc + CollectionsBloc/TabsBloc
+        │  (active env id, env vars, collection tree, linked node id)
+        ▼
+TabVariableContextBuilder  ──►  VariableHoverContext { variables, secretKeys, environmentName }
+        │
+        ├─► VariableTextField (auth fields, form-data values, kv values)
+        │        └─ VariableHighlightController + VariableAutocomplete + VariableHoverController
+        │
+        └─► Body editor
+                 ├─ VariablePromptsBuilder + viewBuilder  (autocomplete)
+                 ├─ variable-aware span builder           (highlight)
+                 └─ MouseRegion + VariableHoverController  (hover, risk-gated)
+```
+
+No new blocs, events, or persisted state. No domain/data changes. Pure
+presentation-layer wiring over existing utilities.
+
+## Testing
+
+Widget tests, mirroring existing URL-bar/params autocomplete tests:
+
+- **`VariableTextField`** (atom): `{{` opens menu; typing filters; Enter/Tap
+  inserts `{{name}}` and positions the caret; existing-`}}` case inserts just
+  the name; highlight colors resolved vs. unresolved; hover shows the popover
+  (incl. secret masking); empty context → plain field, no overlay.
+- **Auth**: each field type (token / user / pass / api-key name / value)
+  autocompletes; password stays obscured while autocompleting.
+- **Form-data**: value field autocompletes; file rows / name field do not.
+- **Body**: `{{` opens the `CodeAutocomplete` menu; accept inserts `{{name}}`
+  with correct caret; non-`{{` typing shows nothing; highlight colors a
+  `{{var}}` inside a JSON string; (hover test gated on Component 6/7 outcome).
+- **Context**: params/headers/auth/form-data/body all surface env + collection
+  + dynamic names from one `TabVariableContextBuilder`.
+
+Full done-bar before claiming complete: `fvm flutter analyze`,
+`fvm dart run custom_lint`, `fvm dart run bloc_tools:bloc lint lib`,
+`fvm dart format` clean, `fvm flutter test` green.
+
+## Wiki sync
+
+Update the variables page (`Getman.wiki.git`) to state that `{{var}}`
+autocomplete, highlighting, and hover preview now apply to **request body
+(raw/JSON), auth fields, and form-data values** — not just URL/params/headers —
+and that suggestions include collection-scoped and dynamic variables in every
+field. (Body hover wording conditional on Component 7 outcome.)
+
+## Risks summary
+
+1. **Body hover (Component 7)** — may require re_editor internals; fallback is
+   defer hover-on-body only. *Spike first in the plan.*
+2. **Body highlight merge (Component 6)** — flat-run merge must not regress
+   existing JSON coloring; covered by a "JSON line with no vars renders
+   identically" test.
+3. **params/headers behavior change** — they gain collection + dynamic
+   suggestions; intended, but call it out in the PR/wiki.

--- a/docs/superpowers/specs/2026-06-19-variable-autocomplete-body-auth-formdata-design.md
+++ b/docs/superpowers/specs/2026-06-19-variable-autocomplete-body-auth-formdata-design.md
@@ -172,7 +172,20 @@ highlighting:
 body widget updates on context change). **Do not reinstate `codeTheme`** — the
 gotcha in CLAUDE.md still holds; coloring stays in the span builder.
 
-### Component 7 — Body hover ⚠️ (highest risk)
+### Component 7 — Body hover ⚠️ (highest risk) — DEFERRED (spike result, 2026-06-20)
+
+> **RESOLUTION:** The Task 9 spike confirmed body hover is **not feasible in
+> `re_editor 0.9.0` without forking the package**, so it is **deferred** per the
+> fallback below. Evidence: the editor's render object is `_CodeFieldRender`
+> (private), reached via a private `editorKey`; the position-from-offset method
+> (`CodeLineRenderParagraph.getPosition(Offset)`) lives on private
+> line/paragraph internals; the public `CodeLineEditingController` exposes no
+> position↔offset API and `CodeEditor` exposes no hover/position callback. The
+> `TextSpan.onEnter/onExit` route also fails because re_editor paints with a
+> custom render object (not `RenderParagraph`), so span hover callbacks never
+> fire. **Delivered:** body autocomplete + highlighting. **Not delivered:**
+> body hover (URL, params, headers, auth, form-data retain full hover). Revisit
+> if/when re_editor exposes a public position API or a fork is justified.
 
 `re_editor` paints lines through a custom render object, so Flutter's
 `TextSpan.onEnter/onExit` hover callbacks are not expected to fire (unlike the

--- a/lib/core/ui/widgets/key_value_list_editor.dart
+++ b/lib/core/ui/widgets/key_value_list_editor.dart
@@ -1,11 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:getman/core/theme/app_theme.dart';
 import 'package:getman/core/theme/responsive.dart';
-import 'package:getman/core/ui/widgets/variable_autocomplete.dart';
 import 'package:getman/core/ui/widgets/variable_highlight_controller.dart';
-import 'package:getman/core/ui/widgets/variable_hover_popover.dart';
-import 'package:getman/core/utils/variable_resolution_helper.dart';
-import 'package:getman/core/utils/variable_suggestions.dart';
+import 'package:getman/core/ui/widgets/variable_text_field.dart';
+import 'package:getman/core/utils/layered_variable_context.dart';
 
 /// Generic editable key/value row list backing the params, headers, and
 /// environment-variable editors. The canonical value type [T] (ordered list,
@@ -46,12 +44,13 @@ class KeyValueListEditor<T extends Object> extends StatefulWidget {
   /// Called with the new secret-key set when a row's lock is toggled.
   final ValueChanged<Set<String>>? onSecretKeysChanged;
 
-  /// When non-null, value fields highlight `{{var}}` tokens and show a hover
-  /// popover resolving them against the active environment. Params and headers
+  /// When non-null, value fields highlight `{{var}}` tokens, show a hover
+  /// popover resolving them, and offer autocomplete suggestions from the
+  /// layered (env + collection + dynamic) variable context. Params and headers
   /// pass a context (highlighting enabled); the env editor and other consumers
   /// pass null, leaving value fields as plain text. Note: this is unrelated to
   /// [secretKeys], which toggles per-row secret obscuring in the env editor.
-  final VariableHoverContext? variableContext;
+  final LayeredVariableContext? variableContext;
 
   /// When set, each row's key/value [TextField] gets a stable
   /// `ValueKey('<prefix>_key_<index>')` / `ValueKey('<prefix>_val_<index>')` so
@@ -68,8 +67,6 @@ class _KeyValueListEditorState<T extends Object>
   late List<TextEditingController> _keyControllers;
   late List<TextEditingController> _valControllers;
   T? _lastEmitted;
-
-  final VariableHoverController _hoverController = VariableHoverController();
 
   @override
   void initState() {
@@ -98,19 +95,6 @@ class _KeyValueListEditorState<T extends Object>
     _valControllers.add(_newValueController(''));
   }
 
-  void _showVariablePopover(BuildContext context, String name, Offset pos) {
-    if (!mounted) return;
-    final varContext = widget.variableContext;
-    if (varContext == null) return;
-    final data = VariableResolutionHelper.classify(
-      name: name,
-      variables: varContext.variables,
-      secretKeys: varContext.secretKeys,
-      environmentName: varContext.environmentName,
-    );
-    _hoverController.showFor(context, data, pos);
-  }
-
   @override
   void didUpdateWidget(KeyValueListEditor<T> oldWidget) {
     super.didUpdateWidget(oldWidget);
@@ -137,7 +121,6 @@ class _KeyValueListEditorState<T extends Object>
 
   @override
   void dispose() {
-    _hoverController.dispose();
     _disposeControllers();
     super.dispose();
   }
@@ -175,37 +158,6 @@ class _KeyValueListEditorState<T extends Object>
         // mis-flag a key with surrounding whitespace.
         final keyText = _keyControllers[index].text.trim();
 
-        final varContext = widget.variableContext;
-        final valController = _valControllers[index];
-        VariableSuggestionsProvider? valueSuggestionsFor;
-        if (varContext != null &&
-            valController is VariableHighlightController) {
-          final palette = context.appPalette;
-          // Block syntax for onVariableEnter prevents the arrow-function body
-          // from greedily capturing the following cascade item as part of its
-          // return expression, which would trigger use_of_void_result.
-          valController
-            ..onVariableEnter = (name, pos) {
-              _showVariablePopover(context, name, pos);
-            }
-            ..onVariableExit = _hoverController.scheduleHide
-            ..updateColors(
-              resolved: palette.variableResolved,
-              unresolved: palette.variableUnresolved,
-            )
-            ..updateVariables(varContext.variables);
-          valueSuggestionsFor = (query) => buildVariableSuggestions(
-            query: query,
-            userVariableNames: varContext.variables.keys,
-            classify: (name) => VariableResolutionHelper.classify(
-              name: name,
-              variables: varContext.variables,
-              secretKeys: varContext.secretKeys,
-              environmentName: varContext.environmentName,
-            ),
-          );
-        }
-
         return _KeyValueRow(
           key: ValueKey(_keyControllers[index]),
           rowIndex: index,
@@ -219,7 +171,7 @@ class _KeyValueListEditorState<T extends Object>
               keyText.isNotEmpty &&
               secrets.contains(keyText),
           onToggleSecret: secrets == null ? null : () => _toggleSecret(index),
-          valueSuggestionsFor: valueSuggestionsFor,
+          variableContext: widget.variableContext,
           onKeyChanged: (val) {
             if (index == _keyControllers.length - 1 && val.isNotEmpty) {
               setState(_addEmptyRow);
@@ -257,7 +209,7 @@ class _KeyValueRow extends StatefulWidget {
     this.showSecretToggle = false,
     this.isSecret = false,
     this.onToggleSecret,
-    this.valueSuggestionsFor,
+    this.variableContext,
   });
   final int rowIndex;
   final String? fieldPrefix;
@@ -270,7 +222,7 @@ class _KeyValueRow extends StatefulWidget {
   final bool showSecretToggle;
   final bool isSecret;
   final VoidCallback? onToggleSecret;
-  final VariableSuggestionsProvider? valueSuggestionsFor;
+  final LayeredVariableContext? variableContext;
 
   @override
   State<_KeyValueRow> createState() => _KeyValueRowState();
@@ -320,44 +272,59 @@ class _KeyValueRowState extends State<_KeyValueRow> {
       enableSuggestions: false,
       onChanged: widget.onKeyChanged,
     );
-    final valueField = TextField(
-      key: widget.fieldPrefix == null
-          ? null
-          : ValueKey('${widget.fieldPrefix}_val_${widget.rowIndex}'),
-      style: textStyle,
-      focusNode: _valueFocusNode,
-      obscureText: widget.isSecret && !_revealed,
-      decoration: InputDecoration(
-        hintText: 'VALUE',
-        isDense: true,
-        contentPadding: fieldPadding,
-        // Reveal toggle lives in the field so the row layout is unchanged.
-        suffixIcon: widget.isSecret
-            ? IconButton(
-                visualDensity: VisualDensity.compact,
-                icon: Icon(
-                  _revealed ? Icons.visibility_off : Icons.visibility,
-                  size: widget.layout.isCompact ? 18 : 20,
-                ),
-                tooltip: _revealed ? 'Hide value' : 'Reveal value',
-                onPressed: () => setState(() => _revealed = !_revealed),
-              )
-            : null,
-      ),
-      controller: widget.valController,
-      autocorrect: false,
-      enableSuggestions: false,
-      onChanged: widget.onValChanged,
+
+    // Build the value field decoration once so both the plain path and the
+    // VariableTextField path share the exact same decoration.
+    final valueDecoration = InputDecoration(
+      hintText: 'VALUE',
+      isDense: true,
+      contentPadding: fieldPadding,
+      // Reveal toggle lives in the field so the row layout is unchanged.
+      suffixIcon: widget.isSecret
+          ? IconButton(
+              visualDensity: VisualDensity.compact,
+              icon: Icon(
+                _revealed ? Icons.visibility_off : Icons.visibility,
+                size: widget.layout.isCompact ? 18 : 20,
+              ),
+              tooltip: _revealed ? 'Hide value' : 'Reveal value',
+              onPressed: () => setState(() => _revealed = !_revealed),
+            )
+          : null,
     );
-    final valueFieldWithAutocomplete = widget.valueSuggestionsFor == null
-        ? valueField
-        : VariableAutocomplete(
-            controller: widget.valController,
+
+    final ctx = widget.variableContext;
+    final valController = widget.valController;
+
+    // Use VariableTextField when the context is non-null and the controller
+    // is a VariableHighlightController. Secret rows pass a null context (the
+    // env editor), so the two paths never combine.
+    final Widget valueFieldWithAutocomplete =
+        (ctx == null || valController is! VariableHighlightController)
+        ? TextField(
+            key: widget.fieldPrefix == null
+                ? null
+                : ValueKey('${widget.fieldPrefix}_val_${widget.rowIndex}'),
+            style: textStyle,
             focusNode: _valueFocusNode,
-            suggestionsFor: widget.valueSuggestionsFor!,
-            onAccepted: widget.onValChanged,
-            child: valueField,
+            obscureText: widget.isSecret && !_revealed,
+            decoration: valueDecoration,
+            controller: valController,
+            autocorrect: false,
+            enableSuggestions: false,
+            onChanged: widget.onValChanged,
+          )
+        : VariableTextField(
+            fieldKey: widget.fieldPrefix == null
+                ? null
+                : ValueKey('${widget.fieldPrefix}_val_${widget.rowIndex}'),
+            variables: ctx,
+            controller: valController,
+            focusNode: _valueFocusNode,
+            onChanged: widget.onValChanged,
+            decoration: valueDecoration,
           );
+
     final secretButton = widget.showSecretToggle
         ? context.appDecoration.wrapInteractive(
             child: IconButton(

--- a/lib/core/ui/widgets/key_value_list_editor.dart
+++ b/lib/core/ui/widgets/key_value_list_editor.dart
@@ -323,6 +323,7 @@ class _KeyValueRowState extends State<_KeyValueRow> {
             focusNode: _valueFocusNode,
             onChanged: widget.onValChanged,
             decoration: valueDecoration,
+            style: textStyle,
           );
 
     final secretButton = widget.showSecretToggle

--- a/lib/core/ui/widgets/tab_variable_context_builder.dart
+++ b/lib/core/ui/widgets/tab_variable_context_builder.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:getman/core/utils/layered_variable_context.dart';
+import 'package:getman/features/collections/domain/logic/collections_tree_helper.dart';
+import 'package:getman/features/collections/presentation/bloc/collections_bloc.dart';
+import 'package:getman/features/collections/presentation/bloc/collections_state.dart';
+import 'package:getman/features/environments/domain/logic/active_environment_helper.dart';
+import 'package:getman/features/environments/presentation/bloc/environments_bloc.dart';
+import 'package:getman/features/environments/presentation/bloc/environments_state.dart';
+import 'package:getman/features/settings/presentation/bloc/settings_bloc.dart';
+import 'package:getman/features/settings/presentation/bloc/settings_state.dart';
+import 'package:getman/features/tabs/domain/entities/request_tab_entity.dart';
+import 'package:getman/features/tabs/presentation/bloc/tabs_bloc.dart';
+import 'package:getman/features/tabs/presentation/bloc/tabs_state.dart';
+
+/// Builds the layered (environment + collection + dynamic) variable context
+/// for [tabId] from live bloc state, rebuilding when the active environment,
+/// the environment set, the collection tree, or the tab's linked node change.
+/// Shared by params, headers, auth, form-data, and the body editor so every
+/// field offers identical suggestions.
+class TabVariableContextBuilder extends StatelessWidget {
+  const TabVariableContextBuilder({
+    required this.tabId,
+    required this.builder,
+    super.key,
+  });
+
+  final String tabId;
+  final Widget Function(BuildContext, LayeredVariableContext) builder;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<SettingsBloc, SettingsState>(
+      buildWhen: (p, n) =>
+          p.settings.activeEnvironmentId != n.settings.activeEnvironmentId,
+      builder: (context, settingsState) {
+        return BlocBuilder<EnvironmentsBloc, EnvironmentsState>(
+          buildWhen: (p, n) => p.environments != n.environments,
+          builder: (context, envState) {
+            return BlocBuilder<TabsBloc, TabsState>(
+              buildWhen: (p, n) =>
+                  p.tabs.byId(tabId)?.collectionNodeId !=
+                  n.tabs.byId(tabId)?.collectionNodeId,
+              builder: (context, tabsState) {
+                return BlocBuilder<CollectionsBloc, CollectionsState>(
+                  buildWhen: (p, n) => p.collections != n.collections,
+                  builder: (context, collectionsState) {
+                    final env = ActiveEnvironmentHelper.activeEnvironment(
+                      envState.environments,
+                      settingsState.settings.activeEnvironmentId,
+                    );
+                    final nodeId = tabsState.tabs.byId(tabId)?.collectionNodeId;
+                    final collected = nodeId == null
+                        ? (
+                            variables: const <String, String>{},
+                            secretKeys: const <String>{},
+                          )
+                        : CollectionsTreeHelper.collectVariables(
+                            collectionsState.collections,
+                            nodeId,
+                          );
+                    return builder(
+                      context,
+                      LayeredVariableContext(
+                        environmentVariables: env?.variables ?? const {},
+                        environmentSecrets: env?.secretKeys ?? const {},
+                        collectionVariables: collected.variables,
+                        collectionSecrets: collected.secretKeys,
+                        environmentName: env?.name,
+                      ),
+                    );
+                  },
+                );
+              },
+            );
+          },
+        );
+      },
+    );
+  }
+}

--- a/lib/core/ui/widgets/variable_hover_popover.dart
+++ b/lib/core/ui/widgets/variable_hover_popover.dart
@@ -1,30 +1,8 @@
 import 'dart:async';
 
-import 'package:equatable/equatable.dart';
 import 'package:flutter/material.dart';
 import 'package:getman/core/theme/app_theme.dart';
 import 'package:getman/core/utils/variable_resolution_helper.dart';
-
-/// Active-environment data passed into a value field (or the URL bar) to enable
-/// `{{var}}` highlighting + hover resolution. Null disables the feature.
-class VariableHoverContext extends Equatable {
-  const VariableHoverContext({
-    this.variables = const {},
-    this.secretKeys = const {},
-    this.environmentName,
-  });
-
-  final Map<String, String> variables;
-
-  /// Names flagged secret in the active environment — masked in the popover.
-  final Set<String> secretKeys;
-
-  /// Active environment display name; null when no environment is active.
-  final String? environmentName;
-
-  @override
-  List<Object?> get props => [variables, secretKeys, environmentName];
-}
 
 /// The hover card. Not a stock Tooltip — secrets need an interactive reveal
 /// toggle and the card must stay open while the pointer is over it.

--- a/lib/core/ui/widgets/variable_text_field.dart
+++ b/lib/core/ui/widgets/variable_text_field.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'package:getman/core/theme/app_theme.dart';
+import 'package:getman/core/ui/widgets/variable_autocomplete.dart';
+import 'package:getman/core/ui/widgets/variable_highlight_controller.dart';
+import 'package:getman/core/ui/widgets/variable_hover_popover.dart';
+import 'package:getman/core/utils/layered_variable_context.dart';
+import 'package:getman/core/utils/variable_suggestions.dart';
+
+/// A [TextField] that highlights `{{var}}` tokens, offers a `{{`-triggered
+/// autocomplete overlay, and shows a hover popover resolving each token —
+/// given a [variables] context and a caller-owned [VariableHighlightController]
+/// (kept by the owner so its echo-suppression survives the bloc round-trip).
+/// When [variables] is empty it degrades to a plain styled field.
+class VariableTextField extends StatefulWidget {
+  const VariableTextField({
+    required this.variables,
+    required this.controller,
+    required this.focusNode,
+    required this.onChanged,
+    this.decoration,
+    this.obscureText = false,
+    this.fieldKey,
+    super.key,
+  });
+
+  final LayeredVariableContext variables;
+  final VariableHighlightController controller;
+  final FocusNode focusNode;
+  final ValueChanged<String> onChanged;
+  final InputDecoration? decoration;
+  final bool obscureText;
+  final Key? fieldKey;
+
+  @override
+  State<VariableTextField> createState() => _VariableTextFieldState();
+}
+
+class _VariableTextFieldState extends State<VariableTextField> {
+  final VariableHoverController _hover = VariableHoverController();
+
+  @override
+  void dispose() {
+    _hover.dispose();
+    super.dispose();
+  }
+
+  void _showPopover(String name, Offset globalPosition) {
+    if (!mounted) return;
+    _hover.showFor(context, widget.variables.classify(name), globalPosition);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.appPalette;
+    final ctx = widget.variables;
+
+    // Wire highlight colors + variable map + hover sinks onto the controller.
+    widget.controller
+      ..updateColors(
+        resolved: palette.variableResolved,
+        unresolved: palette.variableUnresolved,
+      )
+      ..updateVariables(ctx.allVariables)
+      ..onVariableEnter = ctx.isEmpty ? null : _showPopover
+      ..onVariableExit = ctx.isEmpty ? null : _hover.scheduleHide;
+
+    final field = TextField(
+      key: widget.fieldKey,
+      controller: widget.controller,
+      focusNode: widget.focusNode,
+      decoration: widget.decoration,
+      obscureText: widget.obscureText,
+      autocorrect: false,
+      enableSuggestions: false,
+      onChanged: widget.onChanged,
+    );
+
+    if (ctx.isEmpty) return field;
+
+    return VariableAutocomplete(
+      controller: widget.controller,
+      focusNode: widget.focusNode,
+      suggestionsFor: (query) => buildVariableSuggestions(
+        query: query,
+        userVariableNames: ctx.allVariables.keys,
+        classify: ctx.classify,
+      ),
+      onAccepted: widget.onChanged,
+      child: field,
+    );
+  }
+}

--- a/lib/core/ui/widgets/variable_text_field.dart
+++ b/lib/core/ui/widgets/variable_text_field.dart
@@ -63,8 +63,8 @@ class _VariableTextFieldState extends State<VariableTextField> {
         unresolved: palette.variableUnresolved,
       )
       ..updateVariables(ctx.allVariables)
-      ..onVariableEnter = ctx.isEmpty ? null : _showPopover
-      ..onVariableExit = ctx.isEmpty ? null : _hover.scheduleHide;
+      ..onVariableEnter = _showPopover
+      ..onVariableExit = _hover.scheduleHide;
 
     final field = TextField(
       key: widget.fieldKey,
@@ -78,8 +78,9 @@ class _VariableTextFieldState extends State<VariableTextField> {
       onChanged: widget.onChanged,
     );
 
-    if (ctx.isEmpty) return field;
-
+    // Always offer autocomplete: dynamic built-ins ({{$guid}}, {{$timestamp}}…)
+    // are suggestable even with no active environment, matching the URL bar.
+    // The overlay self-closes when a query matches nothing.
     return VariableAutocomplete(
       controller: widget.controller,
       focusNode: widget.focusNode,

--- a/lib/core/ui/widgets/variable_text_field.dart
+++ b/lib/core/ui/widgets/variable_text_field.dart
@@ -18,6 +18,7 @@ class VariableTextField extends StatefulWidget {
     required this.focusNode,
     required this.onChanged,
     this.decoration,
+    this.style,
     this.obscureText = false,
     this.fieldKey,
     super.key,
@@ -28,6 +29,7 @@ class VariableTextField extends StatefulWidget {
   final FocusNode focusNode;
   final ValueChanged<String> onChanged;
   final InputDecoration? decoration;
+  final TextStyle? style;
   final bool obscureText;
   final Key? fieldKey;
 
@@ -69,6 +71,7 @@ class _VariableTextFieldState extends State<VariableTextField> {
       controller: widget.controller,
       focusNode: widget.focusNode,
       decoration: widget.decoration,
+      style: widget.style,
       obscureText: widget.obscureText,
       autocorrect: false,
       enableSuggestions: false,

--- a/lib/core/utils/layered_variable_context.dart
+++ b/lib/core/utils/layered_variable_context.dart
@@ -1,0 +1,57 @@
+import 'package:equatable/equatable.dart';
+import 'package:getman/core/utils/variable_resolution_helper.dart';
+
+/// The full set of variables available to a request field: the active
+/// environment layered over the request's inherited collection variables
+/// (environment wins on conflict), plus dynamic built-ins via [classify].
+/// Pure Dart — the single currency passed to every variable-aware field.
+class LayeredVariableContext extends Equatable {
+  const LayeredVariableContext({
+    this.environmentVariables = const {},
+    this.environmentSecrets = const {},
+    this.collectionVariables = const {},
+    this.collectionSecrets = const {},
+    this.environmentName,
+  });
+
+  static const LayeredVariableContext empty = LayeredVariableContext();
+
+  final Map<String, String> environmentVariables;
+  final Set<String> environmentSecrets;
+  final Map<String, String> collectionVariables;
+  final Set<String> collectionSecrets;
+  final String? environmentName;
+
+  /// Collection overlaid by environment (environment wins). Used for token
+  /// highlighting (resolved-vs-not) and as the autocomplete candidate set.
+  Map<String, String> get allVariables => {
+    ...collectionVariables,
+    ...environmentVariables,
+  };
+
+  Set<String> get allSecretKeys => {
+    ...collectionSecrets,
+    ...environmentSecrets,
+  };
+
+  bool get isEmpty => allVariables.isEmpty;
+
+  ResolvedVariable classify(String name) =>
+      VariableResolutionHelper.classifyLayered(
+        name: name,
+        collectionVariables: collectionVariables,
+        collectionSecrets: collectionSecrets,
+        environmentVariables: environmentVariables,
+        environmentSecrets: environmentSecrets,
+        environmentName: environmentName,
+      );
+
+  @override
+  List<Object?> get props => [
+    environmentVariables,
+    environmentSecrets,
+    collectionVariables,
+    collectionSecrets,
+    environmentName,
+  ];
+}

--- a/lib/features/tabs/presentation/screens/request_view.dart
+++ b/lib/features/tabs/presentation/screens/request_view.dart
@@ -8,7 +8,9 @@ import 'package:getman/core/theme/responsive.dart';
 import 'package:getman/core/ui/widgets/app_snack_bar.dart';
 import 'package:getman/core/ui/widgets/name_prompt_dialog.dart';
 import 'package:getman/core/ui/widgets/splitter.dart';
+import 'package:getman/core/ui/widgets/tab_variable_context_builder.dart';
 import 'package:getman/core/utils/json_utils.dart';
+import 'package:getman/core/utils/layered_variable_context.dart';
 import 'package:getman/features/collections/domain/logic/collections_tree_helper.dart';
 import 'package:getman/features/collections/presentation/bloc/collections_bloc.dart';
 import 'package:getman/features/collections/presentation/bloc/collections_event.dart';
@@ -46,6 +48,13 @@ class _RequestViewState extends State<RequestView> {
   late final CodeLineEditingController _bodyController;
   late final CodeLineEditingController _graphqlVarsController;
   late final CodeLineEditingController _responseController;
+
+  // Live variable highlighting state for the body editor. The span builder
+  // reads these via closures at paint time, so an env or theme change recolors
+  // `{{var}}` tokens on the next [CodeLineEditingController.forceRepaint].
+  LayeredVariableContext _bodyVarContext = LayeredVariableContext.empty;
+  Color _resolvedColor = Colors.transparent;
+  Color _unresolvedColor = Colors.transparent;
   // Live drag ratio. A ValueNotifier (not setState) so dragging the splitter
   // only re-runs the Flex layout — the captured request/response panes (and
   // their code editors) are not rebuilt frame-by-frame. Committed to the
@@ -56,8 +65,18 @@ class _RequestViewState extends State<RequestView> {
   @override
   void initState() {
     super.initState();
-    _bodyController = createJsonCodeController();
-    _graphqlVarsController = createJsonCodeController();
+    _bodyController = createJsonCodeController(
+      variablesProvider: () => _bodyVarContext.allVariables,
+      resolvedColor: () => _resolvedColor,
+      unresolvedColor: () => _unresolvedColor,
+    );
+    // The GraphQL VARIABLES pane is JSON where `{{var}}` applies too — give it
+    // the same live highlighting providers as the body editor.
+    _graphqlVarsController = createJsonCodeController(
+      variablesProvider: () => _bodyVarContext.allVariables,
+      resolvedColor: () => _resolvedColor,
+      unresolvedColor: () => _unresolvedColor,
+    );
     _responseController = createJsonCodeController();
     _bodyController.addListener(_onBodyChanged);
     _graphqlVarsController.addListener(_onGraphqlVarsChanged);
@@ -74,6 +93,15 @@ class _RequestViewState extends State<RequestView> {
         _graphqlVarsController.text != tab.config.graphqlVariables) {
       _graphqlVarsController.text = tab.config.graphqlVariables;
     }
+    // Theme is available here (not in initState). Recolor `{{var}}` tokens when
+    // the variable palette changes (e.g. dark/light or theme switch).
+    final palette = context.appPalette;
+    if (_resolvedColor != palette.variableResolved ||
+        _unresolvedColor != palette.variableUnresolved) {
+      _resolvedColor = palette.variableResolved;
+      _unresolvedColor = palette.variableUnresolved;
+      _bodyController.forceRepaint();
+    }
   }
 
   void _onGraphqlVarsChanged() {
@@ -88,6 +116,18 @@ class _RequestViewState extends State<RequestView> {
         tab.copyWith(config: tab.config.copyWith(graphqlVariables: newText)),
       ),
     );
+  }
+
+  /// Stores the latest layered variable context for the body editor's span
+  /// builder and repaints visible lines so an env/collection switch recolors
+  /// tokens without waiting for a keystroke. Called from the body pane's
+  /// [TabVariableContextBuilder], which rebuilds only on env/collection change.
+  void _syncBodyVarContext(LayeredVariableContext varContext) {
+    if (_bodyVarContext == varContext) return;
+    _bodyVarContext = varContext;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _bodyController.forceRepaint();
+    });
   }
 
   void _onBodyChanged() {
@@ -194,105 +234,71 @@ class _RequestViewState extends State<RequestView> {
                       ),
                       SizedBox(height: layout.sectionSpacing),
                       Expanded(
-                        child: context.useUnifiedRequestTabs
-                            ? UnifiedRequestPanel(
-                                tabId: widget.tabId,
-                                bodyController: _bodyController,
-                                variablesController: _graphqlVarsController,
-                                responseController: _responseController,
-                              )
-                            : LayoutBuilder(
-                                builder: (context, constraints) {
-                                  final totalSize = settings.isVerticalLayout
-                                      ? constraints.maxHeight
-                                      : constraints.maxWidth;
-                                  // Build the panes once; only the Flex (below)
-                                  // rebuilds on drag, so the editors relayout
-                                  // rather than rebuild.
-                                  final requestPane = RequestConfigSection(
+                        child: TabVariableContextBuilder(
+                          tabId: widget.tabId,
+                          builder: (context, varContext) {
+                            _syncBodyVarContext(varContext);
+                            return context.useUnifiedRequestTabs
+                                ? UnifiedRequestPanel(
                                     tabId: widget.tabId,
                                     bodyController: _bodyController,
                                     variablesController: _graphqlVarsController,
-                                  );
-                                  final responsePane = ResponseArea(
-                                    tabId: widget.tabId,
                                     responseController: _responseController,
-                                  );
-                                  final splitter = Splitter(
-                                    isVertical: settings.isVerticalLayout,
-                                    onUpdate: (delta) {
-                                      final base =
-                                          _localSplitRatio.value ??
-                                          settings.splitRatio;
-                                      _localSplitRatio.value =
-                                          (base + delta / totalSize).clamp(
-                                            _splitMin,
-                                            _splitMax,
-                                          );
-                                    },
-                                    onEnd: () {
-                                      final committed = _localSplitRatio.value;
-                                      if (committed == null) return;
-                                      context.read<SettingsBloc>().add(
-                                        UpdateSplitRatio(committed),
+                                  )
+                                : LayoutBuilder(
+                                    builder: (context, constraints) {
+                                      final totalSize =
+                                          settings.isVerticalLayout
+                                          ? constraints.maxHeight
+                                          : constraints.maxWidth;
+                                      // Build the panes once; only the Flex
+                                      // (below) rebuilds on drag, so the
+                                      // editors relayout rather than rebuild.
+                                      final requestPane = RequestConfigSection(
+                                        tabId: widget.tabId,
+                                        bodyController: _bodyController,
+                                        variablesController:
+                                            _graphqlVarsController,
                                       );
-                                      _localSplitRatio.value = null;
+                                      final responsePane = ResponseArea(
+                                        tabId: widget.tabId,
+                                        responseController: _responseController,
+                                      );
+                                      final splitter = Splitter(
+                                        isVertical: settings.isVerticalLayout,
+                                        onUpdate: (delta) {
+                                          final base =
+                                              _localSplitRatio.value ??
+                                              settings.splitRatio;
+                                          _localSplitRatio.value =
+                                              (base + delta / totalSize).clamp(
+                                                _splitMin,
+                                                _splitMax,
+                                              );
+                                        },
+                                        onEnd: () {
+                                          final committed =
+                                              _localSplitRatio.value;
+                                          if (committed == null) return;
+                                          context.read<SettingsBloc>().add(
+                                            UpdateSplitRatio(committed),
+                                          );
+                                          _localSplitRatio.value = null;
+                                        },
+                                      );
+
+                                      return _splitPanes(
+                                        context,
+                                        splitRatio: settings.splitRatio,
+                                        isVertical: settings.isVerticalLayout,
+                                        requestPane: requestPane,
+                                        responsePane: responsePane,
+                                        splitter: splitter,
+                                      );
                                     },
                                   );
-
-                                  return BlocSelector<
-                                    TabsBloc,
-                                    TabsState,
-                                    bool
-                                  >(
-                                    selector: (state) =>
-                                        state.tabs
-                                            .byId(widget.tabId)
-                                            ?.isSending ??
-                                        false,
-                                    builder: (context, isSending) =>
-                                        context.appMotion.inFlightFrame(
-                                          context,
-                                          isSending: isSending,
-                                          child:
-                                              ValueListenableBuilder<double?>(
-                                                valueListenable:
-                                                    _localSplitRatio,
-                                                builder: (context, local, _) {
-                                                  final currentRatio =
-                                                      local ??
-                                                      settings.splitRatio;
-                                                  return Flex(
-                                                    direction:
-                                                        settings
-                                                            .isVerticalLayout
-                                                        ? Axis.vertical
-                                                        : Axis.horizontal,
-                                                    crossAxisAlignment:
-                                                        CrossAxisAlignment
-                                                            .start,
-                                                    children: [
-                                                      Flexible(
-                                                        flex: _ratioToFlex(
-                                                          currentRatio,
-                                                        ),
-                                                        child: requestPane,
-                                                      ),
-                                                      splitter,
-                                                      Flexible(
-                                                        flex: _ratioToFlex(
-                                                          1 - currentRatio,
-                                                        ),
-                                                        child: responsePane,
-                                                      ),
-                                                    ],
-                                                  );
-                                                },
-                                              ),
-                                        ),
-                                  );
-                                },
-                              ),
+                          },
+                        ),
                       ),
                     ],
                   ),
@@ -302,6 +308,44 @@ class _RequestViewState extends State<RequestView> {
           },
         );
       },
+    );
+  }
+
+  /// The request/response split, wrapped in the loud-theme in-flight motion
+  /// frame. Extracted to a method so the body pane's variable-context nesting
+  /// doesn't push this block past the line-length limit.
+  Widget _splitPanes(
+    BuildContext context, {
+    required double splitRatio,
+    required bool isVertical,
+    required Widget requestPane,
+    required Widget responsePane,
+    required Widget splitter,
+  }) {
+    return BlocSelector<TabsBloc, TabsState, bool>(
+      selector: (state) => state.tabs.byId(widget.tabId)?.isSending ?? false,
+      builder: (context, isSending) => context.appMotion.inFlightFrame(
+        context,
+        isSending: isSending,
+        child: ValueListenableBuilder<double?>(
+          valueListenable: _localSplitRatio,
+          builder: (context, local, _) {
+            final currentRatio = local ?? splitRatio;
+            return Flex(
+              direction: isVertical ? Axis.vertical : Axis.horizontal,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Flexible(flex: _ratioToFlex(currentRatio), child: requestPane),
+                splitter,
+                Flexible(
+                  flex: _ratioToFlex(1 - currentRatio),
+                  child: responsePane,
+                ),
+              ],
+            );
+          },
+        ),
+      ),
     );
   }
 

--- a/lib/features/tabs/presentation/widgets/auth_tab_view.dart
+++ b/lib/features/tabs/presentation/widgets/auth_tab_view.dart
@@ -4,17 +4,19 @@ import 'package:getman/core/domain/entities/auth_config.dart';
 import 'package:getman/core/domain/entities/request_config_entity.dart'
     show HttpRequestConfigEntity;
 import 'package:getman/core/theme/app_theme.dart';
-import 'package:getman/core/ui/widgets/key_value_list_editor.dart'
-    show KeyValueListEditor;
+import 'package:getman/core/ui/widgets/tab_variable_context_builder.dart';
+import 'package:getman/core/ui/widgets/variable_highlight_controller.dart';
+import 'package:getman/core/ui/widgets/variable_text_field.dart';
 import 'package:getman/core/utils/equality.dart';
+import 'package:getman/core/utils/layered_variable_context.dart';
 import 'package:getman/features/tabs/domain/entities/request_tab_entity.dart';
 import 'package:getman/features/tabs/presentation/bloc/tabs_bloc.dart';
 import 'package:getman/features/tabs/presentation/bloc/tabs_event.dart';
 import 'package:getman/features/tabs/presentation/bloc/tabs_state.dart';
 
 /// AUTH tab — a fixed-field form over [HttpRequestConfigEntity.auth]. Holds its
-/// own controllers and suppresses echoes of its own emissions (mirrors
-/// [KeyValueListEditor]) so typing never loses focus across the bloc
+/// own controllers and suppresses echoes of its own emissions (same pattern as
+/// `KeyValueListEditor`) so typing never loses focus across the bloc
 /// round-trip. Field values may contain `{{env vars}}`; they resolve at send
 /// time.
 class AuthTabView extends StatefulWidget {
@@ -36,11 +38,16 @@ class _AuthTabViewState extends State<AuthTabView> {
 
   late AuthType _type;
   late ApiKeyLocation _apiKeyLocation;
-  late final TextEditingController _token;
-  late final TextEditingController _username;
-  late final TextEditingController _password;
-  late final TextEditingController _apiKeyName;
-  late final TextEditingController _apiKeyValue;
+  late final VariableHighlightController _token;
+  late final VariableHighlightController _username;
+  late final VariableHighlightController _password;
+  late final VariableHighlightController _apiKeyName;
+  late final VariableHighlightController _apiKeyValue;
+  late final FocusNode _tokenFocus;
+  late final FocusNode _usernameFocus;
+  late final FocusNode _passwordFocus;
+  late final FocusNode _apiKeyNameFocus;
+  late final FocusNode _apiKeyValueFocus;
 
   Map<String, String>? _lastEmitted;
 
@@ -50,11 +57,16 @@ class _AuthTabViewState extends State<AuthTabView> {
     final auth = _currentAuth();
     _type = auth.type;
     _apiKeyLocation = auth.apiKeyLocation;
-    _token = TextEditingController(text: auth.token);
-    _username = TextEditingController(text: auth.username);
-    _password = TextEditingController(text: auth.password);
-    _apiKeyName = TextEditingController(text: auth.apiKeyName);
-    _apiKeyValue = TextEditingController(text: auth.apiKeyValue);
+    _token = VariableHighlightController(text: auth.token);
+    _username = VariableHighlightController(text: auth.username);
+    _password = VariableHighlightController(text: auth.password);
+    _apiKeyName = VariableHighlightController(text: auth.apiKeyName);
+    _apiKeyValue = VariableHighlightController(text: auth.apiKeyValue);
+    _tokenFocus = FocusNode();
+    _usernameFocus = FocusNode();
+    _passwordFocus = FocusNode();
+    _apiKeyNameFocus = FocusNode();
+    _apiKeyValueFocus = FocusNode();
   }
 
   AuthConfig _currentAuth() =>
@@ -74,6 +86,11 @@ class _AuthTabViewState extends State<AuthTabView> {
     _password.dispose();
     _apiKeyName.dispose();
     _apiKeyValue.dispose();
+    _tokenFocus.dispose();
+    _usernameFocus.dispose();
+    _passwordFocus.dispose();
+    _apiKeyNameFocus.dispose();
+    _apiKeyValueFocus.dispose();
     super.dispose();
   }
 
@@ -131,49 +148,62 @@ class _AuthTabViewState extends State<AuthTabView> {
         }
         setState(() => _syncFrom(AuthConfig.fromMap(auth)));
       },
-      child: ListView(
-        padding: EdgeInsets.all(layout.pagePadding),
-        children: [
-          _label(context, 'AUTH TYPE'),
-          SizedBox(height: layout.tabSpacing),
-          DropdownButton<AuthType>(
-            key: const ValueKey('auth_type_dropdown'),
-            value: _type,
-            isExpanded: true,
-            items: [
-              for (final t in AuthType.values)
-                DropdownMenuItem(value: t, child: Text(_labels[t]!)),
-            ],
-            onChanged: (next) {
-              if (next == null) return;
-              setState(() => _type = next);
-              _emit();
-            },
-          ),
-          SizedBox(height: layout.sectionSpacing),
-          ..._fieldsFor(context),
-        ],
+      child: TabVariableContextBuilder(
+        tabId: widget.tabId,
+        builder: (context, varContext) => ListView(
+          padding: EdgeInsets.all(layout.pagePadding),
+          children: [
+            _label(context, 'AUTH TYPE'),
+            SizedBox(height: layout.tabSpacing),
+            DropdownButton<AuthType>(
+              key: const ValueKey('auth_type_dropdown'),
+              value: _type,
+              isExpanded: true,
+              items: [
+                for (final t in AuthType.values)
+                  DropdownMenuItem(value: t, child: Text(_labels[t]!)),
+              ],
+              onChanged: (next) {
+                if (next == null) return;
+                setState(() => _type = next);
+                _emit();
+              },
+            ),
+            SizedBox(height: layout.sectionSpacing),
+            ..._fieldsFor(context, varContext),
+          ],
+        ),
       ),
     );
   }
 
-  List<Widget> _fieldsFor(BuildContext context) {
+  List<Widget> _fieldsFor(
+    BuildContext context,
+    LayeredVariableContext varContext,
+  ) {
     switch (_type) {
       case AuthType.none:
         return [_hint(context, 'This request is sent without authentication.')];
       case AuthType.inherit:
         return [_hint(context, 'Inherits auth from the parent collection.')];
       case AuthType.bearer:
-        return [_field(context, 'TOKEN', _token)];
+        return [_field(context, 'TOKEN', _token, _tokenFocus, varContext)];
       case AuthType.basic:
         return [
-          _field(context, 'USERNAME', _username),
-          _field(context, 'PASSWORD', _password, obscure: true),
+          _field(context, 'USERNAME', _username, _usernameFocus, varContext),
+          _field(
+            context,
+            'PASSWORD',
+            _password,
+            _passwordFocus,
+            varContext,
+            obscure: true,
+          ),
         ];
       case AuthType.apiKey:
         return [
-          _field(context, 'KEY', _apiKeyName),
-          _field(context, 'VALUE', _apiKeyValue),
+          _field(context, 'KEY', _apiKeyName, _apiKeyNameFocus, varContext),
+          _field(context, 'VALUE', _apiKeyValue, _apiKeyValueFocus, varContext),
           _label(context, 'ADD TO'),
           SizedBox(height: context.appLayout.tabSpacing),
           DropdownButton<ApiKeyLocation>(
@@ -220,7 +250,9 @@ class _AuthTabViewState extends State<AuthTabView> {
   Widget _field(
     BuildContext context,
     String label,
-    TextEditingController controller, {
+    VariableHighlightController controller,
+    FocusNode focusNode,
+    LayeredVariableContext variables, {
     bool obscure = false,
   }) {
     final layout = context.appLayout;
@@ -231,12 +263,13 @@ class _AuthTabViewState extends State<AuthTabView> {
         children: [
           _label(context, label),
           SizedBox(height: layout.tabSpacing),
-          TextField(
-            key: ValueKey('auth_field_$label'),
+          VariableTextField(
+            fieldKey: ValueKey('auth_field_$label'),
+            variables: variables,
             controller: controller,
+            focusNode: focusNode,
             obscureText: obscure,
-            autocorrect: false,
-            enableSuggestions: false,
+            onChanged: (_) => _emit(),
             style: TextStyle(
               fontSize: layout.fontSizeNormal,
               fontWeight: context.appTypography.titleWeight,
@@ -246,7 +279,6 @@ class _AuthTabViewState extends State<AuthTabView> {
               isDense: true,
               contentPadding: EdgeInsets.all(layout.isCompact ? 8 : 12),
             ),
-            onChanged: (_) => _emit(),
           ),
         ],
       ),

--- a/lib/features/tabs/presentation/widgets/form_data_editor.dart
+++ b/lib/features/tabs/presentation/widgets/form_data_editor.dart
@@ -7,6 +7,10 @@ import 'package:getman/core/theme/app_theme.dart';
 import 'package:getman/core/ui/widgets/app_snack_bar.dart';
 import 'package:getman/core/ui/widgets/key_value_list_editor.dart'
     show KeyValueListEditor;
+import 'package:getman/core/ui/widgets/tab_variable_context_builder.dart';
+import 'package:getman/core/ui/widgets/variable_highlight_controller.dart';
+import 'package:getman/core/ui/widgets/variable_text_field.dart';
+import 'package:getman/core/utils/layered_variable_context.dart';
 import 'package:getman/core/utils/path_utils.dart';
 import 'package:getman/features/tabs/domain/entities/request_tab_entity.dart';
 import 'package:getman/features/tabs/presentation/bloc/tabs_bloc.dart';
@@ -112,33 +116,41 @@ class _FormDataEditorState extends State<FormDataEditor> {
   Widget build(BuildContext context) {
     final layout = context.appLayout;
 
-    return BlocListener<TabsBloc, TabsState>(
-      listenWhen: (prev, next) => !_fieldListEquality.equals(
-        prev.tabs.byId(widget.tabId)?.config.formFields,
-        next.tabs.byId(widget.tabId)?.config.formFields,
-      ),
-      listener: (context, state) {
-        final fields =
-            state.tabs.byId(widget.tabId)?.config.formFields ?? const [];
-        if (_lastEmitted != null &&
-            _fieldListEquality.equals(fields, _lastEmitted)) {
-          return;
-        }
-        setState(() {
-          _disposeRows();
-          _initRows(fields);
-          _lastEmitted = null;
-        });
-      },
-      child: ListView.builder(
-        padding: EdgeInsets.all(layout.pagePadding),
-        itemCount: _rows.length,
-        itemBuilder: _buildRow,
+    return TabVariableContextBuilder(
+      tabId: widget.tabId,
+      builder: (context, varContext) => BlocListener<TabsBloc, TabsState>(
+        listenWhen: (prev, next) => !_fieldListEquality.equals(
+          prev.tabs.byId(widget.tabId)?.config.formFields,
+          next.tabs.byId(widget.tabId)?.config.formFields,
+        ),
+        listener: (context, state) {
+          final fields =
+              state.tabs.byId(widget.tabId)?.config.formFields ?? const [];
+          if (_lastEmitted != null &&
+              _fieldListEquality.equals(fields, _lastEmitted)) {
+            return;
+          }
+          setState(() {
+            _disposeRows();
+            _initRows(fields);
+            _lastEmitted = null;
+          });
+        },
+        child: ListView.builder(
+          padding: EdgeInsets.all(layout.pagePadding),
+          itemCount: _rows.length,
+          itemBuilder: (context, index) =>
+              _buildRow(context, index, varContext),
+        ),
       ),
     );
   }
 
-  Widget _buildRow(BuildContext context, int index) {
+  Widget _buildRow(
+    BuildContext context,
+    int index,
+    LayeredVariableContext varContext,
+  ) {
     final theme = Theme.of(context);
     final layout = context.appLayout;
     final row = _rows[index];
@@ -172,18 +184,18 @@ class _FormDataEditorState extends State<FormDataEditor> {
             label: row.fileLabel,
             onTap: () => _pickFile(row),
           )
-        : TextField(
-            key: ValueKey('val_${row.id}'),
+        : VariableTextField(
+            fieldKey: ValueKey('val_${row.id}'),
+            variables: varContext,
             controller: row.valueController,
+            focusNode: row.valueFocus,
+            onChanged: (_) => _emit(),
             style: textStyle,
-            autocorrect: false,
-            enableSuggestions: false,
             decoration: InputDecoration(
               hintText: 'VALUE',
               isDense: true,
               contentPadding: fieldPadding,
             ),
-            onChanged: (_) => _emit(),
           );
 
     final children = <Widget>[
@@ -293,6 +305,7 @@ class _RowState {
   _RowState({
     required this.nameController,
     required this.valueController,
+    required this.valueFocus,
     this.isFile = false,
     this.filePath,
     this.fileName,
@@ -301,7 +314,8 @@ class _RowState {
 
   factory _RowState.from(MultipartFieldEntity f) => _RowState(
     nameController: TextEditingController(text: f.name),
-    valueController: TextEditingController(text: f.value),
+    valueController: VariableHighlightController(text: f.value),
+    valueFocus: FocusNode(),
     isFile: f.isFile,
     filePath: f.filePath,
     fileName: f.filePath == null ? null : PathUtils.basename(f.filePath!),
@@ -310,12 +324,14 @@ class _RowState {
 
   factory _RowState.empty() => _RowState(
     nameController: TextEditingController(),
-    valueController: TextEditingController(),
+    valueController: VariableHighlightController(),
+    valueFocus: FocusNode(),
   );
   static int _counter = 0;
   final int id;
   final TextEditingController nameController;
-  final TextEditingController valueController;
+  final VariableHighlightController valueController;
+  final FocusNode valueFocus;
   bool isFile;
   String? filePath;
   String? fileName;
@@ -336,5 +352,6 @@ class _RowState {
   void dispose() {
     nameController.dispose();
     valueController.dispose();
+    valueFocus.dispose();
   }
 }

--- a/lib/features/tabs/presentation/widgets/json_code_editor.dart
+++ b/lib/features/tabs/presentation/widgets/json_code_editor.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:getman/core/theme/app_theme.dart';
 import 'package:getman/features/tabs/presentation/widgets/code_find_panel.dart';
+import 'package:getman/features/tabs/presentation/widgets/variable_json_span_builder.dart';
 import 'package:re_editor/re_editor.dart';
 import 'package:re_highlight/languages/json.dart';
 import 'package:re_highlight/re_highlight.dart';
@@ -51,8 +52,43 @@ TextSpan jsonHighlightSpanBuilder({
 /// Creates a [CodeLineEditingController] pre-wired with JSON syntax
 /// highlighting. Use this (not the bare constructor) for any controller fed to
 /// a [JsonCodeEditor] so highlighting works without an extra setup step.
-CodeLineEditingController createJsonCodeController() =>
-    CodeLineEditingController(spanBuilder: jsonHighlightSpanBuilder);
+///
+/// When [variablesProvider], [resolvedColor], and [unresolvedColor] are all
+/// supplied, the span builder additionally recolors `{{var}}` tokens on top of
+/// the JSON highlighting (resolved vs. unresolved). The providers are read at
+/// span-build time — call [CodeLineEditingController.forceRepaint] after an
+/// env/theme change to recolor without a text edit. When any provider is
+/// omitted (e.g. the response viewer), the behavior is plain JSON highlighting.
+CodeLineEditingController createJsonCodeController({
+  Map<String, String> Function()? variablesProvider,
+  Color Function()? resolvedColor,
+  Color Function()? unresolvedColor,
+}) {
+  if (variablesProvider == null ||
+      resolvedColor == null ||
+      unresolvedColor == null) {
+    return CodeLineEditingController(spanBuilder: jsonHighlightSpanBuilder);
+  }
+  return CodeLineEditingController(
+    spanBuilder:
+        ({
+          required context,
+          required index,
+          required codeLine,
+          required textSpan,
+          required style,
+        }) => variableAwareJsonSpan(
+          context: context,
+          index: index,
+          codeLine: codeLine,
+          textSpan: textSpan,
+          style: style,
+          variables: variablesProvider(),
+          resolvedColor: resolvedColor(),
+          unresolvedColor: unresolvedColor(),
+        ),
+  );
+}
 
 class JsonCodeEditor extends StatelessWidget {
   const JsonCodeEditor({

--- a/lib/features/tabs/presentation/widgets/request_editor_tabs.dart
+++ b/lib/features/tabs/presentation/widgets/request_editor_tabs.dart
@@ -8,16 +8,11 @@ import 'package:getman/core/theme/app_theme.dart';
 import 'package:getman/core/ui/widgets/app_snack_bar.dart';
 import 'package:getman/core/ui/widgets/bulk_kv_editor.dart';
 import 'package:getman/core/ui/widgets/key_value_list_editor.dart';
-import 'package:getman/core/ui/widgets/variable_hover_popover.dart';
+import 'package:getman/core/ui/widgets/tab_variable_context_builder.dart';
 import 'package:getman/core/utils/bulk_kv_codec.dart';
 import 'package:getman/core/utils/equality.dart';
 import 'package:getman/core/utils/json_utils.dart';
 import 'package:getman/core/utils/path_utils.dart';
-import 'package:getman/features/environments/domain/logic/active_environment_helper.dart';
-import 'package:getman/features/environments/presentation/bloc/environments_bloc.dart';
-import 'package:getman/features/environments/presentation/bloc/environments_state.dart';
-import 'package:getman/features/settings/presentation/bloc/settings_bloc.dart';
-import 'package:getman/features/settings/presentation/bloc/settings_state.dart';
 import 'package:getman/features/tabs/domain/entities/request_tab_entity.dart';
 import 'package:getman/features/tabs/presentation/bloc/tabs_bloc.dart';
 import 'package:getman/features/tabs/presentation/bloc/tabs_event.dart';
@@ -33,42 +28,6 @@ import 'package:re_editor/re_editor.dart';
 /// The three request-editor tab bodies (PARAMS / HEADERS / BODY), shared by
 /// the split-pane [RequestConfigSection] and the phone [UnifiedRequestPanel]
 /// so both layouts stay behaviorally identical.
-
-/// Recomputes the active-environment [VariableHoverContext] and rebuilds when
-/// the environment set or the active-environment id changes, so value-field
-/// hover popovers always reflect the current environment.
-class _VariableContextBuilder extends StatelessWidget {
-  const _VariableContextBuilder({required this.builder});
-
-  final Widget Function(BuildContext, VariableHoverContext) builder;
-
-  @override
-  Widget build(BuildContext context) {
-    return BlocBuilder<SettingsBloc, SettingsState>(
-      buildWhen: (p, n) =>
-          p.settings.activeEnvironmentId != n.settings.activeEnvironmentId,
-      builder: (context, settingsState) {
-        return BlocBuilder<EnvironmentsBloc, EnvironmentsState>(
-          buildWhen: (p, n) => p.environments != n.environments,
-          builder: (context, envState) {
-            final env = ActiveEnvironmentHelper.activeEnvironment(
-              envState.environments,
-              settingsState.settings.activeEnvironmentId,
-            );
-            return builder(
-              context,
-              VariableHoverContext(
-                variables: env?.variables ?? const {},
-                secretKeys: env?.secretKeys ?? const {},
-                environmentName: env?.name,
-              ),
-            );
-          },
-        );
-      },
-    );
-  }
-}
 
 /// Small header above the params/headers editor body offering the row⇄bulk
 /// toggle. [bulk] is the current mode; [onToggle] flips it. The icon/label
@@ -191,7 +150,8 @@ class _ParamsTabViewState extends State<ParamsTabView> {
                       onChanged: (text) =>
                           emit(encode(BulkKvCodec.parse(text))),
                     )
-                  : _VariableContextBuilder(
+                  : TabVariableContextBuilder(
+                      tabId: tab.tabId,
                       builder: (context, varContext) =>
                           KeyValueListEditor<List<QueryParamEntity>>(
                             items: tab.config.params,
@@ -272,7 +232,8 @@ class _HeadersTabViewState extends State<HeadersTabView> {
                       onChanged: (text) =>
                           emit(encode(BulkKvCodec.parse(text))),
                     )
-                  : _VariableContextBuilder(
+                  : TabVariableContextBuilder(
+                      tabId: tab.tabId,
                       builder: (context, varContext) =>
                           KeyValueListEditor<Map<String, String>>(
                             items: tab.config.headers,

--- a/lib/features/tabs/presentation/widgets/request_editor_tabs.dart
+++ b/lib/features/tabs/presentation/widgets/request_editor_tabs.dart
@@ -23,6 +23,7 @@ import 'package:getman/features/tabs/presentation/widgets/request_config_section
     show RequestConfigSection;
 import 'package:getman/features/tabs/presentation/widgets/unified_request_panel.dart'
     show UnifiedRequestPanel;
+import 'package:getman/features/tabs/presentation/widgets/variable_code_autocomplete.dart';
 import 'package:re_editor/re_editor.dart';
 
 /// The three request-editor tab bodies (PARAMS / HEADERS / BODY), shared by
@@ -294,7 +295,7 @@ class BodyTabView extends StatelessWidget {
       case BodyType.none:
         return const _EmptyBodyHint();
       case BodyType.raw:
-        return _RawBodyEditor(controller: controller);
+        return _RawBodyEditor(tabId: tabId, controller: controller);
       case BodyType.urlencoded:
         return FormDataEditor(tabId: tabId, allowFiles: false);
       case BodyType.multipart:
@@ -411,7 +412,8 @@ class _BodyTypeChip extends StatelessWidget {
 }
 
 class _RawBodyEditor extends StatelessWidget {
-  const _RawBodyEditor({required this.controller});
+  const _RawBodyEditor({required this.tabId, required this.controller});
+  final String tabId;
   final CodeLineEditingController controller;
 
   @override
@@ -420,7 +422,16 @@ class _RawBodyEditor extends StatelessWidget {
     final layout = context.appLayout;
     return Stack(
       children: [
-        JsonCodeEditor(controller: controller),
+        // The variable context rebuilds on env/collection change, recreating
+        // the prompts builder with the fresh context so env switches apply.
+        // The Beautify overlay stays outside the autocomplete wrap.
+        TabVariableContextBuilder(
+          tabId: tabId,
+          builder: (context, varContext) => wrapBodyWithVariableAutocomplete(
+            contextProvider: () => varContext,
+            child: JsonCodeEditor(controller: controller),
+          ),
+        ),
         Positioned(
           top: 8,
           right: 8,

--- a/lib/features/tabs/presentation/widgets/request_editor_tabs.dart
+++ b/lib/features/tabs/presentation/widgets/request_editor_tabs.dart
@@ -304,6 +304,7 @@ class BodyTabView extends StatelessWidget {
         return _BinaryBodyPicker(tabId: tabId);
       case BodyType.graphql:
         return _GraphqlBodyEditor(
+          tabId: tabId,
           queryController: controller,
           variablesController: variablesController,
         );
@@ -470,9 +471,11 @@ class _RawBodyEditor extends StatelessWidget {
 /// variables are JSON).
 class _GraphqlBodyEditor extends StatelessWidget {
   const _GraphqlBodyEditor({
+    required this.tabId,
     required this.queryController,
     required this.variablesController,
   });
+  final String tabId;
   final CodeLineEditingController queryController;
   final CodeLineEditingController variablesController;
 
@@ -492,7 +495,10 @@ class _GraphqlBodyEditor extends StatelessWidget {
           flex: 2,
           child: _GraphqlPane(
             label: 'VARIABLES (JSON)',
-            child: _RawBodyEditor(controller: variablesController),
+            child: _RawBodyEditor(
+              tabId: tabId,
+              controller: variablesController,
+            ),
           ),
         ),
       ],

--- a/lib/features/tabs/presentation/widgets/variable_code_autocomplete.dart
+++ b/lib/features/tabs/presentation/widgets/variable_code_autocomplete.dart
@@ -1,0 +1,232 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:getman/core/theme/app_theme.dart';
+import 'package:getman/core/utils/layered_variable_context.dart';
+import 'package:getman/core/utils/variable_autocomplete_query.dart';
+import 'package:getman/core/utils/variable_resolution_helper.dart';
+import 'package:getman/core/utils/variable_suggestions.dart';
+import 'package:re_editor/re_editor.dart';
+
+/// Pure detection: the active `{{` query at [caret] in [line] and its ranked
+/// suggestions, or null when the caret is not inside an open `{{name` token.
+({String input, bool hasClosingBraces, List<VariableSuggestion> suggestions})?
+variablePromptsFor(LayeredVariableContext ctx, String line, int caret) {
+  final query = detectActiveVariableQuery(line, caret);
+  if (query == null) return null;
+  final suggestions = buildVariableSuggestions(
+    query: query.query,
+    userVariableNames: ctx.allVariables.keys,
+    classify: ctx.classify,
+  );
+  if (suggestions.isEmpty) return null;
+  return (
+    input: query.query,
+    hasClosingBraces: query.hasClosingBraces,
+    suggestions: suggestions,
+  );
+}
+
+/// The text to insert for an accepted [name]: the bare name when a closing
+/// `}}` already follows the caret, otherwise the name plus `}}`.
+String variableInsertionWord(String name, {required bool hasClosingBraces}) =>
+    hasClosingBraces ? name : '$name}}';
+
+/// A single variable suggestion as a re_editor [CodePrompt]. Carries the
+/// resolved closing-brace decision so `.autocomplete` inserts `name` or
+/// `name}}` correctly.
+class _VariableCodePrompt extends CodePrompt {
+  const _VariableCodePrompt({
+    required super.word, // the variable name (display + match key)
+    required this.hasClosingBraces,
+    required this.classification,
+  });
+
+  final bool hasClosingBraces;
+  final ResolvedVariable classification;
+
+  @override
+  bool match(String input) => word.toLowerCase().contains(input.toLowerCase());
+
+  @override
+  CodeAutocompleteResult get autocomplete {
+    final insert = variableInsertionWord(
+      word,
+      hasClosingBraces: hasClosingBraces,
+    );
+    // The editing value carries the typed query as its `input`; the editor
+    // deletes `[caret - input.length, caret]` (the typed query, after `{{`)
+    // and inserts `word`, leaving the `{{` and landing the caret after the
+    // insert. So this prompt's own `input` is empty.
+    return CodeAutocompleteResult(
+      input: '',
+      word: insert,
+      selection: TextSelection.collapsed(offset: insert.length),
+    );
+  }
+}
+
+/// re_editor prompts builder backed by the live [LayeredVariableContext].
+class VariablePromptsBuilder implements CodeAutocompletePromptsBuilder {
+  VariablePromptsBuilder(this.contextProvider);
+
+  final LayeredVariableContext Function() contextProvider;
+
+  @override
+  CodeAutocompleteEditingValue? build(
+    BuildContext context,
+    CodeLine codeLine,
+    CodeLineSelection selection,
+  ) {
+    if (!selection.isCollapsed) return null;
+    final found = variablePromptsFor(
+      contextProvider(),
+      codeLine.text,
+      selection.extentOffset,
+    );
+    if (found == null) return null;
+    return CodeAutocompleteEditingValue(
+      input: found.input,
+      prompts: [
+        for (final s in found.suggestions)
+          _VariableCodePrompt(
+            word: s.name,
+            hasClosingBraces: found.hasClosingBraces,
+            classification: s.classification,
+          ),
+      ],
+      index: 0,
+    );
+  }
+}
+
+/// Themed suggestion list for the body editor — mirrors the rows used by the
+/// TextField overlay (name + source + resolved preview).
+CodeAutocompleteWidgetBuilder get variableAutocompleteViewBuilder => _buildView;
+
+PreferredSizeWidget _buildView(
+  BuildContext context,
+  ValueNotifier<CodeAutocompleteEditingValue> notifier,
+  ValueChanged<CodeAutocompleteResult> onSelected,
+) => _VariableCodeAutocompleteList(notifier: notifier, onSelected: onSelected);
+
+const double _kRowHeight = 32;
+const double _kMenuWidth = 280;
+const double _kMaxMenuHeight = 240;
+
+class _VariableCodeAutocompleteList extends StatelessWidget
+    implements PreferredSizeWidget {
+  const _VariableCodeAutocompleteList({
+    required this.notifier,
+    required this.onSelected,
+  });
+
+  final ValueNotifier<CodeAutocompleteEditingValue> notifier;
+  final ValueChanged<CodeAutocompleteResult> onSelected;
+
+  @override
+  Size get preferredSize => Size(
+    _kMenuWidth,
+    math.min(_kRowHeight * notifier.value.prompts.length, _kMaxMenuHeight),
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<CodeAutocompleteEditingValue>(
+      valueListenable: notifier,
+      builder: (context, value, _) {
+        final palette = context.appPalette;
+        final layout = context.appLayout;
+        final theme = Theme.of(context);
+        return Container(
+          width: _kMenuWidth,
+          constraints: const BoxConstraints(maxHeight: _kMaxMenuHeight),
+          decoration: context.appDecoration.panelBox(context),
+          clipBehavior: Clip.antiAlias,
+          child: ListView.builder(
+            padding: EdgeInsets.zero,
+            shrinkWrap: true,
+            itemCount: value.prompts.length,
+            itemBuilder: (context, i) {
+              final prompt = value.prompts[i] as _VariableCodePrompt;
+              final c = prompt.classification;
+              final isSecret = c.kind == VariableValueKind.secret;
+              final isDynamic = c.kind == VariableValueKind.dynamicValue;
+              final preview = isSecret ? '••••' : (c.value ?? '');
+              final source = isDynamic ? 'dynamic' : (c.environmentName ?? '');
+              final muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+              return InkWell(
+                onTap: () => onSelected(value.copyWith(index: i).autocomplete),
+                child: Container(
+                  height: _kRowHeight,
+                  color: i == value.index
+                      ? theme.colorScheme.primary.withValues(alpha: 0.12)
+                      : null,
+                  padding: const EdgeInsets.symmetric(horizontal: 12),
+                  child: Row(
+                    children: [
+                      Flexible(
+                        child: Text(
+                          prompt.word,
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(
+                            fontSize: layout.fontSizeNormal,
+                            fontWeight: context.appTypography.titleWeight,
+                            color: isDynamic
+                                ? palette.variableResolved
+                                : theme.colorScheme.onSurface,
+                          ),
+                        ),
+                      ),
+                      if (source.isNotEmpty) ...[
+                        const SizedBox(width: 8),
+                        Text(
+                          source,
+                          style: TextStyle(
+                            fontSize: layout.fontSizeNormal,
+                            color: muted,
+                          ),
+                        ),
+                      ],
+                      if (preview.isNotEmpty) ...[
+                        const SizedBox(width: 12),
+                        Flexible(
+                          child: Text(
+                            preview,
+                            textAlign: TextAlign.right,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(
+                              fontSize: layout.fontSizeNormal,
+                              color: muted,
+                              fontStyle: isDynamic
+                                  ? FontStyle.italic
+                                  : FontStyle.normal,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+              );
+            },
+          ),
+        );
+      },
+    );
+  }
+}
+
+/// Wraps a body [child] (a `CodeEditor`) with variable autocomplete. Returns
+/// [child] unchanged when there are no variables (no empty overlay).
+Widget wrapBodyWithVariableAutocomplete({
+  required LayeredVariableContext Function() contextProvider,
+  required Widget child,
+}) {
+  if (contextProvider().isEmpty) return child;
+  return CodeAutocomplete(
+    viewBuilder: variableAutocompleteViewBuilder,
+    promptsBuilder: VariablePromptsBuilder(contextProvider),
+    child: child,
+  );
+}

--- a/lib/features/tabs/presentation/widgets/variable_code_autocomplete.dart
+++ b/lib/features/tabs/presentation/widgets/variable_code_autocomplete.dart
@@ -217,13 +217,15 @@ class _VariableCodeAutocompleteList extends StatelessWidget
   }
 }
 
-/// Wraps a body [child] (a `CodeEditor`) with variable autocomplete. Returns
-/// [child] unchanged when there are no variables (no empty overlay).
+/// Wraps a body [child] (a `CodeEditor`) with variable autocomplete. Always
+/// wraps: dynamic built-ins ({{$guid}}, {{$timestamp}}…) are suggestable even
+/// with no active environment, matching the URL bar. The `promptsBuilder`
+/// returns null (no overlay) when the caret isn't inside a `{{` token, so an
+/// empty context simply yields the dynamics for a matching query.
 Widget wrapBodyWithVariableAutocomplete({
   required LayeredVariableContext Function() contextProvider,
   required Widget child,
 }) {
-  if (contextProvider().isEmpty) return child;
   return CodeAutocomplete(
     viewBuilder: variableAutocompleteViewBuilder,
     promptsBuilder: VariablePromptsBuilder(contextProvider),

--- a/lib/features/tabs/presentation/widgets/variable_json_span_builder.dart
+++ b/lib/features/tabs/presentation/widgets/variable_json_span_builder.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:getman/core/utils/environment_resolver.dart';
+import 'package:getman/features/tabs/presentation/widgets/json_code_editor.dart'
+    show jsonHighlightSpanBuilder;
+import 'package:re_editor/re_editor.dart';
+
+/// JSON-highlights [codeLine], then recolors every `{{var}}` token: resolved
+/// (in [variables] or a dynamic built-in) -> [resolvedColor], else
+/// [unresolvedColor]. Variable color wins inside `{{…}}`. Implemented as a flat
+/// run merge so it never mutates a nested span tree.
+TextSpan variableAwareJsonSpan({
+  required BuildContext context,
+  required int index,
+  required CodeLine codeLine,
+  required TextSpan textSpan,
+  required TextStyle style,
+  required Map<String, String> variables,
+  required Color resolvedColor,
+  required Color unresolvedColor,
+}) {
+  final base = jsonHighlightSpanBuilder(
+    context: context,
+    index: index,
+    codeLine: codeLine,
+    textSpan: textSpan,
+    style: style,
+  );
+  final text = codeLine.text;
+  final matches = EnvironmentResolver.findVariables(text).toList();
+  if (matches.isEmpty) return base;
+
+  // 1. Flatten `base` into runs: List of (start, end, style).
+  final runs = <({int start, int end, TextStyle style})>[];
+  var cursor = 0;
+  void visit(InlineSpan span, TextStyle inherited) {
+    if (span is TextSpan) {
+      final s = span.style == null ? inherited : inherited.merge(span.style);
+      final t = span.text;
+      if (t != null && t.isNotEmpty) {
+        runs.add((start: cursor, end: cursor + t.length, style: s));
+        cursor += t.length;
+      }
+      for (final child in span.children ?? const <InlineSpan>[]) {
+        visit(child, s);
+      }
+    }
+  }
+
+  visit(base, style);
+  if (cursor == 0) {
+    // base had no leaf text (shouldn't happen) — fall back to whole-line style.
+    runs.add((start: 0, end: text.length, style: style));
+  }
+
+  // 2. Build a per-character color override for variable ranges.
+  Color? overrideAt(int i) {
+    for (final m in matches) {
+      if (i >= m.start && i < m.end) {
+        final resolved =
+            variables.containsKey(m.name) ||
+            EnvironmentResolver.isDynamic(m.name);
+        return resolved ? resolvedColor : unresolvedColor;
+      }
+    }
+    return null;
+  }
+
+  // 3. Re-emit runs, splitting where the variable override changes the color.
+  final children = <InlineSpan>[];
+  for (final run in runs) {
+    var i = run.start;
+    while (i < run.end) {
+      final color = overrideAt(i);
+      var j = i + 1;
+      while (j < run.end && overrideAt(j) == color) {
+        j++;
+      }
+      final segStyle = color == null
+          ? run.style
+          : run.style.copyWith(color: color, fontWeight: FontWeight.w800);
+      children.add(TextSpan(text: text.substring(i, j), style: segStyle));
+      i = j;
+    }
+  }
+  return TextSpan(style: style, children: children);
+}

--- a/test/core/ui/widgets/key_value_list_editor_test.dart
+++ b/test/core/ui/widgets/key_value_list_editor_test.dart
@@ -4,7 +4,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:getman/core/theme/themes/brutalist/brutalist_theme.dart';
 import 'package:getman/core/ui/widgets/key_value_list_editor.dart';
-import 'package:getman/core/ui/widgets/variable_hover_popover.dart';
+import 'package:getman/core/utils/layered_variable_context.dart';
 
 const _mapEquality = MapEquality<String, String>();
 
@@ -241,8 +241,8 @@ void main() {
                 if (key.isNotEmpty) key: value,
             },
             equals: const MapEquality<String, String>().equals,
-            variableContext: const VariableHoverContext(
-              variables: {'baseUrl': 'https://x', 'token': 't'},
+            variableContext: const LayeredVariableContext(
+              environmentVariables: {'baseUrl': 'https://x', 'token': 't'},
               environmentName: 'Dev',
             ),
             onChanged: (_) {},
@@ -276,8 +276,8 @@ void main() {
                   if (key.isNotEmpty) key: value,
               },
               equals: const MapEquality<String, String>().equals,
-              variableContext: const VariableHoverContext(
-                variables: {'baseUrl': 'https://x'},
+              variableContext: const LayeredVariableContext(
+                environmentVariables: {'baseUrl': 'https://x'},
                 environmentName: 'Dev',
               ),
               onChanged: (map) => emitted = map,

--- a/test/core/ui/widgets/tab_variable_context_builder_test.dart
+++ b/test/core/ui/widgets/tab_variable_context_builder_test.dart
@@ -1,0 +1,197 @@
+// Widget test for TabVariableContextBuilder — verifies that the widget
+// correctly assembles a LayeredVariableContext from live bloc state (env vars +
+// collection-node vars for the tab's linked node).
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/core/domain/entities/request_config_entity.dart';
+import 'package:getman/core/ui/widgets/tab_variable_context_builder.dart';
+import 'package:getman/core/utils/layered_variable_context.dart';
+import 'package:getman/features/collections/domain/entities/collection_node_entity.dart';
+import 'package:getman/features/collections/domain/repositories/collections_repository.dart';
+import 'package:getman/features/collections/domain/usecases/collections_usecases.dart';
+import 'package:getman/features/collections/presentation/bloc/collections_bloc.dart';
+import 'package:getman/features/collections/presentation/bloc/collections_event.dart';
+import 'package:getman/features/environments/domain/entities/environment_entity.dart';
+import 'package:getman/features/environments/domain/usecases/environments_usecases.dart';
+import 'package:getman/features/environments/presentation/bloc/environments_bloc.dart';
+import 'package:getman/features/settings/domain/entities/settings_entity.dart';
+import 'package:getman/features/settings/domain/usecases/settings_usecases.dart';
+import 'package:getman/features/settings/presentation/bloc/settings_bloc.dart';
+import 'package:getman/features/tabs/domain/entities/panel_entity.dart';
+import 'package:getman/features/tabs/domain/entities/request_tab_entity.dart';
+import 'package:getman/features/tabs/domain/repositories/tabs_repository.dart';
+import 'package:getman/features/tabs/domain/usecases/send_request_use_case.dart';
+import 'package:getman/features/tabs/presentation/bloc/tabs_bloc.dart';
+import 'package:getman/features/tabs/presentation/bloc/tabs_event.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockTabsRepository extends Mock implements TabsRepository {}
+
+class _MockSendRequestUseCase extends Mock implements SendRequestUseCase {}
+
+class _MockSaveSettingsUseCase extends Mock implements SaveSettingsUseCase {}
+
+class _MockGetEnvironmentsUseCase extends Mock
+    implements GetEnvironmentsUseCase {}
+
+class _MockSaveEnvironmentsUseCase extends Mock
+    implements SaveEnvironmentsUseCase {}
+
+class _MockPutEnvironmentUseCase extends Mock
+    implements PutEnvironmentUseCase {}
+
+class _MockDeleteEnvironmentUseCase extends Mock
+    implements DeleteEnvironmentUseCase {}
+
+class _MockCollectionsRepository extends Mock
+    implements CollectionsRepository {}
+
+class _FakeConfig extends Fake implements HttpRequestConfigEntity {}
+
+class _FakePanel extends Fake implements PanelEntity {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(_FakeConfig());
+    registerFallbackValue(_FakePanel());
+    registerFallbackValue(<CollectionNodeEntity>[]);
+    registerFallbackValue(
+      const HttpRequestTabEntity(
+        tabId: 'fallback',
+        config: HttpRequestConfigEntity(id: 'fallback'),
+      ),
+    );
+    registerFallbackValue(const SettingsEntity());
+  });
+
+  testWidgets('exposes env + collection layered context for the tab', (
+    tester,
+  ) async {
+    // --- Arrange ---
+
+    // Environment with a 'host' variable.
+    final env = EnvironmentEntity(
+      id: 'env1',
+      name: 'Production',
+      variables: const {'host': 'https://api.example.com'},
+    );
+
+    // Collection node (leaf) with a 'path' variable.
+    const node = CollectionNodeEntity(
+      id: 'node1',
+      name: 'GetUsers',
+      isFolder: false,
+      config: HttpRequestConfigEntity(id: 'node1'),
+      variables: {'path': '/v1'},
+    );
+
+    // Tab linked to the collection node.
+    const tab = HttpRequestTabEntity(
+      tabId: 'tab1',
+      config: HttpRequestConfigEntity(id: 'tab1', url: 'https://example.com'),
+      collectionNodeId: 'node1',
+    );
+
+    // --- Blocs ---
+
+    // SettingsBloc: active environment = env1.
+    final mockSaveSettings = _MockSaveSettingsUseCase();
+    when(() => mockSaveSettings(any())).thenAnswer((_) async {});
+    final settingsBloc = SettingsBloc(
+      saveSettingsUseCase: mockSaveSettings,
+      initialSettings: const SettingsEntity(activeEnvironmentId: 'env1'),
+    );
+    addTearDown(settingsBloc.close);
+
+    // EnvironmentsBloc: seeded synchronously via initialEnvironments so no
+    // async LoadEnvironments event is needed before pump.
+    final mockGetEnv = _MockGetEnvironmentsUseCase();
+    when(mockGetEnv.call).thenAnswer((_) async => [env]);
+    final environmentsBloc = EnvironmentsBloc(
+      getEnvironmentsUseCase: mockGetEnv,
+      saveEnvironmentsUseCase: _MockSaveEnvironmentsUseCase(),
+      putEnvironmentUseCase: _MockPutEnvironmentUseCase(),
+      deleteEnvironmentUseCase: _MockDeleteEnvironmentUseCase(),
+      initialEnvironments: [env],
+    );
+    addTearDown(environmentsBloc.close);
+
+    // TabsBloc: one panel containing the linked tab.
+    final tabsRepo = _MockTabsRepository();
+    when(() => tabsRepo.getPanels()).thenAnswer(
+      (_) async => [
+        PanelEntity(
+          id: 'p1',
+          name: 'Panel 1',
+          tabs: [tab],
+          activeTabId: tab.tabId,
+        ),
+      ],
+    );
+    when(() => tabsRepo.getActivePanelId()).thenAnswer((_) async => 'p1');
+    when(() => tabsRepo.saveTabs(any())).thenAnswer((_) async {});
+    when(() => tabsRepo.putTab(any())).thenAnswer((_) async {});
+    when(() => tabsRepo.deleteTabs(any())).thenAnswer((_) async {});
+    when(() => tabsRepo.saveTabOrder(any())).thenAnswer((_) async {});
+    when(() => tabsRepo.putPanel(any())).thenAnswer((_) async {});
+    when(() => tabsRepo.deletePanels(any())).thenAnswer((_) async {});
+    when(() => tabsRepo.savePanelMeta(any(), any())).thenAnswer((_) async {});
+
+    final tabsBloc = TabsBloc(
+      repository: tabsRepo,
+      sendRequestUseCase: _MockSendRequestUseCase(),
+    )..add(const LoadTabs());
+    await tabsBloc.stream.firstWhere((s) => !s.isLoading && s.tabs.isNotEmpty);
+    addTearDown(tabsBloc.close);
+
+    // CollectionsBloc: seeded with the node carrying 'path' = '/v1'.
+    final collectionsRepo = _MockCollectionsRepository();
+    when(
+      () => collectionsRepo.getCollections(),
+    ).thenAnswer((_) async => const []);
+    when(
+      () => collectionsRepo.saveCollections(any()),
+    ).thenAnswer((_) async {});
+
+    final collectionsBloc = CollectionsBloc(
+      getCollectionsUseCase: GetCollectionsUseCase(collectionsRepo),
+      saveCollectionsUseCase: SaveCollectionsUseCase(collectionsRepo),
+      saveDebounce: const Duration(milliseconds: 5),
+    )..add(const ReplaceCollections([node]));
+    await collectionsBloc.stream.first;
+    addTearDown(collectionsBloc.close);
+
+    // --- Capture the context ---
+    late LayeredVariableContext captured;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: MultiBlocProvider(
+            providers: [
+              BlocProvider.value(value: settingsBloc),
+              BlocProvider.value(value: environmentsBloc),
+              BlocProvider.value(value: tabsBloc),
+              BlocProvider.value(value: collectionsBloc),
+            ],
+            child: TabVariableContextBuilder(
+              tabId: 'tab1',
+              builder: (_, ctx) {
+                captured = ctx;
+                return const SizedBox();
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // --- Assert ---
+    expect(captured.environmentVariables['host'], 'https://api.example.com');
+    expect(captured.collectionVariables['path'], '/v1');
+    expect(captured.allVariables.keys, containsAll(['host', 'path']));
+  });
+}

--- a/test/core/ui/widgets/tab_variable_context_builder_test.dart
+++ b/test/core/ui/widgets/tab_variable_context_builder_test.dart
@@ -120,17 +120,17 @@ void main() {
 
     // TabsBloc: one panel containing the linked tab.
     final tabsRepo = _MockTabsRepository();
-    when(() => tabsRepo.getPanels()).thenAnswer(
+    when(tabsRepo.getPanels).thenAnswer(
       (_) async => [
         PanelEntity(
           id: 'p1',
           name: 'Panel 1',
-          tabs: [tab],
+          tabs: const [tab],
           activeTabId: tab.tabId,
         ),
       ],
     );
-    when(() => tabsRepo.getActivePanelId()).thenAnswer((_) async => 'p1');
+    when(tabsRepo.getActivePanelId).thenAnswer((_) async => 'p1');
     when(() => tabsRepo.saveTabs(any())).thenAnswer((_) async {});
     when(() => tabsRepo.putTab(any())).thenAnswer((_) async {});
     when(() => tabsRepo.deleteTabs(any())).thenAnswer((_) async {});
@@ -148,9 +148,7 @@ void main() {
 
     // CollectionsBloc: seeded with the node carrying 'path' = '/v1'.
     final collectionsRepo = _MockCollectionsRepository();
-    when(
-      () => collectionsRepo.getCollections(),
-    ).thenAnswer((_) async => const []);
+    when(collectionsRepo.getCollections).thenAnswer((_) async => const []);
     when(
       () => collectionsRepo.saveCollections(any()),
     ).thenAnswer((_) async {});

--- a/test/core/ui/widgets/variable_text_field_test.dart
+++ b/test/core/ui/widgets/variable_text_field_test.dart
@@ -59,6 +59,32 @@ void main() {
     expect(controller.text, '{{host}}');
   });
 
+  testWidgets('style parameter is forwarded to the inner TextField', (
+    tester,
+  ) async {
+    const testStyle = TextStyle(fontSize: 21, fontWeight: FontWeight.w900);
+    final controller = VariableHighlightController();
+    final focus = FocusNode();
+    addTearDown(controller.dispose);
+    addTearDown(focus.dispose);
+
+    await tester.pumpWidget(
+      _host(
+        VariableTextField(
+          variables: ctx,
+          controller: controller,
+          focusNode: focus,
+          onChanged: (_) {},
+          style: testStyle,
+        ),
+      ),
+    );
+
+    final tf = tester.widget<TextField>(find.byType(TextField));
+    expect(tf.style?.fontSize, 21);
+    expect(tf.style?.fontWeight, FontWeight.w900);
+  });
+
   testWidgets('empty context renders a plain field with no overlay', (
     tester,
   ) async {

--- a/test/core/ui/widgets/variable_text_field_test.dart
+++ b/test/core/ui/widgets/variable_text_field_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/core/theme/theme_registry.dart';
+import 'package:getman/core/ui/widgets/variable_highlight_controller.dart';
+import 'package:getman/core/ui/widgets/variable_text_field.dart';
+import 'package:getman/core/utils/layered_variable_context.dart';
+
+Widget _host(Widget child) => MaterialApp(
+  theme: resolveTheme('brutalist')(Brightness.light),
+  home: Scaffold(body: child),
+);
+
+void main() {
+  const ctx = LayeredVariableContext(
+    environmentVariables: {'host': 'example.com', 'token': 'abc'},
+    environmentName: 'Staging',
+  );
+
+  testWidgets('typing {{ opens the suggestion overlay', (tester) async {
+    final controller = VariableHighlightController();
+    final focus = FocusNode();
+    await tester.pumpWidget(
+      _host(
+        VariableTextField(
+          variables: ctx,
+          controller: controller,
+          focusNode: focus,
+          onChanged: (_) {},
+        ),
+      ),
+    );
+    await tester.tap(find.byType(TextField));
+    await tester.enterText(find.byType(TextField), '{{');
+    await tester.pumpAndSettle();
+
+    expect(find.text('host'), findsOneWidget);
+    expect(find.text('token'), findsOneWidget);
+  });
+
+  testWidgets('accepting a suggestion inserts {{name}}', (tester) async {
+    final controller = VariableHighlightController();
+    final focus = FocusNode();
+    await tester.pumpWidget(
+      _host(
+        VariableTextField(
+          variables: ctx,
+          controller: controller,
+          focusNode: focus,
+          onChanged: (_) {},
+        ),
+      ),
+    );
+    await tester.tap(find.byType(TextField));
+    await tester.enterText(find.byType(TextField), '{{ho');
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('host'));
+    await tester.pumpAndSettle();
+
+    expect(controller.text, '{{host}}');
+  });
+
+  testWidgets('empty context renders a plain field with no overlay', (
+    tester,
+  ) async {
+    final controller = VariableHighlightController();
+    final focus = FocusNode();
+    await tester.pumpWidget(
+      _host(
+        VariableTextField(
+          variables: LayeredVariableContext.empty,
+          controller: controller,
+          focusNode: focus,
+          onChanged: (_) {},
+        ),
+      ),
+    );
+    await tester.tap(find.byType(TextField));
+    await tester.enterText(find.byType(TextField), '{{');
+    await tester.pumpAndSettle();
+    // No suggestions to show.
+    expect(find.byType(ListView), findsNothing);
+  });
+}

--- a/test/core/ui/widgets/variable_text_field_test.dart
+++ b/test/core/ui/widgets/variable_text_field_test.dart
@@ -85,25 +85,34 @@ void main() {
     expect(tf.style?.fontWeight, FontWeight.w900);
   });
 
-  testWidgets('empty context renders a plain field with no overlay', (
-    tester,
-  ) async {
-    final controller = VariableHighlightController();
-    final focus = FocusNode();
-    await tester.pumpWidget(
-      _host(
-        VariableTextField(
-          variables: LayeredVariableContext.empty,
-          controller: controller,
-          focusNode: focus,
-          onChanged: (_) {},
+  testWidgets(
+    'with no env/collection vars, {{ still offers dynamic variables',
+    (tester) async {
+      // Regression: when no environment is active (allVariables empty), the
+      // field must still offer dynamic built-ins ({{$guid}}, {{$timestamp}}…),
+      // exactly like the URL bar — not degrade to a plain field. Dynamics are
+      // always suggestable, so the overlay must appear.
+      final controller = VariableHighlightController();
+      final focus = FocusNode();
+      addTearDown(() {
+        controller.dispose();
+        focus.dispose();
+      });
+      await tester.pumpWidget(
+        _host(
+          VariableTextField(
+            variables: LayeredVariableContext.empty,
+            controller: controller,
+            focusNode: focus,
+            onChanged: (_) {},
+          ),
         ),
-      ),
-    );
-    await tester.tap(find.byType(TextField));
-    await tester.enterText(find.byType(TextField), '{{');
-    await tester.pumpAndSettle();
-    // No suggestions to show.
-    expect(find.byType(ListView), findsNothing);
-  });
+      );
+      await tester.tap(find.byType(TextField));
+      await tester.enterText(find.byType(TextField), '{{time');
+      await tester.pumpAndSettle();
+
+      expect(find.text(r'$timestamp'), findsOneWidget);
+    },
+  );
 }

--- a/test/core/utils/layered_variable_context_test.dart
+++ b/test/core/utils/layered_variable_context_test.dart
@@ -8,7 +8,6 @@ void main() {
       environmentVariables: {'host': 'env.example.com', 'token': 'secret'},
       environmentSecrets: {'token'},
       collectionVariables: {'host': 'col.example.com', 'path': '/v1'},
-      collectionSecrets: {},
       environmentName: 'Staging',
     );
 

--- a/test/core/utils/layered_variable_context_test.dart
+++ b/test/core/utils/layered_variable_context_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/core/utils/layered_variable_context.dart';
+import 'package:getman/core/utils/variable_resolution_helper.dart';
+
+void main() {
+  group('LayeredVariableContext', () {
+    const ctx = LayeredVariableContext(
+      environmentVariables: {'host': 'env.example.com', 'token': 'secret'},
+      environmentSecrets: {'token'},
+      collectionVariables: {'host': 'col.example.com', 'path': '/v1'},
+      collectionSecrets: {},
+      environmentName: 'Staging',
+    );
+
+    test('allVariables merges with environment winning', () {
+      expect(ctx.allVariables['host'], 'env.example.com'); // env wins
+      expect(ctx.allVariables['path'], '/v1'); // collection-only kept
+      expect(ctx.allVariables.keys, containsAll(['host', 'token', 'path']));
+    });
+
+    test('allSecretKeys unions both layers', () {
+      expect(ctx.allSecretKeys, contains('token'));
+    });
+
+    test('classify reports environment source and secret kind', () {
+      final t = ctx.classify('token');
+      expect(t.kind, VariableValueKind.secret);
+      expect(t.environmentName, 'Staging');
+    });
+
+    test('classify reports Collection source for collection-only var', () {
+      final p = ctx.classify('path');
+      expect(p.kind, VariableValueKind.resolved);
+      expect(p.environmentName, 'Collection');
+    });
+
+    test('classify resolves dynamics and marks unknown unresolved', () {
+      expect(ctx.classify(r'$guid').kind, VariableValueKind.dynamicValue);
+      expect(ctx.classify('nope').kind, VariableValueKind.unresolved);
+    });
+
+    test('empty context isEmpty', () {
+      expect(LayeredVariableContext.empty.isEmpty, isTrue);
+      expect(ctx.isEmpty, isFalse);
+    });
+  });
+}

--- a/test/features/tabs/presentation/widgets/auth_tab_view_test.dart
+++ b/test/features/tabs/presentation/widgets/auth_tab_view_test.dart
@@ -1,12 +1,22 @@
 // Widget tests for AuthTabView: scheme selection reveals the right fields and
 // edits round-trip into the tab's config.auth map. Uses a real TabsBloc fed by
-// a mocked repository + use case (same pattern as response_section_test.dart).
+// a mocked repository + use case alongside SettingsBloc, EnvironmentsBloc, and
+// CollectionsBloc (required by TabVariableContextBuilder).
 
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:getman/core/domain/entities/request_config_entity.dart';
 import 'package:getman/core/theme/themes/brutalist/brutalist_theme.dart';
+import 'package:getman/features/collections/domain/entities/collection_node_entity.dart';
+import 'package:getman/features/collections/domain/usecases/collections_usecases.dart';
+import 'package:getman/features/collections/presentation/bloc/collections_bloc.dart';
+import 'package:getman/features/environments/domain/entities/environment_entity.dart';
+import 'package:getman/features/environments/domain/usecases/environments_usecases.dart';
+import 'package:getman/features/environments/presentation/bloc/environments_bloc.dart';
+import 'package:getman/features/settings/domain/entities/settings_entity.dart';
+import 'package:getman/features/settings/domain/usecases/settings_usecases.dart';
+import 'package:getman/features/settings/presentation/bloc/settings_bloc.dart';
 import 'package:getman/features/tabs/domain/entities/panel_entity.dart';
 import 'package:getman/features/tabs/domain/entities/request_tab_entity.dart';
 import 'package:getman/features/tabs/domain/repositories/tabs_repository.dart';
@@ -20,9 +30,56 @@ class MockTabsRepository extends Mock implements TabsRepository {}
 
 class MockSendRequestUseCase extends Mock implements SendRequestUseCase {}
 
+class MockSaveSettingsUseCase extends Mock implements SaveSettingsUseCase {}
+
+class MockGetEnvironmentsUseCase extends Mock
+    implements GetEnvironmentsUseCase {}
+
+class MockSaveEnvironmentsUseCase extends Mock
+    implements SaveEnvironmentsUseCase {}
+
+class MockPutEnvironmentUseCase extends Mock implements PutEnvironmentUseCase {}
+
+class MockDeleteEnvironmentUseCase extends Mock
+    implements DeleteEnvironmentUseCase {}
+
+class MockGetCollectionsUseCase extends Mock implements GetCollectionsUseCase {}
+
+class MockSaveCollectionsUseCase extends Mock
+    implements SaveCollectionsUseCase {}
+
 class _FakeConfig extends Fake implements HttpRequestConfigEntity {}
 
 class _FakePanel extends Fake implements PanelEntity {}
+
+SettingsBloc _settingsBloc(SettingsEntity settings) {
+  final save = MockSaveSettingsUseCase();
+  when(() => save(any())).thenAnswer((_) async {});
+  return SettingsBloc(saveSettingsUseCase: save, initialSettings: settings);
+}
+
+EnvironmentsBloc _environmentsBloc([
+  List<EnvironmentEntity> environments = const [],
+]) {
+  final get = MockGetEnvironmentsUseCase();
+  when(get.call).thenAnswer((_) async => environments);
+  return EnvironmentsBloc(
+    getEnvironmentsUseCase: get,
+    saveEnvironmentsUseCase: MockSaveEnvironmentsUseCase(),
+    putEnvironmentUseCase: MockPutEnvironmentUseCase(),
+    deleteEnvironmentUseCase: MockDeleteEnvironmentUseCase(),
+    initialEnvironments: environments,
+  );
+}
+
+CollectionsBloc _collectionsBloc() {
+  final get = MockGetCollectionsUseCase();
+  when(get.call).thenAnswer((_) async => const <CollectionNodeEntity>[]);
+  return CollectionsBloc(
+    getCollectionsUseCase: get,
+    saveCollectionsUseCase: MockSaveCollectionsUseCase(),
+  );
+}
 
 Future<TabsBloc> _loadedBloc(
   MockTabsRepository repository,
@@ -46,13 +103,33 @@ Future<TabsBloc> _loadedBloc(
   return bloc;
 }
 
-Future<void> _pump(WidgetTester tester, TabsBloc bloc, String tabId) async {
+Future<void> _pump(
+  WidgetTester tester,
+  TabsBloc bloc,
+  String tabId, {
+  List<EnvironmentEntity> environments = const [],
+  String? activeEnvironmentId,
+}) async {
+  final settingsBloc = _settingsBloc(
+    SettingsEntity(activeEnvironmentId: activeEnvironmentId),
+  );
+  addTearDown(settingsBloc.close);
+  final environmentsBloc = _environmentsBloc(environments);
+  addTearDown(environmentsBloc.close);
+  final collectionsBloc = _collectionsBloc();
+  addTearDown(collectionsBloc.close);
+
   await tester.pumpWidget(
     MaterialApp(
       theme: brutalistTheme(Brightness.light),
       home: Scaffold(
-        body: BlocProvider.value(
-          value: bloc,
+        body: MultiBlocProvider(
+          providers: [
+            BlocProvider.value(value: bloc),
+            BlocProvider<SettingsBloc>.value(value: settingsBloc),
+            BlocProvider<EnvironmentsBloc>.value(value: environmentsBloc),
+            BlocProvider<CollectionsBloc>.value(value: collectionsBloc),
+          ],
           child: AuthTabView(tabId: tabId),
         ),
       ),
@@ -74,6 +151,7 @@ void main() {
         config: HttpRequestConfigEntity(id: 'fallback'),
       ),
     );
+    registerFallbackValue(const SettingsEntity());
   });
 
   setUp(() {
@@ -193,4 +271,52 @@ void main() {
 
     await tester.pump(const Duration(seconds: 11));
   });
+
+  testWidgets(
+    'TOKEN field shows {{var}} autocomplete overlay and accepts suggestion',
+    (tester) async {
+      final env = EnvironmentEntity(
+        id: 'env1',
+        name: 'Test',
+        variables: const {'host': 'example.com'},
+      );
+      final bloc = await _loadedBloc(
+        repository,
+        sendRequestUseCase,
+        tabWithAuth('t', const {'type': 'bearer', 'token': ''}),
+      );
+      addTearDown(bloc.close);
+
+      await _pump(
+        tester,
+        bloc,
+        't',
+        environments: [env],
+        activeEnvironmentId: 'env1',
+      );
+
+      // Enter text that triggers autocomplete for the 'host' variable.
+      await tester.enterText(
+        find.byKey(const ValueKey('auth_field_TOKEN')),
+        '{{ho',
+      );
+      await tester.pumpAndSettle();
+
+      // The 'host' suggestion must appear in the overlay.
+      expect(find.text('host'), findsOneWidget);
+
+      // Tap the suggestion to accept it.
+      await tester.tap(find.text('host'));
+      await tester.pumpAndSettle();
+
+      // The token in the bloc state should be fully completed.
+      expect(
+        bloc.state.tabs.byId('t')!.config.auth['token'],
+        '{{host}}',
+      );
+
+      // Flush the debounced-save timer.
+      await tester.pump(const Duration(seconds: 11));
+    },
+  );
 }

--- a/test/features/tabs/presentation/widgets/body_tab_view_test.dart
+++ b/test/features/tabs/presentation/widgets/body_tab_view_test.dart
@@ -8,6 +8,14 @@ import 'package:getman/core/domain/entities/body_type.dart';
 import 'package:getman/core/domain/entities/multipart_field_entity.dart';
 import 'package:getman/core/domain/entities/request_config_entity.dart';
 import 'package:getman/core/theme/themes/brutalist/brutalist_theme.dart';
+import 'package:getman/features/collections/domain/entities/collection_node_entity.dart';
+import 'package:getman/features/collections/domain/usecases/collections_usecases.dart';
+import 'package:getman/features/collections/presentation/bloc/collections_bloc.dart';
+import 'package:getman/features/environments/domain/usecases/environments_usecases.dart';
+import 'package:getman/features/environments/presentation/bloc/environments_bloc.dart';
+import 'package:getman/features/settings/domain/entities/settings_entity.dart';
+import 'package:getman/features/settings/domain/usecases/settings_usecases.dart';
+import 'package:getman/features/settings/presentation/bloc/settings_bloc.dart';
 import 'package:getman/features/tabs/domain/entities/panel_entity.dart';
 import 'package:getman/features/tabs/domain/entities/request_tab_entity.dart';
 import 'package:getman/features/tabs/domain/repositories/tabs_repository.dart';
@@ -23,9 +31,62 @@ class MockTabsRepository extends Mock implements TabsRepository {}
 
 class MockSendRequestUseCase extends Mock implements SendRequestUseCase {}
 
+class _MockSaveSettingsUseCase extends Mock implements SaveSettingsUseCase {}
+
+class _MockGetEnvironmentsUseCase extends Mock
+    implements GetEnvironmentsUseCase {}
+
+class _MockSaveEnvironmentsUseCase extends Mock
+    implements SaveEnvironmentsUseCase {}
+
+class _MockPutEnvironmentUseCase extends Mock
+    implements PutEnvironmentUseCase {}
+
+class _MockDeleteEnvironmentUseCase extends Mock
+    implements DeleteEnvironmentUseCase {}
+
+class _MockGetCollectionsUseCase extends Mock
+    implements GetCollectionsUseCase {}
+
+class _MockSaveCollectionsUseCase extends Mock
+    implements SaveCollectionsUseCase {}
+
 class _FakeConfig extends Fake implements HttpRequestConfigEntity {}
 
 class _FakePanel extends Fake implements PanelEntity {}
+
+// Minimal SettingsBloc with no active environment (no env/collection vars;
+// dynamic built-ins remain suggestable, so fields still wire autocomplete).
+SettingsBloc _settingsBloc() {
+  final save = _MockSaveSettingsUseCase();
+  when(() => save(any())).thenAnswer((_) async {});
+  return SettingsBloc(
+    saveSettingsUseCase: save,
+    initialSettings: const SettingsEntity(),
+  );
+}
+
+// Minimal EnvironmentsBloc with no environments.
+EnvironmentsBloc _environmentsBloc() {
+  final get = _MockGetEnvironmentsUseCase();
+  when(get.call).thenAnswer((_) async => const []);
+  return EnvironmentsBloc(
+    getEnvironmentsUseCase: get,
+    saveEnvironmentsUseCase: _MockSaveEnvironmentsUseCase(),
+    putEnvironmentUseCase: _MockPutEnvironmentUseCase(),
+    deleteEnvironmentUseCase: _MockDeleteEnvironmentUseCase(),
+  );
+}
+
+// Minimal CollectionsBloc with no collections.
+CollectionsBloc _collectionsBloc() {
+  final get = _MockGetCollectionsUseCase();
+  when(get.call).thenAnswer((_) async => const <CollectionNodeEntity>[]);
+  return CollectionsBloc(
+    getCollectionsUseCase: get,
+    saveCollectionsUseCase: _MockSaveCollectionsUseCase(),
+  );
+}
 
 Future<TabsBloc> _loadedBloc(
   MockTabsRepository repository,
@@ -57,12 +118,26 @@ Future<CodeLineEditingController> _pump(
   final controller = CodeLineEditingController();
   final variablesController = CodeLineEditingController();
   addTearDown(variablesController.dispose);
+  // TabVariableContextBuilder (used by FormDataEditor + the body editor)
+  // requires all four blocs. Build eagerly — when() stubs must not run inside
+  // pumpWidget callbacks. Close via addTearDown so handlers don't outlive it.
+  final settingsBloc = _settingsBloc();
+  addTearDown(settingsBloc.close);
+  final environmentsBloc = _environmentsBloc();
+  addTearDown(environmentsBloc.close);
+  final collectionsBloc = _collectionsBloc();
+  addTearDown(collectionsBloc.close);
   await tester.pumpWidget(
     MaterialApp(
       theme: brutalistTheme(Brightness.light),
       home: Scaffold(
-        body: BlocProvider.value(
-          value: bloc,
+        body: MultiBlocProvider(
+          providers: [
+            BlocProvider.value(value: bloc),
+            BlocProvider<SettingsBloc>.value(value: settingsBloc),
+            BlocProvider<EnvironmentsBloc>.value(value: environmentsBloc),
+            BlocProvider<CollectionsBloc>.value(value: collectionsBloc),
+          ],
           child: BodyTabView(
             tabId: tabId,
             controller: controller,
@@ -89,6 +164,9 @@ void main() {
         config: HttpRequestConfigEntity(id: 'fallback'),
       ),
     );
+    // Required by _settingsBloc() → when(() => save(any())) where save takes
+    // a SettingsEntity; mocktail needs a fallback for sound null safety.
+    registerFallbackValue(const SettingsEntity());
   });
 
   setUp(() {

--- a/test/features/tabs/presentation/widgets/bulk_kv_toggle_test.dart
+++ b/test/features/tabs/presentation/widgets/bulk_kv_toggle_test.dart
@@ -1,10 +1,11 @@
 // Widget tests for the row⇄bulk edit toggle on the PARAMS and HEADERS tabs.
 //
 // Both tab views require a TabsBloc (the canonical value + UpdateTab path),
-// plus SettingsBloc + EnvironmentsBloc (read by _VariableContextBuilder even
-// when no environment is active). The toggle flips between the row editor
-// (KeyValueListEditor) and the bulk editor (BulkKvEditor); both feed the same
-// encode/decode closures, so the round-trip is lossless.
+// plus SettingsBloc + EnvironmentsBloc + CollectionsBloc (read by
+// TabVariableContextBuilder even when no environment/collection is active).
+// The toggle flips between the row editor (KeyValueListEditor) and the bulk
+// editor (BulkKvEditor); both feed the same encode/decode closures, so the
+// round-trip is lossless.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -13,6 +14,9 @@ import 'package:getman/core/domain/entities/request_config_entity.dart';
 import 'package:getman/core/theme/themes/brutalist/brutalist_theme.dart';
 import 'package:getman/core/ui/widgets/bulk_kv_editor.dart';
 import 'package:getman/core/ui/widgets/key_value_list_editor.dart';
+import 'package:getman/features/collections/domain/entities/collection_node_entity.dart';
+import 'package:getman/features/collections/domain/usecases/collections_usecases.dart';
+import 'package:getman/features/collections/presentation/bloc/collections_bloc.dart';
 import 'package:getman/features/environments/domain/entities/environment_entity.dart';
 import 'package:getman/features/environments/domain/usecases/environments_usecases.dart';
 import 'package:getman/features/environments/presentation/bloc/environments_bloc.dart';
@@ -45,6 +49,11 @@ class MockPutEnvironmentUseCase extends Mock implements PutEnvironmentUseCase {}
 class MockDeleteEnvironmentUseCase extends Mock
     implements DeleteEnvironmentUseCase {}
 
+class MockGetCollectionsUseCase extends Mock implements GetCollectionsUseCase {}
+
+class MockSaveCollectionsUseCase extends Mock
+    implements SaveCollectionsUseCase {}
+
 class _FakeConfig extends Fake implements HttpRequestConfigEntity {}
 
 class _FakePanel extends Fake implements PanelEntity {}
@@ -69,6 +78,17 @@ EnvironmentsBloc _environmentsBloc() {
     saveEnvironmentsUseCase: MockSaveEnvironmentsUseCase(),
     putEnvironmentUseCase: MockPutEnvironmentUseCase(),
     deleteEnvironmentUseCase: MockDeleteEnvironmentUseCase(),
+  );
+}
+
+/// A [CollectionsBloc] with no collections — required by
+/// TabVariableContextBuilder even when the tab has no linked node.
+CollectionsBloc _collectionsBloc() {
+  final get = MockGetCollectionsUseCase();
+  when(get.call).thenAnswer((_) async => const <CollectionNodeEntity>[]);
+  return CollectionsBloc(
+    getCollectionsUseCase: get,
+    saveCollectionsUseCase: MockSaveCollectionsUseCase(),
   );
 }
 
@@ -126,13 +146,15 @@ void main() {
   });
 
   Future<void> pumpTab(WidgetTester tester, TabsBloc bloc, Widget child) async {
-    // Build the settings + environments blocs eagerly (their mock use-case
-    // stubbing must not run inside a BlocProvider `create:` callback during
-    // pump — mocktail forbids calling `when` mid-stub).
+    // Build the settings + environments + collections blocs eagerly (their mock
+    // use-case stubbing must not run inside a BlocProvider `create:` callback
+    // during pump — mocktail forbids calling `when` mid-stub).
     final settingsBloc = _settingsBloc(const SettingsEntity());
     addTearDown(settingsBloc.close);
     final environmentsBloc = _environmentsBloc();
     addTearDown(environmentsBloc.close);
+    final collectionsBloc = _collectionsBloc();
+    addTearDown(collectionsBloc.close);
     await tester.pumpWidget(
       MaterialApp(
         theme: brutalistTheme(Brightness.light),
@@ -142,6 +164,7 @@ void main() {
               BlocProvider.value(value: bloc),
               BlocProvider<SettingsBloc>.value(value: settingsBloc),
               BlocProvider<EnvironmentsBloc>.value(value: environmentsBloc),
+              BlocProvider<CollectionsBloc>.value(value: collectionsBloc),
             ],
             child: child,
           ),

--- a/test/features/tabs/presentation/widgets/form_data_editor_test.dart
+++ b/test/features/tabs/presentation/widgets/form_data_editor_test.dart
@@ -1,0 +1,255 @@
+// Widget tests for form-data value-field variable autocomplete.
+//
+// Verifies that non-file VALUE fields in FormDataEditor offer {{var}}
+// autocomplete (via VariableTextField) while the KEY/name field remains a
+// plain TextField with no autocomplete overlay.
+//
+// Uses the same four-bloc harness as bulk_kv_toggle_test.dart because
+// TabVariableContextBuilder reads SettingsBloc + EnvironmentsBloc +
+// CollectionsBloc + TabsBloc.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/core/domain/entities/multipart_field_entity.dart';
+import 'package:getman/core/domain/entities/request_config_entity.dart';
+import 'package:getman/core/theme/themes/brutalist/brutalist_theme.dart';
+import 'package:getman/features/collections/domain/entities/collection_node_entity.dart';
+import 'package:getman/features/collections/domain/usecases/collections_usecases.dart';
+import 'package:getman/features/collections/presentation/bloc/collections_bloc.dart';
+import 'package:getman/features/environments/domain/entities/environment_entity.dart';
+import 'package:getman/features/environments/domain/usecases/environments_usecases.dart';
+import 'package:getman/features/environments/presentation/bloc/environments_bloc.dart';
+import 'package:getman/features/settings/domain/entities/settings_entity.dart';
+import 'package:getman/features/settings/domain/usecases/settings_usecases.dart';
+import 'package:getman/features/settings/presentation/bloc/settings_bloc.dart';
+import 'package:getman/features/tabs/domain/entities/panel_entity.dart';
+import 'package:getman/features/tabs/domain/entities/request_tab_entity.dart';
+import 'package:getman/features/tabs/domain/repositories/tabs_repository.dart';
+import 'package:getman/features/tabs/domain/usecases/send_request_use_case.dart';
+import 'package:getman/features/tabs/presentation/bloc/tabs_bloc.dart';
+import 'package:getman/features/tabs/presentation/bloc/tabs_event.dart';
+import 'package:getman/features/tabs/presentation/widgets/form_data_editor.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockTabsRepository extends Mock implements TabsRepository {}
+
+class _MockSendRequestUseCase extends Mock implements SendRequestUseCase {}
+
+class _MockSaveSettingsUseCase extends Mock implements SaveSettingsUseCase {}
+
+class _MockGetEnvironmentsUseCase extends Mock
+    implements GetEnvironmentsUseCase {}
+
+class _MockSaveEnvironmentsUseCase extends Mock
+    implements SaveEnvironmentsUseCase {}
+
+class _MockPutEnvironmentUseCase extends Mock
+    implements PutEnvironmentUseCase {}
+
+class _MockDeleteEnvironmentUseCase extends Mock
+    implements DeleteEnvironmentUseCase {}
+
+class _MockGetCollectionsUseCase extends Mock
+    implements GetCollectionsUseCase {}
+
+class _MockSaveCollectionsUseCase extends Mock
+    implements SaveCollectionsUseCase {}
+
+class _FakeConfig extends Fake implements HttpRequestConfigEntity {}
+
+class _FakePanel extends Fake implements PanelEntity {}
+
+// A pre-built environment with a single variable so we can assert on it.
+final _env = EnvironmentEntity(
+  id: 'env1',
+  name: 'Test',
+  variables: const {'host': 'example.com'},
+);
+
+SettingsBloc _settingsBloc() {
+  final save = _MockSaveSettingsUseCase();
+  when(() => save(any())).thenAnswer((_) async {});
+  return SettingsBloc(
+    saveSettingsUseCase: save,
+    initialSettings: const SettingsEntity().copyWith(
+      activeEnvironmentId: 'env1',
+    ),
+  );
+}
+
+EnvironmentsBloc _environmentsBloc() {
+  final get = _MockGetEnvironmentsUseCase();
+  when(get.call).thenAnswer((_) async => [_env]);
+  return EnvironmentsBloc(
+    getEnvironmentsUseCase: get,
+    saveEnvironmentsUseCase: _MockSaveEnvironmentsUseCase(),
+    putEnvironmentUseCase: _MockPutEnvironmentUseCase(),
+    deleteEnvironmentUseCase: _MockDeleteEnvironmentUseCase(),
+    initialEnvironments: [_env],
+  );
+}
+
+CollectionsBloc _collectionsBloc() {
+  final get = _MockGetCollectionsUseCase();
+  when(get.call).thenAnswer((_) async => const <CollectionNodeEntity>[]);
+  return CollectionsBloc(
+    getCollectionsUseCase: get,
+    saveCollectionsUseCase: _MockSaveCollectionsUseCase(),
+  );
+}
+
+Future<TabsBloc> _loadedBloc(
+  _MockTabsRepository repository,
+  _MockSendRequestUseCase useCase,
+  HttpRequestTabEntity tab,
+) async {
+  when(() => repository.getPanels()).thenAnswer(
+    (_) async => [
+      PanelEntity(
+        id: 'p1',
+        name: 'Panel 1',
+        tabs: [tab],
+        activeTabId: tab.tabId,
+      ),
+    ],
+  );
+  when(() => repository.getActivePanelId()).thenAnswer((_) async => 'p1');
+  final bloc = TabsBloc(repository: repository, sendRequestUseCase: useCase)
+    ..add(const LoadTabs());
+  await bloc.stream.firstWhere((s) => !s.isLoading && s.tabs.isNotEmpty);
+  return bloc;
+}
+
+void main() {
+  late _MockTabsRepository repository;
+  late _MockSendRequestUseCase sendRequestUseCase;
+
+  setUpAll(() {
+    registerFallbackValue(_FakeConfig());
+    registerFallbackValue(_FakePanel());
+    registerFallbackValue(
+      const HttpRequestTabEntity(
+        tabId: 'fallback',
+        config: HttpRequestConfigEntity(id: 'fallback'),
+      ),
+    );
+    registerFallbackValue(const SettingsEntity());
+  });
+
+  setUp(() {
+    repository = _MockTabsRepository();
+    sendRequestUseCase = _MockSendRequestUseCase();
+    when(() => repository.saveTabs(any())).thenAnswer((_) async {});
+    when(() => repository.putTab(any())).thenAnswer((_) async {});
+    when(() => repository.deleteTabs(any())).thenAnswer((_) async {});
+    when(() => repository.saveTabOrder(any())).thenAnswer((_) async {});
+    when(() => repository.putPanel(any())).thenAnswer((_) async {});
+    when(() => repository.deletePanels(any())).thenAnswer((_) async {});
+    when(
+      () => repository.savePanelMeta(any(), any()),
+    ).thenAnswer((_) async {});
+  });
+
+  Future<void> pumpEditor(
+    WidgetTester tester,
+    TabsBloc bloc, {
+    bool allowFiles = true,
+  }) async {
+    final settingsBloc = _settingsBloc();
+    addTearDown(settingsBloc.close);
+    final environmentsBloc = _environmentsBloc();
+    addTearDown(environmentsBloc.close);
+    final collectionsBloc = _collectionsBloc();
+    addTearDown(collectionsBloc.close);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: brutalistTheme(Brightness.light),
+        home: Scaffold(
+          body: MultiBlocProvider(
+            providers: [
+              BlocProvider.value(value: bloc),
+              BlocProvider<SettingsBloc>.value(value: settingsBloc),
+              BlocProvider<EnvironmentsBloc>.value(value: environmentsBloc),
+              BlocProvider<CollectionsBloc>.value(value: collectionsBloc),
+            ],
+            child: FormDataEditor(tabId: 't', allowFiles: allowFiles),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  // Finds a TextField whose InputDecoration hint text matches [hint].
+  Finder fieldByHint(String hint) => find.byWidgetPredicate(
+    (w) => w is TextField && w.decoration?.hintText == hint,
+    description: '$hint text field',
+  );
+
+  testWidgets(
+    'value field shows variable suggestion when typing {{ho and accepts it',
+    (tester) async {
+      const tab = HttpRequestTabEntity(
+        tabId: 't',
+        config: HttpRequestConfigEntity(
+          id: 't',
+          formFields: [MultipartFieldEntity(name: 'param')],
+        ),
+      );
+      final bloc = await _loadedBloc(repository, sendRequestUseCase, tab);
+      addTearDown(bloc.close);
+
+      await pumpEditor(tester, bloc);
+
+      // Enter partial variable name into the first VALUE field.
+      // tap first so the FocusNode is focused before the text change arrives.
+      final valueFields = fieldByHint('VALUE');
+      expect(valueFields, findsAtLeastNWidgets(1));
+      await tester.tap(valueFields.first);
+      await tester.enterText(valueFields.first, '{{ho');
+      await tester.pumpAndSettle();
+
+      // The autocomplete overlay must show the 'host' suggestion.
+      expect(find.text('host'), findsOneWidget);
+
+      // Tapping the suggestion completes the token.
+      await tester.tap(find.text('host'));
+      await tester.pumpAndSettle();
+
+      // The VALUE controller text is now the completed variable.
+      final tf = tester.widget<TextField>(valueFields.first);
+      expect(tf.controller?.text, '{{host}}');
+
+      // Flush the 10 s debounced-save timer.
+      await tester.pump(const Duration(seconds: 11));
+    },
+  );
+
+  testWidgets(
+    'name (KEY) field does not show variable autocomplete overlay',
+    (tester) async {
+      const tab = HttpRequestTabEntity(
+        tabId: 't',
+        config: HttpRequestConfigEntity(id: 't'),
+      );
+      final bloc = await _loadedBloc(repository, sendRequestUseCase, tab);
+      addTearDown(bloc.close);
+
+      await pumpEditor(tester, bloc);
+
+      // Type a variable prefix into the KEY field.
+      final nameFields = fieldByHint('KEY');
+      expect(nameFields, findsAtLeastNWidgets(1));
+      await tester.enterText(nameFields.first, '{{');
+      await tester.pumpAndSettle();
+
+      // No autocomplete overlay — the KEY field is a plain TextField.
+      expect(find.text('host'), findsNothing);
+
+      // Flush the debounced-save timer triggered by the name-field onChanged.
+      await tester.pump(const Duration(seconds: 11));
+    },
+  );
+}

--- a/test/features/tabs/presentation/widgets/variable_code_autocomplete_test.dart
+++ b/test/features/tabs/presentation/widgets/variable_code_autocomplete_test.dart
@@ -146,15 +146,18 @@ void main() {
   });
 
   group('wrapBodyWithVariableAutocomplete', () {
-    testWidgets('returns the child unchanged when the context is empty', (
+    testWidgets('wraps even when the context is empty (dynamics apply)', (
       tester,
     ) async {
+      // Regression: dynamic built-ins ({{$guid}}, {{$timestamp}}…) are
+      // suggestable with no active environment, so the body editor must still
+      // wrap — matching the URL bar — rather than return the bare child.
       const child = SizedBox(key: Key('body-child'));
       final wrapped = wrapBodyWithVariableAutocomplete(
         contextProvider: () => LayeredVariableContext.empty,
         child: child,
       );
-      expect(identical(wrapped, child), isTrue);
+      expect(wrapped, isA<CodeAutocomplete>());
     });
 
     testWidgets('wraps with CodeAutocomplete when variables exist', (

--- a/test/features/tabs/presentation/widgets/variable_code_autocomplete_test.dart
+++ b/test/features/tabs/presentation/widgets/variable_code_autocomplete_test.dart
@@ -215,5 +215,68 @@ void main() {
 
       expect(controller.text, '{{host}}');
     });
+
+    testWidgets(
+      'accepts host without doubling braces when closing braces present',
+      (tester) async {
+        final controller = CodeLineEditingController();
+        addTearDown(controller.dispose);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: resolveTheme('brutalist')(Brightness.light),
+            home: Scaffold(
+              body: SizedBox(
+                width: 600,
+                height: 400,
+                child: wrapBodyWithVariableAutocomplete(
+                  contextProvider: () => ctx,
+                  child: CodeEditor(controller: controller),
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Focus the editor so it attaches a text-input connection.
+        await tester.tap(find.byType(CodeEditor));
+        await tester.pumpAndSettle();
+
+        // Establish `{{}}` in the editor with the caret at offset 2 (between
+        // the braces) — simulates the user already having `{{}}` and moving
+        // the caret inside it.
+        await sendInsertionDelta(
+          tester,
+          oldText: '',
+          deltaText: '{{}}',
+          insertAt: 0,
+          caret: 2,
+        );
+        // Brief pump — do NOT wait the 60 ms autocomplete timer yet.
+        await tester.pump(const Duration(milliseconds: 5));
+
+        // Now type `ho` at position 2 (between `{{` and `}}`).
+        await sendInsertionDelta(
+          tester,
+          oldText: '{{}}',
+          deltaText: 'ho',
+          insertAt: 2,
+          caret: 4,
+        );
+        // Wait for the 50 ms autocomplete debounce.
+        await tester.pump(const Duration(milliseconds: 60));
+        await tester.pumpAndSettle();
+
+        expect(controller.text, '{{ho}}');
+        expect(find.text('host'), findsOneWidget);
+
+        // Accepting must yield `{{host}}`, NOT the doubled `{{host}}}}`.
+        await tester.tap(find.text('host'));
+        await tester.pumpAndSettle();
+
+        expect(controller.text, '{{host}}');
+      },
+    );
   });
 }

--- a/test/features/tabs/presentation/widgets/variable_code_autocomplete_test.dart
+++ b/test/features/tabs/presentation/widgets/variable_code_autocomplete_test.dart
@@ -1,0 +1,219 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/core/theme/theme_registry.dart';
+import 'package:getman/core/utils/layered_variable_context.dart';
+import 'package:getman/features/tabs/presentation/widgets/variable_code_autocomplete.dart';
+import 'package:re_editor/re_editor.dart';
+
+/// Drives a real insertion delta into the focused re_editor.
+///
+/// re_editor is a [DeltaTextInputClient] (`enableDeltaModel: true`) whose
+/// plain `updateEditingValue` is a no-op — only `updateEditingValueWithDeltas`
+/// applies text and triggers the autocomplete. `tester.testTextInput.enterText`
+/// sends the plain (non-delta) message, so we hand-build the delta platform
+/// message here. Client id `-1` is the framework's magic test id that bypasses
+/// the connection-id check.
+Future<void> sendInsertionDelta(
+  WidgetTester tester, {
+  required String oldText,
+  required String deltaText,
+  required int insertAt,
+  required int caret,
+}) async {
+  final message = const JSONMethodCodec().encodeMethodCall(
+    MethodCall('TextInputClient.updateEditingStateWithDeltas', <dynamic>[
+      -1,
+      <String, dynamic>{
+        'deltas': <dynamic>[
+          <String, dynamic>{
+            'oldText': oldText,
+            'deltaText': deltaText,
+            'deltaStart': insertAt,
+            'deltaEnd': insertAt,
+            'selectionBase': caret,
+            'selectionExtent': caret,
+            'selectionAffinity': 'TextAffinity.downstream',
+            'selectionIsDirectional': false,
+            'composingBase': -1,
+            'composingExtent': -1,
+          },
+        ],
+      },
+    ]),
+  );
+  await tester.binding.defaultBinaryMessenger.handlePlatformMessage(
+    'flutter/textinput',
+    message,
+    (_) {},
+  );
+}
+
+void main() {
+  const ctx = LayeredVariableContext(
+    environmentVariables: {'host': 'example.com', 'token': 'abc'},
+    environmentName: 'Staging',
+  );
+
+  group('variablePromptsFor', () {
+    test('returns suggestions for an open {{ token', () {
+      final r = variablePromptsFor(ctx, '{{ho', 4);
+      expect(r, isNotNull);
+      expect(r!.input, 'ho');
+      expect(r.hasClosingBraces, isFalse);
+      expect(r.suggestions.map((s) => s.name), contains('host'));
+    });
+
+    test('returns null when caret is not in a {{ token', () {
+      expect(variablePromptsFor(ctx, 'plain text', 5), isNull);
+    });
+
+    test('detects already-present closing braces', () {
+      // Caret between `{{` and `}}` at offset 4 ('{{ho}}').
+      final r = variablePromptsFor(ctx, '{{ho}}', 4);
+      expect(r, isNotNull);
+      expect(r!.hasClosingBraces, isTrue);
+    });
+  });
+
+  group('variableInsertionWord', () {
+    test('appends closing braces when not already present', () {
+      expect(variableInsertionWord('host', hasClosingBraces: false), 'host}}');
+    });
+
+    test('keeps the bare name when braces already present', () {
+      expect(variableInsertionWord('host', hasClosingBraces: true), 'host');
+    });
+  });
+
+  group('VariablePromptsBuilder.build', () {
+    final builder = VariablePromptsBuilder(() => ctx);
+
+    testWidgets('produces a CodeAutocompleteEditingValue for {{ho', (
+      tester,
+    ) async {
+      late BuildContext capturedContext;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              capturedContext = context;
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      final value = builder.build(
+        capturedContext,
+        const CodeLine('{{ho'),
+        const CodeLineSelection.collapsed(index: 0, offset: 4),
+      );
+      expect(value, isNotNull);
+      expect(value!.input, 'ho');
+      expect(value.prompts, isNotEmpty);
+      expect(
+        value.prompts.map((p) => p.word),
+        contains('host'),
+      );
+    });
+
+    testWidgets('returns null on a non-collapsed selection', (tester) async {
+      late BuildContext capturedContext;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              capturedContext = context;
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      final value = builder.build(
+        capturedContext,
+        const CodeLine('{{ho'),
+        const CodeLineSelection(
+          baseIndex: 0,
+          baseOffset: 2,
+          extentIndex: 0,
+          extentOffset: 4,
+        ),
+      );
+      expect(value, isNull);
+    });
+  });
+
+  group('wrapBodyWithVariableAutocomplete', () {
+    testWidgets('returns the child unchanged when the context is empty', (
+      tester,
+    ) async {
+      const child = SizedBox(key: Key('body-child'));
+      final wrapped = wrapBodyWithVariableAutocomplete(
+        contextProvider: () => LayeredVariableContext.empty,
+        child: child,
+      );
+      expect(identical(wrapped, child), isTrue);
+    });
+
+    testWidgets('wraps with CodeAutocomplete when variables exist', (
+      tester,
+    ) async {
+      const child = SizedBox(key: Key('body-child'));
+      final wrapped = wrapBodyWithVariableAutocomplete(
+        contextProvider: () => ctx,
+        child: child,
+      );
+      expect(wrapped, isA<CodeAutocomplete>());
+    });
+
+    testWidgets('shows the suggestion overlay and inserts {{host}}', (
+      tester,
+    ) async {
+      final controller = CodeLineEditingController();
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: resolveTheme('brutalist')(Brightness.light),
+          home: Scaffold(
+            body: SizedBox(
+              width: 600,
+              height: 400,
+              child: wrapBodyWithVariableAutocomplete(
+                contextProvider: () => ctx,
+                child: CodeEditor(controller: controller),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Focus the editor so it attaches a text-input connection.
+      await tester.tap(find.byType(CodeEditor));
+      await tester.pumpAndSettle();
+
+      // Type `{{ho` via a real insertion delta (the path re_editor honors).
+      await sendInsertionDelta(
+        tester,
+        oldText: '',
+        deltaText: '{{ho',
+        insertAt: 0,
+        caret: 4,
+      );
+      // The autocomplete update is fired 50ms after user input.
+      await tester.pump(const Duration(milliseconds: 60));
+      await tester.pumpAndSettle();
+
+      expect(controller.text, '{{ho');
+      expect(find.text('host'), findsOneWidget);
+
+      await tester.tap(find.text('host'));
+      await tester.pumpAndSettle();
+
+      expect(controller.text, '{{host}}');
+    });
+  });
+}

--- a/test/features/tabs/presentation/widgets/variable_json_span_builder_test.dart
+++ b/test/features/tabs/presentation/widgets/variable_json_span_builder_test.dart
@@ -75,6 +75,37 @@ void main() {
     },
   );
 
+  testWidgets(
+    'span plain-text fidelity: variable line preserves every character',
+    (tester) async {
+      const line = '{"url": "{{host}}/v1"}';
+      late String spanText;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              final span = variableAwareJsonSpan(
+                context: context,
+                index: 0,
+                codeLine: const CodeLine(line),
+                textSpan: const TextSpan(text: line),
+                style: const TextStyle(color: Colors.black),
+                variables: const {'host': 'example.com'},
+                resolvedColor: const Color(0xFF00FF00),
+                unresolvedColor: const Color(0xFFFF0000),
+              );
+              spanText = span.toPlainText();
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      // The flat-run merge must not drop or duplicate any characters.
+      expect(spanText, line);
+    },
+  );
+
   testWidgets('unknown variable uses the unresolved color', (tester) async {
     late TextSpan span;
     await tester.pumpWidget(

--- a/test/features/tabs/presentation/widgets/variable_json_span_builder_test.dart
+++ b/test/features/tabs/presentation/widgets/variable_json_span_builder_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/features/tabs/presentation/widgets/json_code_editor.dart';
+import 'package:getman/features/tabs/presentation/widgets/variable_json_span_builder.dart';
+import 'package:re_editor/re_editor.dart';
+
+void main() {
+  testWidgets('colors a {{var}} token inside a JSON string', (tester) async {
+    late TextSpan span;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) {
+            span = variableAwareJsonSpan(
+              context: context,
+              index: 0,
+              codeLine: const CodeLine('{"url": "{{host}}/v1"}'),
+              textSpan: const TextSpan(text: '{"url": "{{host}}/v1"}'),
+              style: const TextStyle(color: Colors.black),
+              variables: const {'host': 'example.com'},
+              resolvedColor: const Color(0xFF00FF00),
+              unresolvedColor: const Color(0xFFFF0000),
+            );
+            return const SizedBox();
+          },
+        ),
+      ),
+    );
+
+    final resolvedRun = _findRun(span, '{{host}}');
+    expect(resolvedRun, isNotNull);
+    expect(resolvedRun?.style?.color, const Color(0xFF00FF00));
+    expect(resolvedRun?.style?.fontWeight, FontWeight.w800);
+  });
+
+  testWidgets(
+    'a JSON line with no variables is unchanged vs base highlighter',
+    (
+      tester,
+    ) async {
+      const line = '{"name": "getman", "version": 1}';
+      late String baseText;
+      late String overlaidText;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              final base = jsonHighlightSpanBuilder(
+                context: context,
+                index: 0,
+                codeLine: const CodeLine(line),
+                textSpan: const TextSpan(text: line),
+                style: const TextStyle(color: Colors.black),
+              );
+              final overlaid = variableAwareJsonSpan(
+                context: context,
+                index: 0,
+                codeLine: const CodeLine(line),
+                textSpan: const TextSpan(text: line),
+                style: const TextStyle(color: Colors.black),
+                variables: const {'host': 'example.com'},
+                resolvedColor: const Color(0xFF00FF00),
+                unresolvedColor: const Color(0xFFFF0000),
+              );
+              baseText = base.toPlainText();
+              overlaidText = overlaid.toPlainText();
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      expect(overlaidText, baseText);
+      expect(overlaidText, line);
+    },
+  );
+
+  testWidgets('unknown variable uses the unresolved color', (tester) async {
+    late TextSpan span;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) {
+            span = variableAwareJsonSpan(
+              context: context,
+              index: 0,
+              codeLine: const CodeLine('{"x": "{{nope}}"}'),
+              textSpan: const TextSpan(text: '{"x": "{{nope}}"}'),
+              style: const TextStyle(color: Colors.black),
+              variables: const {},
+              resolvedColor: const Color(0xFF00FF00),
+              unresolvedColor: const Color(0xFFFF0000),
+            );
+            return const SizedBox();
+          },
+        ),
+      ),
+    );
+
+    final run = _findRun(span, '{{nope}}');
+    expect(run, isNotNull);
+    expect(run?.style?.color, const Color(0xFFFF0000));
+  });
+}
+
+/// Depth-first search the span tree for the child whose text == [needle].
+TextSpan? _findRun(InlineSpan span, String needle) {
+  if (span is TextSpan) {
+    if (span.text == needle) return span;
+    for (final child in span.children ?? const <InlineSpan>[]) {
+      final found = _findRun(child, needle);
+      if (found != null) return found;
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
Extends the `{{var}}` environment-variable experience from URL/params/headers to the **request body (raw/JSON)**, **auth fields**, and **form-data values** — with a shared layered (env + collection + dynamic) variable context across every field.

## What's new

| Field | Autocomplete | Highlight | Hover |
|---|:-:|:-:|:-:|
| URL / params / headers | ✅ (params/headers now also suggest collection + dynamic vars) | ✅ | ✅ |
| **Auth** (bearer / basic / api-key) | ✅ | ✅ | ✅ |
| **Form-data** values (multipart + urlencoded) | ✅ | ✅ | ✅ |
| **Raw/JSON body** | ✅ | ✅ | ⛔ deferred |
| **GraphQL** variables pane | ✅ | ✅ | ⛔ deferred |
| GraphQL query pane | — | ✅ | — |

## How it works
- **`LayeredVariableContext`** — env overlaid by collection vars + dynamics; one currency for every field.
- **`TabVariableContextBuilder`** — feeds that context per-tab from live bloc state with narrow `buildWhen`.
- **`VariableTextField`** — reusable atom bundling highlight + autocomplete + hover; auth, form-data, and the kv editor all use it (removed the old duplicated inline wiring).
- **Body** uses `re_editor`'s built-in `CodeAutocomplete` (no custom overlay) + a flat-run span merge that layers `{{var}}` colors over JSON highlighting.

## Body hover deferred (documented)
The spike confirmed body hover isn't feasible in `re_editor 0.9.0` without forking — the render object and position↔offset API are private, and it paints with a custom render object so `TextSpan.onEnter/onExit` never fire. Body ships autocomplete + highlighting; hover stays on the other fields.

## Notable
- **Behavior change:** params/headers now also suggest collection-scoped + dynamic variables (previously env-only) — intended.
- Fixed a regression where fields suppressed the dropdown with no active environment.
- Integrated cleanly with master's GraphQL body + in-flight-motion features.