### PR TITLE
test(export): cover deferred branches in the API-docs export (DW3 follow-up)

### DIFF
--- a/test/core/utils/apidoc/api_doc_test.dart
+++ b/test/core/utils/apidoc/api_doc_test.dart
@@ -18,6 +18,13 @@ void main() {
     expect(op.responses, isEmpty);
   });
 
+  test('ApiServer value-equality with variables', () {
+    expect(
+      const ApiServer(url: 'a', variables: {'k': 'v'}),
+      equals(const ApiServer(url: 'a', variables: {'k': 'v'})),
+    );
+  });
+
   test('value objects compare by value (Equatable)', () {
     const a = ApiParam(name: 'id', isRequired: true);
     const b = ApiParam(name: 'id', isRequired: true);

--- a/test/core/utils/apidoc/collection_to_api_doc_body_test.dart
+++ b/test/core/utils/apidoc/collection_to_api_doc_body_test.dart
@@ -135,6 +135,29 @@ void main() {
     );
   });
 
+  test('urlencoded body → x-www-form-urlencoded object with example', () {
+    final doc = CollectionToApiDoc.build(
+      _rootWith(
+        const HttpRequestConfigEntity(
+          id: 'c',
+          method: 'POST',
+          url: 'https://api.test.com/form',
+          bodyType: BodyType.urlencoded,
+          formFields: [
+            MultipartFieldEntity(name: 'a', value: '1'),
+            MultipartFieldEntity(name: 'b', value: '2'),
+          ],
+        ),
+      ),
+    );
+    final body = doc.operations.single.requestBody!;
+    expect(body.contentType, 'application/x-www-form-urlencoded');
+    expect(body.schema!.type, 'object');
+    expect(body.schema!.properties['a']!.type, 'string');
+    expect(body.schema!.properties['b']!.type, 'string');
+    expect(body.example, {'a': '1', 'b': '2'});
+  });
+
   test('Content-Type and Accept are excluded from header params', () {
     final doc = CollectionToApiDoc.build(
       _rootWith(

--- a/test/core/utils/apidoc/collection_to_api_doc_response_test.dart
+++ b/test/core/utils/apidoc/collection_to_api_doc_response_test.dart
@@ -91,6 +91,96 @@ void main() {
     expect(responses.map((r) => r.statusCode), contains(404));
   });
 
+  test('inherit auth is mapped to none on the operation', () {
+    final root = CollectionNodeEntity(
+      id: 'r',
+      name: 'API',
+      children: [
+        CollectionNodeEntity(
+          id: 'a',
+          name: 'Get',
+          isFolder: false,
+          config: HttpRequestConfigEntity(
+            id: 'c',
+            url: 'https://api.test.com/x',
+            auth: const AuthConfig(type: AuthType.inherit).toMap(),
+          ),
+        ),
+      ],
+    );
+    final op = CollectionToApiDoc.build(root).operations.single;
+    expect(op.security.type, AuthType.none);
+  });
+
+  test('example at same status as live response suppresses the live one', () {
+    final root = CollectionNodeEntity(
+      id: 'r',
+      name: 'API',
+      children: [
+        CollectionNodeEntity(
+          id: 'a',
+          name: 'Get',
+          isFolder: false,
+          config: const HttpRequestConfigEntity(
+            id: 'c',
+            url: 'https://api.test.com/x',
+            statusCode: 200,
+            responseBody: '{"live":true}',
+          ),
+          examples: [
+            SavedExampleEntity(
+              id: 'e1',
+              name: 'myExample',
+              capturedAt: DateTime(2026),
+              config: const HttpRequestConfigEntity(
+                id: 'ec',
+                url: 'https://api.test.com/x',
+                statusCode: 200,
+                responseBody: '{"example":true}',
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+    final responses = CollectionToApiDoc.build(
+      root,
+    ).operations.single.responses;
+    expect(responses.where((r) => r.statusCode == 200).length, 1);
+    expect(
+      responses.single.description,
+      'Example: myExample',
+    );
+  });
+
+  test(
+    'non-JSON live response body falls back to text/plain content type',
+    () {
+      const root = CollectionNodeEntity(
+        id: 'r',
+        name: 'API',
+        children: [
+          CollectionNodeEntity(
+            id: 'a',
+            name: 'Get',
+            isFolder: false,
+            config: HttpRequestConfigEntity(
+              id: 'c',
+              url: 'https://api.test.com/x',
+              statusCode: 200,
+              responseBody: 'not json at all',
+            ),
+          ),
+        ],
+      );
+      final response = CollectionToApiDoc.build(
+        root,
+      ).operations.single.responses.single;
+      expect(response.body!.contentType, 'text/plain');
+      expect(response.body!.example, 'not json at all');
+    },
+  );
+
   test('bearer auth is carried on the operation', () {
     final root = CollectionNodeEntity(
       id: 'r',

--- a/test/core/utils/apidoc/collection_to_api_doc_test.dart
+++ b/test/core/utils/apidoc/collection_to_api_doc_test.dart
@@ -77,5 +77,31 @@ void main() {
       expect(doc.servers.single.url, '{baseUrl}');
       expect(doc.servers.single.variables.containsKey('baseUrl'), isTrue);
     });
+
+    test(
+      'bare path with no scheme and no var falls back to server "/" with warning',
+      () {
+        const root = CollectionNodeEntity(
+          id: 'r',
+          name: 'API',
+          children: [
+            CollectionNodeEntity(
+              id: 'a',
+              name: 'Orphan',
+              isFolder: false,
+              config: HttpRequestConfigEntity(
+                id: 'c',
+                url: 'orphan/path',
+              ),
+            ),
+          ],
+        );
+        final doc = CollectionToApiDoc.build(root); // no env
+        expect(doc.servers.single.url, '/');
+        expect(doc.warnings, hasLength(1));
+        expect(doc.warnings.single, contains('Could not determine'));
+        expect(doc.operations.single.path, '/orphan/path');
+      },
+    );
   });
 }

--- a/test/core/utils/apidoc/markdown_doc_serializer_test.dart
+++ b/test/core/utils/apidoc/markdown_doc_serializer_test.dart
@@ -37,6 +37,33 @@ void main() {
     expect(md, contains('`200` — OK'));
   });
 
+  test('response body example renders as fenced json block', () {
+    const doc = ApiDoc(
+      title: 'API',
+      operations: [
+        ApiOperation(
+          method: 'GET',
+          path: '/items',
+          summary: 'List items',
+          responses: [
+            ApiResponse(
+              statusCode: 200,
+              description: 'OK',
+              body: ApiBody(
+                contentType: 'application/json',
+                example: {'id': 1},
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+    final md = MarkdownDocSerializer.toMarkdown(doc);
+    expect(md, contains('`200` — OK'));
+    expect(md, contains('```json'));
+    expect(md, contains('"id": 1'));
+  });
+
   test('untagged operations fall under General', () {
     const doc = ApiDoc(
       title: 'API',


### PR DESCRIPTION
## What & why

Test-only follow-up to the merged DW3 feature (collection → API docs export). The final whole-branch review of DW3 deferred a handful of small branch-coverage gaps as non-blocking; this PR closes them so those code paths have explicit regression protection. **No production code changes** — 5 test files, +173 lines.

## Tests added

- **`collection_to_api_doc_test.dart`** — the `/`-fallback warning branch: a bare-path URL (no scheme, no `{{var}}`) → server `/` + a "Could not determine" warning + leading-slash path.
- **`collection_to_api_doc_body_test.dart`** — `urlencoded` request body (previously only covered indirectly via the multipart path): content type, object schema, and example map.
- **`collection_to_api_doc_response_test.dart`** —
  - `inherit` auth maps to `none` on the operation
  - status-code dedup: a saved example at 200 suppresses a live 200 response (example wins)
  - non-JSON response body falls back to `text/plain` with the raw example
- **`markdown_doc_serializer_test.dart`** — response-body example rendering (the fenced \`\`\`json block under a response).
- **`api_doc_test.dart`** — `ApiServer` value-equality with a non-empty `variables` map.

## Verification

- `fvm flutter test test/core/utils/apidoc/` — 49 passing (42 pre-existing + 7 new)
- `fvm flutter analyze` and `fvm dart run custom_lint` — 0 issues
- `git diff --stat` confirms only test files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)