### PR TITLE
feat(mcp): MCP client support (tools, Streamable HTTP)

### DIFF
--- a/docs/superpowers/plans/2026-06-24-mcp-client.md
+++ b/docs/superpowers/plans/2026-06-24-mcp-client.md
@@ -1,0 +1,2210 @@
+# MCP Client Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Model Context Protocol (MCP) *client* to Getman — a new request kind that connects to an external MCP server over Streamable HTTP, lists its tools, and invokes a tool with user-supplied JSON arguments, showing the result.
+
+**Architecture:** MCP slots into the existing `RequestKind` seam (the same mechanism that drives WebSocket/SSE). A new `RequestKind.mcp` makes a tab speak MCP; `ResponseArea` swaps in an `McpPanel`; a connect button in the URL bar opens the connection. The protocol lives in a pure-`dio`, web-safe `McpService` returning an `McpConnection`; an `McpBloc` (bloc-over-service, no domain/data split — exactly like `RealtimeBloc`) owns one connection per tab. JSON-RPC 2.0 messages are POSTed and responses parsed from either `application/json` or `text/event-stream` (reusing `SseParser`).
+
+**Tech Stack:** Flutter, `flutter_bloc`, `dio` (Streamable HTTP), `equatable`, `re_editor` (JSON args editor), `mocktail` + `bloc_test` (tests). Invoke Flutter as `fvm flutter ...`.
+
+## Global Constraints
+
+- Flutter SDK is pinned via `.fvmrc` — always invoke as `fvm flutter ...`, never plain `flutter`.
+- Imports are `package:getman/...` everywhere (no relative imports; `directives_ordering` + `always_use_package_imports`).
+- Domain layer is pure Dart + `equatable` only — zero imports from `data/` or Flutter UI.
+- BLoCs must not import `package:flutter/foundation.dart`/material (bloc_lint `avoid_flutter_imports`); BLoC logging uses `dart:developer`'s `log(msg, name: 'McpBloc')`, never `debugPrint`/`print`.
+- Widgets never call `sl<T>()`/`GetIt` (custom_lint `avoid_get_it_in_widgets`); reach services/blocs via `BlocProvider`/`RepositoryProvider`. GetIt is referenced only in `lib/core/di/` + `main.dart`.
+- No hardcoded sizes/colors/radii/weights in widgets — read from `context.appLayout`/`appPalette`/`appShape`/`appTypography`/`appDecoration`. No `Colors.black/white/red` literals outside `lib/core/theme/` (custom_lint `avoid_hardcoded_brand_colors`).
+- All states/events are `Equatable`; every entity is immutable.
+- **Verification bar (all must be clean before "done"):** `fvm flutter analyze` (0 issues), `fvm dart run custom_lint` (0 issues), `fvm dart run bloc_tools:bloc lint lib` (0 issues), `fvm dart format lib test` clean, and `fvm flutter test` 100% green. These are independent passes.
+- No new Hive typeId / no migration: `RequestKind` persists as the existing int discriminator (config model field 14); a new enum value reads back via `RequestKind.fromWire`.
+
+---
+
+## File Structure
+
+**Create:**
+- `lib/features/mcp/domain/entities/mcp_session.dart` — `McpSession` value object + `fromInitializeResult`.
+- `lib/features/mcp/domain/entities/mcp_tool.dart` — `McpTool` value object + `fromJson`.
+- `lib/features/mcp/domain/entities/mcp_tool_result.dart` — `McpToolResult` value object + `fromJson`.
+- `lib/core/network/mcp_service.dart` — `McpService`, `McpConnection`, `McpException`, protocol constants. Pure dio, web-safe.
+- `lib/features/mcp/presentation/bloc/mcp_event.dart` — `McpEvent` hierarchy.
+- `lib/features/mcp/presentation/bloc/mcp_state.dart` — `McpState` + `McpTabSession`.
+- `lib/features/mcp/presentation/bloc/mcp_bloc.dart` — `McpBloc`.
+- `lib/features/mcp/presentation/widgets/mcp_connect_button.dart` — URL-bar CONNECT/DISCONNECT button.
+- `lib/features/mcp/presentation/widgets/mcp_panel.dart` — the post-connect UI (tool list, args editor, result, log).
+- Tests mirroring each (paths in tasks).
+
+**Modify:**
+- `lib/core/network/request_kind.dart` — add `mcp(3)`.
+- `lib/features/tabs/presentation/widgets/request_kind_method_selector.dart` — add an "MCP" dropdown item.
+- `lib/features/tabs/presentation/widgets/url_bar.dart` — show `McpConnectButton` for MCP kind.
+- `lib/features/tabs/presentation/widgets/response_area.dart` — render `McpPanel` for MCP kind.
+- `lib/core/di/injection_container.dart` — register `McpService` + `McpBloc`.
+- `lib/main.dart` — provide `McpBloc`.
+
+---
+
+### Task 1: Add `RequestKind.mcp`
+
+**Files:**
+- Modify: `lib/core/network/request_kind.dart`
+- Test: `test/core/network/request_kind_test.dart`
+
+**Interfaces:**
+- Produces: `RequestKind.mcp` (wire `3`); `RequestKind.fromWire(3) == RequestKind.mcp`; unknown wires still fall back to `RequestKind.http`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/core/network/request_kind_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/core/network/request_kind.dart';
+
+void main() {
+  group('RequestKind', () {
+    test('mcp has wire value 3', () {
+      expect(RequestKind.mcp.wire, 3);
+    });
+
+    test('fromWire(3) resolves to mcp', () {
+      expect(RequestKind.fromWire(3), RequestKind.mcp);
+    });
+
+    test('unknown wire falls back to http', () {
+      expect(RequestKind.fromWire(99), RequestKind.http);
+      expect(RequestKind.fromWire(null), RequestKind.http);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `fvm flutter test test/core/network/request_kind_test.dart`
+Expected: FAIL — `mcp` is not a member of `RequestKind`.
+
+- [ ] **Step 3: Add the enum value**
+
+In `lib/core/network/request_kind.dart`, extend the enum and the doc comment:
+
+```dart
+/// The protocol a request speaks. Orthogonal to the HTTP method — a WebSocket,
+/// SSE, or MCP request has no method. Persisted as an int discriminator (Hive
+/// field 14 on the config model, default 0 = http) so existing records read as
+/// HTTP.
+enum RequestKind {
+  http(0),
+  webSocket(1),
+  sse(2),
+  mcp(3)
+  ;
+```
+
+(Leave `fromWire` unchanged — it already iterates `values`.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `fvm flutter test test/core/network/request_kind_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/core/network/request_kind.dart test/core/network/request_kind_test.dart
+git commit -m "feat(mcp): add RequestKind.mcp protocol discriminator"
+```
+
+---
+
+### Task 2: MCP domain entities
+
+**Files:**
+- Create: `lib/features/mcp/domain/entities/mcp_session.dart`
+- Create: `lib/features/mcp/domain/entities/mcp_tool.dart`
+- Create: `lib/features/mcp/domain/entities/mcp_tool_result.dart`
+- Test: `test/features/mcp/domain/entities/mcp_entities_test.dart`
+
+**Interfaces:**
+- Produces:
+  - `McpSession({required String sessionId, required String protocolVersion, required String serverName, required String serverVersion})`; `McpSession.fromInitializeResult(Map<String, dynamic> result, {String? sessionId})`.
+  - `McpTool({required String name, required String description, required Map<String, dynamic> inputSchema})`; `McpTool.fromJson(Map<String, dynamic> json)`.
+  - `McpToolResult({required bool isError, required List<String> textBlocks, required List<Map<String, dynamic>> rawBlocks})`; `McpToolResult.fromJson(Map<String, dynamic> result)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/features/mcp/domain/entities/mcp_entities_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/features/mcp/domain/entities/mcp_session.dart';
+import 'package:getman/features/mcp/domain/entities/mcp_tool.dart';
+import 'package:getman/features/mcp/domain/entities/mcp_tool_result.dart';
+
+void main() {
+  group('McpSession.fromInitializeResult', () {
+    test('reads server info + protocol version, sessionId from header', () {
+      final s = McpSession.fromInitializeResult(
+        const {
+          'protocolVersion': '2025-06-18',
+          'serverInfo': {'name': 'demo', 'version': '1.2.3'},
+        },
+        sessionId: 'abc-123',
+      );
+      expect(s.sessionId, 'abc-123');
+      expect(s.protocolVersion, '2025-06-18');
+      expect(s.serverName, 'demo');
+      expect(s.serverVersion, '1.2.3');
+    });
+
+    test('tolerates missing fields with safe defaults', () {
+      final s = McpSession.fromInitializeResult(const {});
+      expect(s.sessionId, '');
+      expect(s.serverName, '');
+      expect(s.protocolVersion, '');
+    });
+  });
+
+  group('McpTool.fromJson', () {
+    test('parses name, description, and raw input schema', () {
+      final t = McpTool.fromJson(const {
+        'name': 'add',
+        'description': 'Adds numbers',
+        'inputSchema': {
+          'type': 'object',
+          'properties': {
+            'a': {'type': 'number'},
+          },
+        },
+      });
+      expect(t.name, 'add');
+      expect(t.description, 'Adds numbers');
+      expect(t.inputSchema['type'], 'object');
+    });
+
+    test('defaults description to empty and schema to empty map', () {
+      final t = McpTool.fromJson(const {'name': 'noop'});
+      expect(t.description, '');
+      expect(t.inputSchema, isEmpty);
+    });
+  });
+
+  group('McpToolResult.fromJson', () {
+    test('collects text blocks and isError flag', () {
+      final r = McpToolResult.fromJson(const {
+        'isError': true,
+        'content': [
+          {'type': 'text', 'text': 'boom'},
+          {'type': 'text', 'text': 'second'},
+        ],
+      });
+      expect(r.isError, isTrue);
+      expect(r.textBlocks, ['boom', 'second']);
+    });
+
+    test('keeps non-text blocks as raw maps and defaults isError to false', () {
+      final r = McpToolResult.fromJson(const {
+        'content': [
+          {'type': 'image', 'data': 'xxx', 'mimeType': 'image/png'},
+        ],
+      });
+      expect(r.isError, isFalse);
+      expect(r.textBlocks, isEmpty);
+      expect(r.rawBlocks.single['type'], 'image');
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `fvm flutter test test/features/mcp/domain/entities/mcp_entities_test.dart`
+Expected: FAIL — entity files don't exist.
+
+- [ ] **Step 3: Create the entities**
+
+Create `lib/features/mcp/domain/entities/mcp_session.dart`:
+
+```dart
+import 'package:equatable/equatable.dart';
+
+/// An established MCP session: the negotiated protocol version, the server's
+/// self-reported identity, and the transport session id (from the
+/// `Mcp-Session-Id` response header). Pure data — no transport concerns.
+class McpSession extends Equatable {
+  const McpSession({
+    required this.sessionId,
+    required this.protocolVersion,
+    required this.serverName,
+    required this.serverVersion,
+  });
+
+  /// Builds a session from an `initialize` JSON-RPC result, with the transport
+  /// [sessionId] supplied separately (it rides on the HTTP response header, not
+  /// the JSON-RPC body). Missing fields default to empty strings.
+  factory McpSession.fromInitializeResult(
+    Map<String, dynamic> result, {
+    String? sessionId,
+  }) {
+    final info = (result['serverInfo'] as Map?)?.cast<String, dynamic>() ??
+        const <String, dynamic>{};
+    return McpSession(
+      sessionId: sessionId ?? '',
+      protocolVersion: (result['protocolVersion'] as String?) ?? '',
+      serverName: (info['name'] as String?) ?? '',
+      serverVersion: (info['version'] as String?) ?? '',
+    );
+  }
+
+  final String sessionId;
+  final String protocolVersion;
+  final String serverName;
+  final String serverVersion;
+
+  @override
+  List<Object?> get props =>
+      [sessionId, protocolVersion, serverName, serverVersion];
+}
+```
+
+Create `lib/features/mcp/domain/entities/mcp_tool.dart`:
+
+```dart
+import 'package:equatable/equatable.dart';
+
+/// A tool advertised by an MCP server via `tools/list`. [inputSchema] is the
+/// tool's raw JSON Schema (kept verbatim; not modeled further in v1).
+class McpTool extends Equatable {
+  const McpTool({
+    required this.name,
+    required this.description,
+    required this.inputSchema,
+  });
+
+  factory McpTool.fromJson(Map<String, dynamic> json) => McpTool(
+        name: (json['name'] as String?) ?? '',
+        description: (json['description'] as String?) ?? '',
+        inputSchema:
+            (json['inputSchema'] as Map?)?.cast<String, dynamic>() ??
+                const <String, dynamic>{},
+      );
+
+  final String name;
+  final String description;
+  final Map<String, dynamic> inputSchema;
+
+  @override
+  List<Object?> get props => [name, description, inputSchema];
+}
+```
+
+Create `lib/features/mcp/domain/entities/mcp_tool_result.dart`:
+
+```dart
+import 'package:equatable/equatable.dart';
+
+/// The result of a `tools/call`. [textBlocks] are the `type: "text"` content
+/// items (the common case); [rawBlocks] preserves every content item verbatim
+/// so non-text blocks (images, resources) can still be shown as raw JSON.
+class McpToolResult extends Equatable {
+  const McpToolResult({
+    required this.isError,
+    required this.textBlocks,
+    required this.rawBlocks,
+  });
+
+  factory McpToolResult.fromJson(Map<String, dynamic> result) {
+    final content = (result['content'] as List?) ?? const [];
+    final raw = content
+        .whereType<Map>()
+        .map((m) => m.cast<String, dynamic>())
+        .toList();
+    final text = raw
+        .where((m) => m['type'] == 'text')
+        .map((m) => (m['text'] as String?) ?? '')
+        .toList();
+    return McpToolResult(
+      isError: (result['isError'] as bool?) ?? false,
+      textBlocks: text,
+      rawBlocks: raw,
+    );
+  }
+
+  final bool isError;
+  final List<String> textBlocks;
+  final List<Map<String, dynamic>> rawBlocks;
+
+  @override
+  List<Object?> get props => [isError, textBlocks, rawBlocks];
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `fvm flutter test test/features/mcp/domain/entities/mcp_entities_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/mcp/domain/entities test/features/mcp/domain
+git commit -m "feat(mcp): add MCP session/tool/result domain entities"
+```
+
+---
+
+### Task 3: `McpService` — JSON-RPC over Streamable HTTP
+
+**Files:**
+- Create: `lib/core/network/mcp_service.dart`
+- Test: `test/core/network/mcp_service_test.dart`
+
+**Interfaces:**
+- Consumes: `McpSession`, `McpTool`, `McpToolResult` (Task 2).
+- Produces:
+  - `class McpService { McpService({Dio? dio}); Future<McpConnection> connect(String url, {Map<String, String> headers = const {}}); }`
+  - `abstract class McpConnection { McpSession get session; Future<List<McpTool>> listTools(); Future<McpToolResult> callTool(String name, Map<String, dynamic> arguments, {CancelToken? cancelToken}); Future<void> close(); }`
+  - `class McpException implements Exception { McpException(this.message, {this.code}); final String message; final int? code; }`
+  - `const String kMcpProtocolVersion = '2025-06-18';`
+
+**Background — Streamable HTTP transport (what the code below implements):**
+- One endpoint URL. Every JSON-RPC message is a `POST` with `Content-Type: application/json` and `Accept: application/json, text/event-stream`.
+- `initialize` request → result carries `protocolVersion` + `serverInfo`; the HTTP response carries an `Mcp-Session-Id` header. After it, POST a `notifications/initialized` notification (no `id`, server replies `202` with empty body).
+- Subsequent requests echo `Mcp-Session-Id` and `MCP-Protocol-Version` headers.
+- A response may come back as a single `application/json` object **or** as `text/event-stream` (the JSON-RPC message arrives inside SSE `data:` frames). Both are read by draining the byte stream and decoding.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/core/network/mcp_service_test.dart`:
+
+```dart
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/core/network/mcp_service.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockDio extends Mock implements Dio {}
+
+ResponseBody _jsonBody(Map<String, dynamic> json, {int status = 200}) {
+  final bytes = Uint8List.fromList(utf8.encode(jsonEncode(json)));
+  return ResponseBody(
+    Stream<Uint8List>.value(bytes),
+    status,
+    headers: {
+      Headers.contentTypeHeader: ['application/json'],
+    },
+  );
+}
+
+ResponseBody _sseBody(Map<String, dynamic> json, {int status = 200}) {
+  final frame = 'event: message\ndata: ${jsonEncode(json)}\n\n';
+  final bytes = Uint8List.fromList(utf8.encode(frame));
+  return ResponseBody(
+    Stream<Uint8List>.value(bytes),
+    status,
+    headers: {
+      Headers.contentTypeHeader: ['text/event-stream'],
+    },
+  );
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(Options());
+    registerFallbackValue(CancelToken());
+  });
+
+  late _MockDio dio;
+  late McpService service;
+
+  setUp(() {
+    dio = _MockDio();
+    service = McpService(dio: dio);
+  });
+
+  // Queues a sequence of POST responses; the Nth POST returns responses[N].
+  void stubPosts(List<Response<ResponseBody>> responses) {
+    var i = 0;
+    when(
+      () => dio.post<ResponseBody>(
+        any(),
+        data: any(named: 'data'),
+        options: any(named: 'options'),
+        cancelToken: any(named: 'cancelToken'),
+      ),
+    ).thenAnswer((_) async => responses[i++]);
+  }
+
+  Response<ResponseBody> resp(ResponseBody body, {Map<String, List<String>>? headers}) =>
+      Response<ResponseBody>(
+        data: body,
+        statusCode: body.statusCode,
+        headers: Headers.fromMap(headers ?? {}),
+        requestOptions: RequestOptions(path: '/'),
+      );
+
+  test('connect performs the initialize handshake and captures session id',
+      () async {
+    stubPosts([
+      resp(
+        _jsonBody({
+          'jsonrpc': '2.0',
+          'id': 1,
+          'result': {
+            'protocolVersion': '2025-06-18',
+            'serverInfo': {'name': 'demo', 'version': '9.9'},
+          },
+        }),
+        headers: {
+          'mcp-session-id': ['sess-1'],
+        },
+      ),
+      resp(_jsonBody({'jsonrpc': '2.0'}), headers: {}), // initialized notif (202-ish)
+    ]);
+
+    final conn = await service.connect('https://mcp.dev/');
+    expect(conn.session.sessionId, 'sess-1');
+    expect(conn.session.serverName, 'demo');
+    // initialize POST + initialized notification POST = 2 calls.
+    verify(
+      () => dio.post<ResponseBody>(
+        any(),
+        data: any(named: 'data'),
+        options: any(named: 'options'),
+        cancelToken: any(named: 'cancelToken'),
+      ),
+    ).called(2);
+  });
+
+  test('listTools parses tools from an application/json response', () async {
+    stubPosts([
+      resp(_jsonBody({
+        'jsonrpc': '2.0',
+        'id': 2,
+        'result': {
+          'tools': [
+            {'name': 'add', 'description': 'Add', 'inputSchema': {'type': 'object'}},
+          ],
+        },
+      })),
+    ]);
+
+    final conn = _ConnectedFixture.build(service, dio);
+    final tools = await conn.listTools();
+    expect(tools.single.name, 'add');
+  });
+
+  test('callTool parses a result delivered over text/event-stream', () async {
+    stubPosts([
+      resp(_sseBody({
+        'jsonrpc': '2.0',
+        'id': 3,
+        'result': {
+          'content': [
+            {'type': 'text', 'text': 'hello'},
+          ],
+          'isError': false,
+        },
+      })),
+    ]);
+
+    final conn = _ConnectedFixture.build(service, dio);
+    final result = await conn.callTool('echo', const {'msg': 'hi'});
+    expect(result.textBlocks, ['hello']);
+    expect(result.isError, isFalse);
+  });
+
+  test('a JSON-RPC error response throws McpException', () async {
+    stubPosts([
+      resp(_jsonBody({
+        'jsonrpc': '2.0',
+        'id': 2,
+        'error': {'code': -32601, 'message': 'Method not found'},
+      })),
+    ]);
+
+    final conn = _ConnectedFixture.build(service, dio);
+    await expectLater(
+      conn.listTools(),
+      throwsA(
+        isA<McpException>()
+            .having((e) => e.code, 'code', -32601)
+            .having((e) => e.message, 'message', contains('Method not found')),
+      ),
+    );
+  });
+}
+
+/// Builds a connection without re-stubbing the initialize handshake: connect()
+/// is exercised in its own test, so here we drive listTools/callTool directly
+/// by stubbing the initialize POST first, then the operation POST.
+class _ConnectedFixture {
+  static McpConnection build(McpService service, _MockDio dio) {
+    throw UnimplementedError();
+  }
+}
+```
+
+> Note: `_ConnectedFixture` is a placeholder so the file compiles for the
+> first failing run. Replace it in Step 3b once `McpConnection` exists.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `fvm flutter test test/core/network/mcp_service_test.dart`
+Expected: FAIL — `mcp_service.dart` doesn't exist.
+
+- [ ] **Step 3: Create the service**
+
+Create `lib/core/network/mcp_service.dart`:
+
+```dart
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:getman/core/network/sse_parser.dart';
+import 'package:getman/features/mcp/domain/entities/mcp_session.dart';
+import 'package:getman/features/mcp/domain/entities/mcp_tool.dart';
+import 'package:getman/features/mcp/domain/entities/mcp_tool_result.dart';
+
+/// MCP protocol version Getman negotiates in `initialize`.
+const String kMcpProtocolVersion = '2025-06-18';
+
+/// Client identity sent in `initialize.params.clientInfo`.
+const String _kClientName = 'Getman';
+const String _kClientVersion = '1.0';
+
+/// A JSON-RPC error returned by an MCP server, or a transport-level failure.
+class McpException implements Exception {
+  McpException(this.message, {this.code});
+  final String message;
+  final int? code;
+  @override
+  String toString() =>
+      'McpException(${code == null ? '' : '$code: '}$message)';
+}
+
+/// A live MCP session over Streamable HTTP. One per connected tab.
+abstract class McpConnection {
+  McpSession get session;
+  Future<List<McpTool>> listTools();
+  Future<McpToolResult> callTool(
+    String name,
+    Map<String, dynamic> arguments, {
+    CancelToken? cancelToken,
+  });
+  Future<void> close();
+}
+
+/// Opens MCP connections over Streamable HTTP (JSON-RPC 2.0). Pure `dio`, so it
+/// is web-safe (no `dart:io`). The [Dio] is injectable for tests.
+class McpService {
+  McpService({Dio? dio}) : _dio = dio ?? _buildDio();
+  final Dio _dio;
+
+  static Dio _buildDio() => Dio(
+        BaseOptions(
+          connectTimeout: const Duration(seconds: 30),
+          receiveTimeout: const Duration(seconds: 60),
+          // MCP servers may answer with a JSON-RPC error at HTTP 200, or with
+          // 4xx/5xx — read every status so we can surface the body either way.
+          validateStatus: (_) => true,
+          responseType: ResponseType.stream,
+        ),
+      );
+
+  /// Performs the `initialize` handshake, captures the `Mcp-Session-Id`
+  /// header, sends the `notifications/initialized` notification, and returns a
+  /// ready connection.
+  Future<McpConnection> connect(
+    String url, {
+    Map<String, String> headers = const {},
+  }) async {
+    final conn = _HttpMcpConnection(_dio, url, headers);
+    await conn._initialize();
+    return conn;
+  }
+}
+
+class _HttpMcpConnection implements McpConnection {
+  _HttpMcpConnection(this._dio, this._url, this._headers);
+  final Dio _dio;
+  final String _url;
+  final Map<String, String> _headers;
+
+  McpSession _session = const McpSession(
+    sessionId: '',
+    protocolVersion: '',
+    serverName: '',
+    serverVersion: '',
+  );
+  int _nextId = 0;
+
+  @override
+  McpSession get session => _session;
+
+  Future<void> _initialize() async {
+    final (result, respHeaders) = await _request('initialize', {
+      'protocolVersion': kMcpProtocolVersion,
+      'capabilities': <String, dynamic>{},
+      'clientInfo': {'name': _kClientName, 'version': _kClientVersion},
+    });
+    _session = McpSession.fromInitializeResult(
+      result,
+      sessionId: respHeaders.value('mcp-session-id'),
+    );
+    await _notify('notifications/initialized', const {});
+  }
+
+  @override
+  Future<List<McpTool>> listTools() async {
+    final (result, _) = await _request('tools/list', const {});
+    final tools = (result['tools'] as List?) ?? const [];
+    return tools
+        .whereType<Map>()
+        .map((t) => McpTool.fromJson(t.cast<String, dynamic>()))
+        .toList();
+  }
+
+  @override
+  Future<McpToolResult> callTool(
+    String name,
+    Map<String, dynamic> arguments, {
+    CancelToken? cancelToken,
+  }) async {
+    final (result, _) = await _request(
+      'tools/call',
+      {'name': name, 'arguments': arguments},
+      cancelToken: cancelToken,
+    );
+    return McpToolResult.fromJson(result);
+  }
+
+  @override
+  Future<void> close() async {
+    // v1: nothing to release (each call is a discrete POST). Session
+    // termination via HTTP DELETE is deferred.
+  }
+
+  Map<String, dynamic> _envelope(String method, Map<String, dynamic> params) =>
+      {'jsonrpc': '2.0', 'id': ++_nextId, 'method': method, 'params': params};
+
+  Options _options() => Options(
+        responseType: ResponseType.stream,
+        headers: {
+          ..._headers,
+          'Content-Type': 'application/json',
+          'Accept': 'application/json, text/event-stream',
+          if (_session.sessionId.isNotEmpty)
+            'Mcp-Session-Id': _session.sessionId,
+          if (_session.protocolVersion.isNotEmpty)
+            'MCP-Protocol-Version': _session.protocolVersion,
+        },
+      );
+
+  /// Sends a JSON-RPC request and returns `(result, responseHeaders)`. Throws
+  /// [McpException] on a JSON-RPC `error` or a missing/invalid result.
+  Future<(Map<String, dynamic>, Headers)> _request(
+    String method,
+    Map<String, dynamic> params, {
+    CancelToken? cancelToken,
+  }) async {
+    final envelope = _envelope(method, params);
+    final response = await _dio.post<ResponseBody>(
+      _url,
+      data: jsonEncode(envelope),
+      options: _options(),
+      cancelToken: cancelToken,
+    );
+    final message = await _readMessage(response, envelope['id'] as int);
+    if (message == null) {
+      throw McpException('Empty response from server for $method');
+    }
+    final error = message['error'];
+    if (error is Map) {
+      throw McpException(
+        (error['message'] as String?) ?? 'Unknown error',
+        code: error['code'] as int?,
+      );
+    }
+    final result = (message['result'] as Map?)?.cast<String, dynamic>();
+    if (result == null) {
+      throw McpException('Malformed JSON-RPC response for $method');
+    }
+    return (result, response.headers);
+  }
+
+  /// Fire-and-forget JSON-RPC notification (no id, no response body expected).
+  Future<void> _notify(String method, Map<String, dynamic> params) async {
+    final response = await _dio.post<ResponseBody>(
+      _url,
+      data: jsonEncode({'jsonrpc': '2.0', 'method': method, 'params': params}),
+      options: _options(),
+      cancelToken: null,
+    );
+    // Drain so the connection is released; the body is ignored (202 Accepted).
+    await _drain(response.data);
+  }
+
+  /// Reads a JSON-RPC message from either an `application/json` body or a
+  /// `text/event-stream` body, returning the message whose `id` matches
+  /// [expectedId] (or the first message that has no id match for json).
+  Future<Map<String, dynamic>?> _readMessage(
+    Response<ResponseBody> response,
+    int expectedId,
+  ) async {
+    final body = response.data;
+    if (body == null) return null;
+    final text = await _drain(body);
+    final contentType =
+        response.headers.value(Headers.contentTypeHeader) ?? '';
+
+    if (contentType.contains('text/event-stream')) {
+      final parser = SseParser();
+      final events = [...parser.addChunk(text), ...parser.flush()];
+      for (final raw in events) {
+        final decoded = _tryDecode(raw);
+        if (decoded != null && decoded['id'] == expectedId) return decoded;
+      }
+      // Fall back to the last decodable event if no id matched.
+      for (final raw in events.reversed) {
+        final decoded = _tryDecode(raw);
+        if (decoded != null) return decoded;
+      }
+      return null;
+    }
+
+    return _tryDecode(text);
+  }
+
+  Map<String, dynamic>? _tryDecode(String raw) {
+    if (raw.trim().isEmpty) return null;
+    try {
+      final decoded = jsonDecode(raw);
+      return decoded is Map<String, dynamic> ? decoded : null;
+    } on FormatException {
+      return null;
+    }
+  }
+
+  /// Drains a streamed [ResponseBody] to a UTF-8 string.
+  Future<String> _drain(ResponseBody? body) async {
+    if (body == null) return '';
+    final bytes = <int>[];
+    await for (final Uint8List chunk in body.stream) {
+      bytes.addAll(chunk);
+    }
+    return utf8.decode(bytes, allowMalformed: true);
+  }
+}
+```
+
+- [ ] **Step 3b: Replace the test's `_ConnectedFixture` with a real helper**
+
+The connection is only reachable through `connect()`, which runs the
+initialize handshake first. Update the test to build a connected fixture by
+stubbing initialize then the operation. Replace the `_ConnectedFixture` class
+**and** update the three tests that use it (`listTools`, `callTool`, error) to
+queue the initialize responses ahead of the operation response. Concretely,
+replace the class with a helper that returns a `Future<McpConnection>`:
+
+```dart
+// Replaces `_ConnectedFixture`. Queues: initialize result, initialized notif
+// ack, then the caller-supplied operation responses.
+Future<McpConnection> _connected(
+  McpService service,
+  void Function(List<Response<ResponseBody>>) stub,
+  List<Response<ResponseBody>> Function(Response<ResponseBody> Function(ResponseBody, {Map<String, List<String>>? headers}) resp, ResponseBody Function(Map<String, dynamic>, {int status}) jsonBody) ops,
+) async {
+  throw UnimplementedError();
+}
+```
+
+This signature is awkward; instead, prefer restructuring each of the three
+tests to call `stubPosts([...])` with the initialize + notif responses
+**prepended** to the operation response, then `final conn = await service.connect('https://mcp.dev/');` before the operation. For example, the `listTools` test body becomes:
+
+```dart
+test('listTools parses tools from an application/json response', () async {
+  stubPosts([
+    // initialize
+    resp(
+      _jsonBody({
+        'jsonrpc': '2.0',
+        'id': 1,
+        'result': {
+          'protocolVersion': '2025-06-18',
+          'serverInfo': {'name': 'demo', 'version': '1'},
+        },
+      }),
+      headers: {'mcp-session-id': ['s1']},
+    ),
+    // initialized notification ack
+    resp(_jsonBody({'jsonrpc': '2.0'})),
+    // tools/list
+    resp(_jsonBody({
+      'jsonrpc': '2.0',
+      'id': 2,
+      'result': {
+        'tools': [
+          {'name': 'add', 'description': 'Add', 'inputSchema': {'type': 'object'}},
+        ],
+      },
+    })),
+  ]);
+
+  final conn = await service.connect('https://mcp.dev/');
+  final tools = await conn.listTools();
+  expect(tools.single.name, 'add');
+});
+```
+
+Apply the same prepend-initialize pattern to the `callTool` (SSE) and error
+tests, then delete the `_ConnectedFixture` class. (The standalone `connect`
+test already stands alone — leave it.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `fvm flutter test test/core/network/mcp_service_test.dart`
+Expected: PASS (all four tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/core/network/mcp_service.dart test/core/network/mcp_service_test.dart
+git commit -m "feat(mcp): McpService — JSON-RPC over Streamable HTTP (json + SSE)"
+```
+
+---
+
+### Task 4: `McpBloc` + events + state
+
+**Files:**
+- Create: `lib/features/mcp/presentation/bloc/mcp_event.dart`
+- Create: `lib/features/mcp/presentation/bloc/mcp_state.dart`
+- Create: `lib/features/mcp/presentation/bloc/mcp_bloc.dart`
+- Test: `test/features/mcp/presentation/bloc/mcp_bloc_test.dart`
+
+**Interfaces:**
+- Consumes: `McpService`, `McpConnection`, `McpException` (Task 3); `McpTool`, `McpToolResult` (Task 2).
+- Produces:
+  - Events: `McpConnectRequested({required String tabId, required String url, Map<String, String> headers})`, `McpDisconnectRequested(String tabId)`, `McpToolSelected({required String tabId, required String toolName})`, `McpToolCallRequested({required String tabId, required String toolName, required Map<String, dynamic> arguments})`.
+  - State: `McpState({Map<String, McpTabSession> sessions})` with `McpTabSession sessionFor(String tabId)`.
+  - `McpConnectionStatus { disconnected, connecting, connected, error }`.
+  - `McpTabSession({McpConnectionStatus status, McpSession? session, List<McpTool> tools, String? selectedTool, McpToolResult? lastResult, bool calling, String? errorMessage, List<String> log})` with `copyWith`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/features/mcp/presentation/bloc/mcp_bloc_test.dart`:
+
+```dart
+import 'package:bloc_test/bloc_test.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/core/network/mcp_service.dart';
+import 'package:getman/features/mcp/domain/entities/mcp_session.dart';
+import 'package:getman/features/mcp/domain/entities/mcp_tool.dart';
+import 'package:getman/features/mcp/domain/entities/mcp_tool_result.dart';
+import 'package:getman/features/mcp/presentation/bloc/mcp_bloc.dart';
+import 'package:getman/features/mcp/presentation/bloc/mcp_event.dart';
+import 'package:getman/features/mcp/presentation/bloc/mcp_state.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockService extends Mock implements McpService {}
+
+class _MockConnection extends Mock implements McpConnection {}
+
+void main() {
+  late _MockService service;
+  late _MockConnection conn;
+
+  const tool = McpTool(name: 'add', description: 'Add', inputSchema: {});
+  const session = McpSession(
+    sessionId: 's1',
+    protocolVersion: '2025-06-18',
+    serverName: 'demo',
+    serverVersion: '1',
+  );
+
+  setUp(() {
+    service = _MockService();
+    conn = _MockConnection();
+    when(() => conn.session).thenReturn(session);
+    when(() => conn.listTools()).thenAnswer((_) async => [tool]);
+    when(() => conn.close()).thenAnswer((_) async {});
+  });
+
+  blocTest<McpBloc, McpState>(
+    'connect → connected with tools',
+    build: () {
+      when(() => service.connect(any(), headers: any(named: 'headers')))
+          .thenAnswer((_) async => conn);
+      return McpBloc(service: service);
+    },
+    act: (b) => b.add(
+      const McpConnectRequested(tabId: 't1', url: 'https://mcp.dev/'),
+    ),
+    verify: (b) {
+      final s = b.state.sessionFor('t1');
+      expect(s.status, McpConnectionStatus.connected);
+      expect(s.tools.single.name, 'add');
+      expect(s.session?.serverName, 'demo');
+    },
+  );
+
+  blocTest<McpBloc, McpState>(
+    'connect failure → error status with message',
+    build: () {
+      when(() => service.connect(any(), headers: any(named: 'headers')))
+          .thenThrow(McpException('nope', code: -1));
+      return McpBloc(service: service);
+    },
+    act: (b) => b.add(
+      const McpConnectRequested(tabId: 't1', url: 'https://mcp.dev/'),
+    ),
+    verify: (b) {
+      final s = b.state.sessionFor('t1');
+      expect(s.status, McpConnectionStatus.error);
+      expect(s.errorMessage, contains('nope'));
+    },
+  );
+
+  blocTest<McpBloc, McpState>(
+    'call tool → lastResult populated',
+    build: () {
+      when(() => service.connect(any(), headers: any(named: 'headers')))
+          .thenAnswer((_) async => conn);
+      when(
+        () => conn.callTool(any(), any(), cancelToken: any(named: 'cancelToken')),
+      ).thenAnswer(
+        (_) async => const McpToolResult(
+          isError: false,
+          textBlocks: ['42'],
+          rawBlocks: [],
+        ),
+      );
+      return McpBloc(service: service);
+    },
+    act: (b) async {
+      b.add(const McpConnectRequested(tabId: 't1', url: 'https://mcp.dev/'));
+      await Future<void>.delayed(Duration.zero);
+      b.add(
+        const McpToolCallRequested(
+          tabId: 't1',
+          toolName: 'add',
+          arguments: {'a': 1, 'b': 2},
+        ),
+      );
+    },
+    verify: (b) {
+      expect(b.state.sessionFor('t1').lastResult?.textBlocks, ['42']);
+    },
+  );
+
+  blocTest<McpBloc, McpState>(
+    'disconnect closes the connection and resets status',
+    build: () {
+      when(() => service.connect(any(), headers: any(named: 'headers')))
+          .thenAnswer((_) async => conn);
+      return McpBloc(service: service);
+    },
+    act: (b) async {
+      b.add(const McpConnectRequested(tabId: 't1', url: 'https://mcp.dev/'));
+      await Future<void>.delayed(Duration.zero);
+      b.add(const McpDisconnectRequested('t1'));
+    },
+    verify: (b) {
+      expect(b.state.sessionFor('t1').status, McpConnectionStatus.disconnected);
+      verify(() => conn.close()).called(1);
+    },
+  );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `fvm flutter test test/features/mcp/presentation/bloc/mcp_bloc_test.dart`
+Expected: FAIL — bloc/event/state files don't exist.
+
+- [ ] **Step 3: Create event, state, and bloc**
+
+Create `lib/features/mcp/presentation/bloc/mcp_event.dart`:
+
+```dart
+import 'package:equatable/equatable.dart';
+
+abstract class McpEvent extends Equatable {
+  const McpEvent();
+  @override
+  List<Object?> get props => [];
+}
+
+class McpConnectRequested extends McpEvent {
+  const McpConnectRequested({
+    required this.tabId,
+    required this.url,
+    this.headers = const {},
+  });
+  final String tabId;
+  final String url;
+  final Map<String, String> headers;
+  @override
+  List<Object?> get props => [tabId, url, headers];
+}
+
+class McpDisconnectRequested extends McpEvent {
+  const McpDisconnectRequested(this.tabId);
+  final String tabId;
+  @override
+  List<Object?> get props => [tabId];
+}
+
+class McpToolSelected extends McpEvent {
+  const McpToolSelected({required this.tabId, required this.toolName});
+  final String tabId;
+  final String toolName;
+  @override
+  List<Object?> get props => [tabId, toolName];
+}
+
+class McpToolCallRequested extends McpEvent {
+  const McpToolCallRequested({
+    required this.tabId,
+    required this.toolName,
+    required this.arguments,
+  });
+  final String tabId;
+  final String toolName;
+  final Map<String, dynamic> arguments;
+  @override
+  List<Object?> get props => [tabId, toolName, arguments];
+}
+```
+
+Create `lib/features/mcp/presentation/bloc/mcp_state.dart`:
+
+```dart
+import 'package:equatable/equatable.dart';
+import 'package:getman/features/mcp/domain/entities/mcp_session.dart';
+import 'package:getman/features/mcp/domain/entities/mcp_tool.dart';
+import 'package:getman/features/mcp/domain/entities/mcp_tool_result.dart';
+
+enum McpConnectionStatus { disconnected, connecting, connected, error }
+
+/// The MCP state for one tab: connection status, server session, advertised
+/// tools, the selected tool, the last call result, and a debug log of traffic.
+class McpTabSession extends Equatable {
+  const McpTabSession({
+    this.status = McpConnectionStatus.disconnected,
+    this.session,
+    this.tools = const [],
+    this.selectedTool,
+    this.lastResult,
+    this.calling = false,
+    this.errorMessage,
+    this.log = const [],
+  });
+
+  final McpConnectionStatus status;
+  final McpSession? session;
+  final List<McpTool> tools;
+  final String? selectedTool;
+  final McpToolResult? lastResult;
+  final bool calling;
+  final String? errorMessage;
+  final List<String> log;
+
+  McpTabSession copyWith({
+    McpConnectionStatus? status,
+    McpSession? session,
+    List<McpTool>? tools,
+    String? selectedTool,
+    McpToolResult? lastResult,
+    bool? calling,
+    String? errorMessage,
+    List<String>? log,
+  }) =>
+      McpTabSession(
+        status: status ?? this.status,
+        session: session ?? this.session,
+        tools: tools ?? this.tools,
+        selectedTool: selectedTool ?? this.selectedTool,
+        lastResult: lastResult ?? this.lastResult,
+        calling: calling ?? this.calling,
+        errorMessage: errorMessage,
+        log: log ?? this.log,
+      );
+
+  @override
+  List<Object?> get props => [
+        status,
+        session,
+        tools,
+        selectedTool,
+        lastResult,
+        calling,
+        errorMessage,
+        log,
+      ];
+}
+
+class McpState extends Equatable {
+  const McpState({this.sessions = const {}});
+  final Map<String, McpTabSession> sessions;
+
+  McpTabSession sessionFor(String tabId) =>
+      sessions[tabId] ?? const McpTabSession();
+
+  McpState withSession(String tabId, McpTabSession session) =>
+      McpState(sessions: {...sessions, tabId: session});
+
+  @override
+  List<Object?> get props => [sessions];
+}
+```
+
+> Note: `copyWith` sets `errorMessage` directly (not `?? this.errorMessage`) so
+> a successful step can clear a prior error by passing `errorMessage: null`.
+
+Create `lib/features/mcp/presentation/bloc/mcp_bloc.dart`:
+
+```dart
+import 'dart:developer';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:getman/core/network/mcp_service.dart';
+import 'package:getman/features/mcp/presentation/bloc/mcp_event.dart';
+import 'package:getman/features/mcp/presentation/bloc/mcp_state.dart';
+
+/// Owns one live [McpConnection] per tab and its derived state. Mirrors
+/// RealtimeBloc's teardown discipline: a connection is closed on disconnect, on
+/// reconnect for the same tab, and on bloc close.
+class McpBloc extends Bloc<McpEvent, McpState> {
+  McpBloc({required McpService service})
+      : _service = service,
+        super(const McpState()) {
+    on<McpConnectRequested>(_onConnect);
+    on<McpDisconnectRequested>(_onDisconnect);
+    on<McpToolSelected>(_onToolSelected);
+    on<McpToolCallRequested>(_onCallTool);
+  }
+
+  final McpService _service;
+  final Map<String, McpConnection> _connections = {};
+
+  Future<void> _onConnect(
+    McpConnectRequested event,
+    Emitter<McpState> emit,
+  ) async {
+    await _teardown(event.tabId);
+    emit(
+      state.withSession(
+        event.tabId,
+        const McpTabSession(status: McpConnectionStatus.connecting),
+      ),
+    );
+    try {
+      final conn = await _service.connect(event.url, headers: event.headers);
+      _connections[event.tabId] = conn;
+      final tools = await conn.listTools();
+      emit(
+        state.withSession(
+          event.tabId,
+          McpTabSession(
+            status: McpConnectionStatus.connected,
+            session: conn.session,
+            tools: tools,
+            log: [
+              'Connected to ${conn.session.serverName} '
+                  '(${conn.session.protocolVersion})',
+              'Listed ${tools.length} tool(s)',
+            ],
+          ),
+        ),
+      );
+    } on Object catch (e) {
+      log('MCP connect failed: $e', name: 'McpBloc');
+      await _teardown(event.tabId);
+      emit(
+        state.withSession(
+          event.tabId,
+          McpTabSession(
+            status: McpConnectionStatus.error,
+            errorMessage: e.toString(),
+            log: ['Connect failed: $e'],
+          ),
+        ),
+      );
+    }
+  }
+
+  Future<void> _onDisconnect(
+    McpDisconnectRequested event,
+    Emitter<McpState> emit,
+  ) async {
+    await _teardown(event.tabId);
+    emit(
+      state.withSession(
+        event.tabId,
+        const McpTabSession(),
+      ),
+    );
+  }
+
+  void _onToolSelected(McpToolSelected event, Emitter<McpState> emit) {
+    final s = state.sessionFor(event.tabId);
+    emit(
+      state.withSession(
+        event.tabId,
+        s.copyWith(selectedTool: event.toolName, lastResult: null),
+      ),
+    );
+  }
+
+  Future<void> _onCallTool(
+    McpToolCallRequested event,
+    Emitter<McpState> emit,
+  ) async {
+    final conn = _connections[event.tabId];
+    if (conn == null) return;
+    final base = state.sessionFor(event.tabId);
+    emit(
+      state.withSession(
+        event.tabId,
+        base.copyWith(calling: true, selectedTool: event.toolName),
+      ),
+    );
+    try {
+      final result = await conn.callTool(event.toolName, event.arguments);
+      final after = state.sessionFor(event.tabId);
+      emit(
+        state.withSession(
+          event.tabId,
+          after.copyWith(
+            calling: false,
+            lastResult: result,
+            log: [...after.log, 'Called ${event.toolName}'],
+          ),
+        ),
+      );
+    } on Object catch (e) {
+      log('MCP tool call failed: $e', name: 'McpBloc');
+      final after = state.sessionFor(event.tabId);
+      emit(
+        state.withSession(
+          event.tabId,
+          after.copyWith(
+            calling: false,
+            errorMessage: e.toString(),
+            log: [...after.log, 'Call failed: $e'],
+          ),
+        ),
+      );
+    }
+  }
+
+  Future<void> _teardown(String tabId) async {
+    await _connections.remove(tabId)?.close();
+  }
+
+  @override
+  Future<void> close() async {
+    for (final conn in _connections.values) {
+      await conn.close();
+    }
+    _connections.clear();
+    return super.close();
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `fvm flutter test test/features/mcp/presentation/bloc/mcp_bloc_test.dart`
+Expected: PASS (all four `blocTest`s).
+
+- [ ] **Step 5: Run bloc_lint on the new bloc**
+
+Run: `fvm dart run bloc_tools:bloc lint lib`
+Expected: no issues (confirms no Flutter import / naming violations).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/features/mcp/presentation/bloc test/features/mcp/presentation
+git commit -m "feat(mcp): McpBloc owning one MCP connection + tool state per tab"
+```
+
+---
+
+### Task 5: Register `McpService` + `McpBloc` in DI and provide the bloc
+
+**Files:**
+- Modify: `lib/core/di/injection_container.dart:242-244` (the Realtime block)
+- Modify: `lib/main.dart` (imports + the `MultiBlocProvider` `providers` list near line 216)
+- Test: `test/features/mcp/di_registration_test.dart`
+
+**Interfaces:**
+- Consumes: `McpService` (Task 3), `McpBloc` (Task 4), the existing `sl` GetIt instance.
+- Produces: `sl<McpService>()` and `sl<McpBloc>()` resolve; `McpBloc` is provided above `MaterialApp`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/features/mcp/di_registration_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/core/di/injection_container.dart' as di;
+import 'package:getman/core/network/mcp_service.dart';
+import 'package:getman/features/mcp/presentation/bloc/mcp_bloc.dart';
+
+void main() {
+  test('McpService and McpBloc are registered after init', () async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    await di.init();
+    expect(di.sl.isRegistered<McpService>(), isTrue);
+    expect(di.sl<McpBloc>(), isA<McpBloc>());
+  });
+}
+```
+
+> If `di.init()` requires Hive temp dirs and other suites already do this setup,
+> follow the pattern in an existing DI/integration test (e.g. search
+> `test/` for `di.init(`); reuse its `setUp`/`setUpAll` (Hive `path_provider`
+> mock) verbatim if present. If no such test exists, this test may need the
+> same `hive_test`/temp-dir bootstrapping — match the project's convention.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `fvm flutter test test/features/mcp/di_registration_test.dart`
+Expected: FAIL — `McpService`/`McpBloc` not registered.
+
+- [ ] **Step 3: Register in DI**
+
+In `lib/core/di/injection_container.dart`, add imports (respecting
+`directives_ordering` — alphabetical within the `package:getman` group):
+
+```dart
+import 'package:getman/core/network/mcp_service.dart';
+import 'package:getman/features/mcp/presentation/bloc/mcp_bloc.dart';
+```
+
+Then, immediately after the Realtime registrations (currently lines 242-244):
+
+```dart
+    // Features - MCP (Model Context Protocol client over Streamable HTTP)
+    ..registerLazySingleton(McpService.new)
+    ..registerLazySingleton(() => McpBloc(service: sl()))
+```
+
+- [ ] **Step 4: Provide the bloc in `main.dart`**
+
+In `lib/main.dart`, add the import (alphabetical in the `package:getman` group):
+
+```dart
+import 'package:getman/features/mcp/presentation/bloc/mcp_bloc.dart';
+```
+
+Then in the `MultiBlocProvider` `providers` list, directly after the
+`BlocProvider(create: (_) => di.sl<RealtimeBloc>())` line (near line 216):
+
+```dart
+          BlocProvider(create: (_) => di.sl<McpBloc>()),
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `fvm flutter test test/features/mcp/di_registration_test.dart`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/core/di/injection_container.dart lib/main.dart test/features/mcp/di_registration_test.dart
+git commit -m "feat(mcp): register McpService + McpBloc in DI and provide app-wide"
+```
+
+---
+
+### Task 6: URL-bar wiring — MCP dropdown item + CONNECT button
+
+**Files:**
+- Modify: `lib/features/tabs/presentation/widgets/request_kind_method_selector.dart`
+- Create: `lib/features/mcp/presentation/widgets/mcp_connect_button.dart`
+- Modify: `lib/features/tabs/presentation/widgets/url_bar.dart` (the send/connect button branch near line 432)
+- Test: `test/features/mcp/presentation/widgets/mcp_connect_button_test.dart`
+
+**Interfaces:**
+- Consumes: `McpBloc`, `McpConnectRequested`, `McpDisconnectRequested`, `McpState`/`McpConnectionStatus` (Tasks 4); `EnvironmentResolver.resolve`/`resolveMap`; `TabsBloc` for reading the live config; `context.appLayout`/`appTypography`/`appDecoration`.
+- Produces: `McpConnectButton({required String tabId, required HttpRequestConfigEntity config, required bool isNarrow, required Map<String, String> activeVars})`.
+
+- [ ] **Step 1: Add the MCP dropdown item**
+
+In `request_kind_method_selector.dart`, add to the `DropdownButton<RequestKind>`
+`items` list, after the SSE item:
+
+```dart
+                DropdownMenuItem(value: RequestKind.mcp, child: Text('MCP')),
+```
+
+(No test needed for this one-line list addition; it is covered by the connect-button test compiling against the new kind and by analyze.)
+
+- [ ] **Step 2: Write the failing connect-button test**
+
+Create `test/features/mcp/presentation/widgets/mcp_connect_button_test.dart`:
+
+```dart
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/core/domain/entities/request_config_entity.dart';
+import 'package:getman/core/network/request_kind.dart';
+import 'package:getman/core/theme/theme_registry.dart';
+import 'package:getman/features/mcp/presentation/bloc/mcp_bloc.dart';
+import 'package:getman/features/mcp/presentation/bloc/mcp_event.dart';
+import 'package:getman/features/mcp/presentation/bloc/mcp_state.dart';
+import 'package:getman/features/mcp/presentation/widgets/mcp_connect_button.dart';
+import 'package:getman/features/tabs/domain/entities/request_tab_entity.dart';
+import 'package:getman/features/tabs/presentation/bloc/tabs_bloc.dart';
+import 'package:getman/features/tabs/presentation/bloc/tabs_state.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockMcpBloc extends MockBloc<McpEvent, McpState> implements McpBloc {}
+
+class _MockTabsBloc extends MockBloc<dynamic, TabsState> implements TabsBloc {}
+
+void main() {
+  late _MockMcpBloc mcp;
+  late _MockTabsBloc tabs;
+
+  const config = HttpRequestConfigEntity(
+    id: 'c1',
+    url: 'https://mcp.dev/',
+    kind: RequestKind.mcp,
+  );
+  const tab = HttpRequestTabEntity(tabId: 't1', name: 'T', config: config);
+
+  setUp(() {
+    mcp = _MockMcpBloc();
+    tabs = _MockTabsBloc();
+    when(() => tabs.state).thenReturn(
+      const TabsState(
+        panels: [
+          PanelEntity(id: 'p1', name: 'Panel 1', tabs: [tab], activeTabId: 't1'),
+        ],
+        activePanelId: 'p1',
+      ),
+    );
+  });
+
+  Widget harness(McpState mcpState) {
+    when(() => mcp.state).thenReturn(mcpState);
+    return MaterialApp(
+      theme: resolveTheme('classic')(Brightness.light, false),
+      home: Scaffold(
+        body: MultiBlocProvider(
+          providers: [
+            BlocProvider<McpBloc>.value(value: mcp),
+            BlocProvider<TabsBloc>.value(value: tabs),
+          ],
+          child: const McpConnectButton(
+            tabId: 't1',
+            config: config,
+            isNarrow: false,
+            activeVars: {},
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('shows CONNECT when disconnected and dispatches connect',
+      (tester) async {
+    await tester.pumpWidget(harness(const McpState()));
+    expect(find.text('CONNECT'), findsOneWidget);
+    await tester.tap(find.byKey(const ValueKey('mcp_connect_button')));
+    await tester.pump();
+    verify(
+      () => mcp.add(
+        any(that: isA<McpConnectRequested>()),
+      ),
+    ).called(1);
+  });
+
+  testWidgets('shows DISCONNECT when connected', (tester) async {
+    await tester.pumpWidget(
+      harness(
+        const McpState(
+          sessions: {
+            't1': McpTabSession(status: McpConnectionStatus.connected),
+          },
+        ),
+      ),
+    );
+    expect(find.text('DISCONNECT'), findsOneWidget);
+  });
+}
+```
+
+> If the `TabsState`/`PanelEntity` constructor argument names differ, adjust to
+> match `lib/features/tabs/presentation/bloc/tabs_state.dart` and
+> `lib/features/tabs/domain/entities/panel_entity.dart` — read those for the
+> exact required params.
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `fvm flutter test test/features/mcp/presentation/widgets/mcp_connect_button_test.dart`
+Expected: FAIL — `mcp_connect_button.dart` doesn't exist.
+
+- [ ] **Step 4: Create the connect button**
+
+Create `lib/features/mcp/presentation/widgets/mcp_connect_button.dart` (closely
+mirrors `RealtimeButton`):
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:getman/core/domain/entities/request_config_entity.dart';
+import 'package:getman/core/theme/app_theme.dart';
+import 'package:getman/core/utils/environment_resolver.dart';
+import 'package:getman/features/mcp/presentation/bloc/mcp_bloc.dart';
+import 'package:getman/features/mcp/presentation/bloc/mcp_event.dart';
+import 'package:getman/features/mcp/presentation/bloc/mcp_state.dart';
+import 'package:getman/features/tabs/domain/entities/request_tab_entity.dart';
+import 'package:getman/features/tabs/presentation/bloc/tabs_bloc.dart';
+
+/// CONNECT / DISCONNECT button for MCP requests, driven by the MCP connection
+/// status for this tab. Resolves `{{var}}` in the endpoint URL + headers at
+/// press time (the URL bar does not rebuild on URL edits, so read the live
+/// config from TabsBloc).
+class McpConnectButton extends StatelessWidget {
+  const McpConnectButton({
+    required this.tabId,
+    required this.config,
+    required this.isNarrow,
+    required this.activeVars,
+    super.key,
+  });
+  final String tabId;
+  final HttpRequestConfigEntity config;
+  final bool isNarrow;
+  final Map<String, String> activeVars;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final layout = context.appLayout;
+    return BlocBuilder<McpBloc, McpState>(
+      buildWhen: (p, n) =>
+          p.sessionFor(tabId).status != n.sessionFor(tabId).status,
+      builder: (context, mcp) {
+        final status = mcp.sessionFor(tabId).status;
+        final connected = status == McpConnectionStatus.connected;
+        final connecting = status == McpConnectionStatus.connecting;
+        return context.appDecoration.wrapInteractive(
+          child: ElevatedButton(
+            key: const ValueKey('mcp_connect_button'),
+            onPressed: connecting
+                ? null
+                : () {
+                    final bloc = context.read<McpBloc>();
+                    if (connected) {
+                      bloc.add(McpDisconnectRequested(tabId));
+                      return;
+                    }
+                    final current = context
+                            .read<TabsBloc>()
+                            .state
+                            .tabs
+                            .byId(tabId)
+                            ?.config ??
+                        config;
+                    bloc.add(
+                      McpConnectRequested(
+                        tabId: tabId,
+                        url: EnvironmentResolver.resolve(
+                          current.url,
+                          activeVars,
+                        ),
+                        headers: EnvironmentResolver.resolveMap(
+                          current.headers,
+                          activeVars,
+                        ),
+                      ),
+                    );
+                  },
+            style: ElevatedButton.styleFrom(
+              backgroundColor: connected ? theme.colorScheme.error : null,
+              foregroundColor: connected ? theme.colorScheme.onError : null,
+              padding: EdgeInsets.symmetric(
+                horizontal: isNarrow ? 12 : layout.buttonPaddingHorizontal,
+                vertical: isNarrow ? 10 : layout.buttonPaddingVertical,
+              ),
+              minimumSize: Size.zero,
+              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            ),
+            child: Text(
+              connected
+                  ? (isNarrow ? 'STOP' : 'DISCONNECT')
+                  : (connecting ? '...' : 'CONNECT'),
+              style: TextStyle(
+                fontSize: layout.fontSizeTitle,
+                fontWeight: context.appTypography.displayWeight,
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+```
+
+- [ ] **Step 5: Wire it into the URL bar**
+
+In `lib/features/tabs/presentation/widgets/url_bar.dart`, locate the
+send/connect branch (currently `if (tab.config.kind == RequestKind.http) ... else RealtimeButton(...)` near lines 345/432). Change the `else` into a kind switch so MCP gets its own button. Add the import:
+
+```dart
+import 'package:getman/features/mcp/presentation/widgets/mcp_connect_button.dart';
+```
+
+Replace the trailing `else RealtimeButton(...)` with:
+
+```dart
+                          else if (tab.config.kind == RequestKind.mcp)
+                            McpConnectButton(
+                              tabId: tab.tabId,
+                              config: tab.config,
+                              isNarrow: isNarrow,
+                              activeVars: _activeVariables(context),
+                            )
+                          else
+                            RealtimeButton(
+                              tabId: tab.tabId,
+                              config: tab.config,
+                              isNarrow: isNarrow,
+                              activeVars: _activeVariables(context),
+                            ),
+```
+
+- [ ] **Step 6: Run tests + analyze**
+
+Run: `fvm flutter test test/features/mcp/presentation/widgets/mcp_connect_button_test.dart`
+Expected: PASS.
+Run: `fvm flutter analyze lib/features/tabs/presentation/widgets/url_bar.dart lib/features/mcp`
+Expected: 0 issues.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/features/tabs/presentation/widgets/request_kind_method_selector.dart lib/features/tabs/presentation/widgets/url_bar.dart lib/features/mcp/presentation/widgets/mcp_connect_button.dart test/features/mcp/presentation/widgets/mcp_connect_button_test.dart
+git commit -m "feat(mcp): MCP kind in selector + CONNECT button in URL bar"
+```
+
+---
+
+### Task 7: `McpPanel` + `ResponseArea` switch
+
+**Files:**
+- Create: `lib/features/mcp/presentation/widgets/mcp_panel.dart`
+- Modify: `lib/features/tabs/presentation/widgets/response_area.dart`
+- Test: `test/features/mcp/presentation/widgets/mcp_panel_test.dart`
+
+**Interfaces:**
+- Consumes: `McpBloc`/`McpState`/`McpConnectionStatus`/`McpTabSession` (Task 4); `McpTool`/`McpToolResult` (Task 2); `McpToolSelected`/`McpToolCallRequested` (Task 4); `createJsonCodeController` + `JsonCodeEditor` (`lib/features/tabs/presentation/widgets/json_code_editor.dart`); `context.appLayout`/`appPalette`/`appTypography`/`appShape`.
+- Produces: `McpPanel({required String tabId})`.
+
+**Behavior:** When `status != connected`, show a centered hint ("Not connected — press CONNECT" / error message / spinner for connecting). When connected: a tool list (tappable rows dispatching `McpToolSelected`); for the selected tool, a read-only schema reference (`JsonCodeEditor(readOnly: true)`) + an editable JSON args editor + a "CALL" button dispatching `McpToolCallRequested` with the parsed args (invalid JSON shows an inline error and does not dispatch); the last result (text blocks, or raw JSON for non-text); and a collapsible session log.
+
+- [ ] **Step 1: Write the failing widget test**
+
+Create `test/features/mcp/presentation/widgets/mcp_panel_test.dart`:
+
+```dart
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/core/theme/theme_registry.dart';
+import 'package:getman/features/mcp/domain/entities/mcp_tool.dart';
+import 'package:getman/features/mcp/domain/entities/mcp_tool_result.dart';
+import 'package:getman/features/mcp/presentation/bloc/mcp_bloc.dart';
+import 'package:getman/features/mcp/presentation/bloc/mcp_event.dart';
+import 'package:getman/features/mcp/presentation/bloc/mcp_state.dart';
+import 'package:getman/features/mcp/presentation/widgets/mcp_panel.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockMcpBloc extends MockBloc<McpEvent, McpState> implements McpBloc {}
+
+void main() {
+  late _MockMcpBloc mcp;
+
+  setUp(() => mcp = _MockMcpBloc());
+
+  Widget harness(McpState state) {
+    when(() => mcp.state).thenReturn(state);
+    return MaterialApp(
+      theme: resolveTheme('classic')(Brightness.light, false),
+      home: Scaffold(
+        body: BlocProvider<McpBloc>.value(
+          value: mcp,
+          child: const SizedBox(
+            width: 800,
+            height: 600,
+            child: McpPanel(tabId: 't1'),
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('disconnected shows a hint', (tester) async {
+    await tester.pumpWidget(harness(const McpState()));
+    expect(find.textContaining('CONNECT'), findsWidgets);
+  });
+
+  testWidgets('connected lists tools and renders without overflow',
+      (tester) async {
+    await tester.pumpWidget(
+      harness(
+        const McpState(
+          sessions: {
+            't1': McpTabSession(
+              status: McpConnectionStatus.connected,
+              tools: [
+                McpTool(name: 'add', description: 'Add', inputSchema: {}),
+                McpTool(name: 'echo', description: 'Echo', inputSchema: {}),
+              ],
+              selectedTool: 'add',
+              lastResult: McpToolResult(
+                isError: false,
+                textBlocks: ['result text'],
+                rawBlocks: [],
+              ),
+            ),
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('add'), findsWidgets);
+    expect(find.text('echo'), findsWidgets);
+    expect(find.textContaining('result text'), findsWidgets);
+    expect(tester.takeException(), isNull); // no RenderFlex overflow
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `fvm flutter test test/features/mcp/presentation/widgets/mcp_panel_test.dart`
+Expected: FAIL — `mcp_panel.dart` doesn't exist.
+
+- [ ] **Step 3: Create the panel**
+
+Create `lib/features/mcp/presentation/widgets/mcp_panel.dart`:
+
+```dart
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:getman/core/theme/app_theme.dart';
+import 'package:getman/features/mcp/domain/entities/mcp_tool.dart';
+import 'package:getman/features/mcp/presentation/bloc/mcp_bloc.dart';
+import 'package:getman/features/mcp/presentation/bloc/mcp_event.dart';
+import 'package:getman/features/mcp/presentation/bloc/mcp_state.dart';
+import 'package:getman/features/tabs/presentation/widgets/json_code_editor.dart';
+import 'package:re_editor/re_editor.dart';
+
+/// Post-connect MCP UI for one tab: tool list, the selected tool's schema +
+/// JSON arguments editor + CALL, the last result, and a session log. Connecting
+/// itself is driven by the URL-bar CONNECT button.
+class McpPanel extends StatefulWidget {
+  const McpPanel({required this.tabId, super.key});
+  final String tabId;
+
+  @override
+  State<McpPanel> createState() => _McpPanelState();
+}
+
+class _McpPanelState extends State<McpPanel> {
+  final CodeLineEditingController _args = createJsonCodeController();
+  String? _argsErrorFor;
+  String? _editingTool;
+
+  @override
+  void dispose() {
+    _args.dispose();
+    super.dispose();
+  }
+
+  void _syncArgsForTool(String? tool) {
+    if (tool == _editingTool) return;
+    _editingTool = tool;
+    _args.text = '{}';
+    _argsErrorFor = null;
+  }
+
+  void _call(BuildContext context, String tool) {
+    final raw = _args.text.trim().isEmpty ? '{}' : _args.text;
+    Map<String, dynamic>? parsed;
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is Map<String, dynamic>) parsed = decoded;
+    } on FormatException {
+      parsed = null;
+    }
+    if (parsed == null) {
+      setState(() => _argsErrorFor = 'Arguments must be a JSON object');
+      return;
+    }
+    setState(() => _argsErrorFor = null);
+    context.read<McpBloc>().add(
+          McpToolCallRequested(
+            tabId: widget.tabId,
+            toolName: tool,
+            arguments: parsed,
+          ),
+        );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final layout = context.appLayout;
+    final palette = context.appPalette;
+    final typo = context.appTypography;
+    final theme = Theme.of(context);
+
+    return BlocBuilder<McpBloc, McpState>(
+      buildWhen: (p, n) => p.sessionFor(widget.tabId) != n.sessionFor(widget.tabId),
+      builder: (context, state) {
+        final s = state.sessionFor(widget.tabId);
+
+        if (s.status != McpConnectionStatus.connected) {
+          return Center(
+            child: Padding(
+              padding: EdgeInsets.all(layout.spacingLarge),
+              child: Text(
+                switch (s.status) {
+                  McpConnectionStatus.connecting => 'Connecting…',
+                  McpConnectionStatus.error =>
+                    s.errorMessage ?? 'Connection error',
+                  _ => 'Not connected — press CONNECT to list tools',
+                },
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  color: s.status == McpConnectionStatus.error
+                      ? theme.colorScheme.error
+                      : theme.colorScheme.onSurface,
+                  fontWeight: typo.bodyWeight,
+                ),
+              ),
+            ),
+          );
+        }
+
+        _syncArgsForTool(s.selectedTool);
+        final selected = s.tools
+            .where((t) => t.name == s.selectedTool)
+            .cast<McpTool?>()
+            .firstOrNull;
+
+        return Padding(
+          padding: EdgeInsets.all(layout.spacingMedium),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(
+                'Tools (${s.tools.length})',
+                style: TextStyle(fontWeight: typo.titleWeight),
+              ),
+              SizedBox(height: layout.spacingSmall),
+              // Tool chips.
+              Wrap(
+                spacing: layout.spacingSmall,
+                runSpacing: layout.spacingSmall,
+                children: s.tools
+                    .map(
+                      (t) => ChoiceChip(
+                        label: Text(t.name),
+                        selected: t.name == s.selectedTool,
+                        onSelected: (_) => context.read<McpBloc>().add(
+                              McpToolSelected(
+                                tabId: widget.tabId,
+                                toolName: t.name,
+                              ),
+                            ),
+                      ),
+                    )
+                    .toList(),
+              ),
+              SizedBox(height: layout.spacingMedium),
+              if (selected != null)
+                Expanded(
+                  child: _ToolDetail(
+                    tool: selected,
+                    argsController: _args,
+                    argsError: _argsErrorFor,
+                    calling: s.calling,
+                    resultText: _resultText(s),
+                    onCall: () => _call(context, selected.name),
+                  ),
+                )
+              else
+                Expanded(
+                  child: Center(
+                    child: Text(
+                      'Select a tool',
+                      style: TextStyle(color: palette.codeBackground),
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  String _resultText(McpTabSession s) {
+    final r = s.lastResult;
+    if (r == null) return '';
+    if (r.textBlocks.isNotEmpty) return r.textBlocks.join('\n');
+    if (r.rawBlocks.isNotEmpty) {
+      return const JsonEncoder.withIndent('  ').convert(r.rawBlocks);
+    }
+    return r.isError ? '(error, no content)' : '(no content)';
+  }
+}
+
+class _ToolDetail extends StatelessWidget {
+  const _ToolDetail({
+    required this.tool,
+    required this.argsController,
+    required this.argsError,
+    required this.calling,
+    required this.resultText,
+    required this.onCall,
+  });
+  final McpTool tool;
+  final CodeLineEditingController argsController;
+  final String? argsError;
+  final bool calling;
+  final String resultText;
+  final VoidCallback onCall;
+
+  @override
+  Widget build(BuildContext context) {
+    final layout = context.appLayout;
+    final typo = context.appTypography;
+    final theme = Theme.of(context);
+    final schemaText = tool.inputSchema.isEmpty
+        ? '(no input schema)'
+        : const JsonEncoder.withIndent('  ').convert(tool.inputSchema);
+
+    return SingleChildScrollView(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          if (tool.description.isNotEmpty) ...[
+            Text(tool.description, style: TextStyle(fontWeight: typo.bodyWeight)),
+            SizedBox(height: layout.spacingSmall),
+          ],
+          Text('Input schema', style: TextStyle(fontWeight: typo.titleWeight)),
+          SizedBox(height: layout.spacingSmall),
+          SizedBox(
+            height: 160,
+            child: JsonCodeEditor(
+              controller: createJsonCodeController()..text = schemaText,
+              readOnly: true,
+              autofocus: false,
+            ),
+          ),
+          SizedBox(height: layout.spacingMedium),
+          Text('Arguments (JSON)',
+              style: TextStyle(fontWeight: typo.titleWeight)),
+          SizedBox(height: layout.spacingSmall),
+          SizedBox(
+            height: 160,
+            child: JsonCodeEditor(
+              controller: argsController,
+              autofocus: false,
+            ),
+          ),
+          if (argsError != null) ...[
+            SizedBox(height: layout.spacingSmall),
+            Text(argsError!, style: TextStyle(color: theme.colorScheme.error)),
+          ],
+          SizedBox(height: layout.spacingMedium),
+          Align(
+            alignment: Alignment.centerLeft,
+            child: context.appDecoration.wrapInteractive(
+              child: ElevatedButton(
+                key: const ValueKey('mcp_call_button'),
+                onPressed: calling ? null : onCall,
+                child: Text(
+                  calling ? 'CALLING…' : 'CALL',
+                  style: TextStyle(fontWeight: typo.displayWeight),
+                ),
+              ),
+            ),
+          ),
+          if (resultText.isNotEmpty) ...[
+            SizedBox(height: layout.spacingMedium),
+            Text('Result', style: TextStyle(fontWeight: typo.titleWeight)),
+            SizedBox(height: layout.spacingSmall),
+            SelectableText(resultText),
+          ],
+        ],
+      ),
+    );
+  }
+}
+```
+
+> `firstOrNull` comes from `package:collection`, already a dependency. If
+> analyze flags the import as missing, add `import 'package:collection/collection.dart';`.
+> Verify `layout.spacingLarge`/`spacingMedium`/`spacingSmall` exist on
+> `AppLayout`; if the field names differ, use the actual ones (read
+> `lib/core/theme/extensions/` — search `AppLayout` for the spacing fields). Do
+> not hardcode pixel values.
+
+- [ ] **Step 4: Switch `ResponseArea` to the panel for MCP**
+
+In `lib/features/tabs/presentation/widgets/response_area.dart`, add the import:
+
+```dart
+import 'package:getman/features/mcp/presentation/widgets/mcp_panel.dart';
+```
+
+Update the builder so MCP renders `McpPanel`, WS/SSE render `RealtimePanel`:
+
+```dart
+        final kind = state.tabs.byId(tabId)?.config.kind ?? RequestKind.http;
+        if (kind == RequestKind.http) {
+          return ResponseSection(
+            tabId: tabId,
+            responseController: responseController,
+            showMetadata: showMetadata,
+          );
+        }
+        if (kind == RequestKind.mcp) {
+          return McpPanel(tabId: tabId);
+        }
+        return RealtimePanel(tabId: tabId);
+```
+
+- [ ] **Step 5: Run tests + analyze**
+
+Run: `fvm flutter test test/features/mcp/presentation/widgets/mcp_panel_test.dart`
+Expected: PASS (including the no-overflow assertion).
+Run: `fvm flutter analyze lib/features/mcp lib/features/tabs/presentation/widgets/response_area.dart`
+Expected: 0 issues.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/features/mcp/presentation/widgets/mcp_panel.dart lib/features/tabs/presentation/widgets/response_area.dart test/features/mcp/presentation/widgets/mcp_panel_test.dart
+git commit -m "feat(mcp): McpPanel (tools, args editor, result) wired into ResponseArea"
+```
+
+---
+
+### Task 8: Full verification + wiki documentation
+
+**Files:**
+- No app code; runs the full verification bar and updates the external wiki repo.
+
+- [ ] **Step 1: Run the entire verification bar**
+
+Run each and confirm the stated expectation:
+
+```bash
+fvm flutter analyze
+```
+Expected: "No issues found!"
+
+```bash
+fvm dart run custom_lint
+```
+Expected: "No issues found!"
+
+```bash
+fvm dart run bloc_tools:bloc lint lib
+```
+Expected: no issues.
+
+```bash
+fvm dart format lib test
+```
+Expected: formats with no diffs needed (or commit the formatting).
+
+```bash
+fvm flutter test
+```
+Expected: all tests pass (the prior suite count + the new MCP tests).
+
+- [ ] **Step 2: Fix anything that fails, then re-run until all five are clean**
+
+If any pass reports issues, fix them and re-run that pass plus `fvm flutter test`. Do not proceed until all five are clean.
+
+- [ ] **Step 3: Update the wiki**
+
+Clone and edit the separate wiki repo (per the "keep the wiki in sync" mandate):
+
+```bash
+git clone https://github.com/thiagomiranda3/Getman.wiki.git /tmp/getman-wiki
+```
+
+Create `/tmp/getman-wiki/MCP-Requests.md` documenting (verbatim UI labels):
+- What MCP support is (a client that connects to MCP servers over HTTP).
+- How to use it: set the request kind dropdown to **MCP**, enter the server **endpoint URL**, add an `Authorization` header in the **HEADERS** tab if needed, press **CONNECT**.
+- Selecting a tool, editing the **Arguments (JSON)** field (supports `{{var}}`), pressing **CALL**, reading the **Result**.
+- Current limits: HTTP transport only (no stdio), **tools only** (resources/prompts not yet supported), no server-initiated notifications.
+
+Add a line to `/tmp/getman-wiki/_Sidebar.md` linking the new page, alongside the other feature pages.
+
+```bash
+cd /tmp/getman-wiki
+git add MCP-Requests.md _Sidebar.md
+git commit -m "docs: MCP requests page"
+git push origin master
+```
+
+- [ ] **Step 4: Final commit (if formatting changed any files)**
+
+```bash
+git add -A
+git commit -m "chore(mcp): format + final verification" || echo "nothing to commit"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- New `RequestKind.mcp`, no Hive migration → Task 1. ✓
+- Streamable HTTP JSON-RPC service, json + SSE responses, initialize handshake, session-id/protocol-version headers, tools/list, tools/call, error→exception, cancellable call → Task 3. ✓
+- Domain entities (`McpSession`/`McpTool`/`McpToolResult`) → Task 2. ✓
+- `McpBloc` bloc-over-service, per-tab sessions, status/tools/selected/result/log → Task 4. ✓
+- DI + app-wide provider → Task 5. ✓
+- Selector item + URL-bar CONNECT button reusing env resolution + live-config read → Task 6. ✓
+- `McpPanel` (tool list, schema reference, raw JSON args editor with `{{}}`-capable controller + validation, result, log) + `ResponseArea` switch → Task 7. ✓
+- Headers tab reused for auth: no code needed (editor area is not kind-gated; HEADERS already shows) — documented in Task 8 wiki step. ✓
+- MCP traffic excluded from HTTP history/time-travel: satisfied by construction (MCP never dispatches `SendRequest`; it uses `McpBloc`, not `TabsBloc` send path). No task needed. ✓
+- Verification bar + wiki → Task 8. ✓
+- Deferred (resources, prompts, server-initiated SSE, generated form, stdio, DELETE session-terminate): explicitly not implemented; noted in code comments + wiki. ✓
+
+**Placeholder scan:** The only intentional placeholder is the test-only `_ConnectedFixture` in Task 3 Step 1, which Step 3b explicitly removes; flagged inline. No `TBD`/`TODO`/"handle edge cases" in shipped code.
+
+**Type consistency:** `McpConnection.callTool(name, arguments, {cancelToken})`, `listTools()`, `connect(url, {headers})`, `McpTabSession.copyWith(...)`, `McpState.withSession/sessionFor`, `McpConnectionStatus` enum values, and event constructor signatures are used identically across Tasks 3–7. `createJsonCodeController()` / `JsonCodeEditor(controller:, readOnly:, autofocus:)` match the real signatures read from `json_code_editor.dart`.

--- a/docs/superpowers/specs/2026-06-24-mcp-client-design.md
+++ b/docs/superpowers/specs/2026-06-24-mcp-client-design.md
@@ -1,0 +1,159 @@
+# MCP Client Support — Design
+
+**Date:** 2026-06-24
+**Status:** Approved (design); implementation pending
+**Branch:** `feat/mcp-client`
+
+## Summary
+
+Add **MCP (Model Context Protocol) client** support to Getman, analogous to
+Postman's "MCP request": Getman acts as an MCP host/client that connects to an
+external MCP server, lists its **tools**, and invokes a tool with
+user-supplied arguments, showing the result.
+
+Scope is deliberately tight for v1:
+
+- **Direction:** client only (consume external MCP servers). Exposing Getman
+  collections *as* an MCP server is out of scope.
+- **Transport:** HTTP only — **Streamable HTTP** (JSON-RPC 2.0 over POST, with
+  `application/json` or `text/event-stream` responses). No stdio / local
+  process spawning, so the feature is web-safe on every platform.
+- **Capabilities:** **tools only** (initialize → list tools → call tool).
+  Resources and prompts are deferred.
+
+## Why this approach
+
+Getman already models non-HTTP protocols as a `RequestKind` that swaps the
+response panel (`http` / `webSocket` / `sse`). The `realtime` feature is a
+"bloc-over-service" feature with **no full domain/data split**, driven by
+`RealtimeBloc` over `RealtimeService`, surfaced by `ResponseArea` switching on
+`tab.config.kind`. MCP slots into exactly this seam as a new
+`RequestKind.mcp` — reusing the tab system, persistence, URL bar, env
+resolution, and panel-switching with no new tab/workspace machinery.
+
+A standalone "MCP workspace" screen was considered and rejected: it would
+duplicate tab/panel/env-resolution plumbing and diverge from the established
+WebSocket/SSE precedent for no real benefit.
+
+## Architecture
+
+### 1. Protocol & transport — `core/network/`
+
+- Add `mcp(3)` to the `RequestKind` enum (`core/network/request_kind.dart`).
+  It persists as the **existing** int discriminator (config Hive model field
+  14, default `0 = http`). **No new Hive typeId, no migration** — existing
+  records keep reading as `http`, and `RequestKind.fromWire` already falls back
+  to `http` for unknown values.
+
+- New `McpService` (`core/network/mcp_service.dart`) — pure `dio`, web-safe,
+  with the `Dio` injectable for tests (mirrors `RealtimeService`). Speaks
+  **JSON-RPC 2.0 over Streamable HTTP**:
+  - `connect(url, headers)` → POST `initialize`; capture the returned
+    `Mcp-Session-Id` and negotiated `MCP-Protocol-Version`; send the
+    `notifications/initialized` notification; return an `McpSession`.
+  - `listTools(session)` → POST `tools/list`.
+  - `callTool(session, name, args)` → POST `tools/call`.
+  - Handles **both** response content-types per the spec: `application/json`
+    (single JSON-RPC response) and `text/event-stream` (SSE-framed response,
+    reusing the existing `SseParser`). Subsequent requests carry the session id
+    + protocol-version headers.
+  - In-flight calls are cancellable (a cancel token on the active request).
+
+- **Out of scope for v1:** the standalone GET SSE stream for server-initiated
+  messages, resources, prompts, and subscriptions.
+
+### 2. Domain entities (pure Dart + `equatable`, `copyWith` where mutated)
+
+- `McpSession { sessionId, protocolVersion, serverName, serverVersion }`
+- `McpTool { name, description, inputSchema }` — `inputSchema` is the raw JSON
+  Schema `Map` (not modeled further in v1).
+- `McpToolResult { isError, List<text content block> }` — v1 renders text
+  content blocks; non-text blocks are shown as their raw JSON.
+
+### 3. State — `McpBloc` (bloc-over-service, no domain/data split)
+
+Follows `RealtimeBloc` exactly. State carries:
+
+- connection status: `disconnected` / `connecting` / `connected` / `error`
+- server info (from `McpSession`)
+- `tools` (from `tools/list`)
+- `selectedTool`
+- `lastResult`
+- `sessionLog` — the JSON-RPC traffic (request/response/notification) for
+  debugging.
+
+Events are scoped by `tabId` (matching `RealtimeBloc` and the identity-based
+`TabsEvent` convention). `McpBloc` is registered app-wide in the `main.dart`
+`MultiBlocProvider`, like `RealtimeBloc`.
+
+### 4. UI
+
+- `RequestKindMethodSelector` — add an **MCP** dropdown item alongside
+  HTTP/WebSocket/SSE.
+- For MCP kind, the **URL bar** holds the MCP **endpoint URL**. Auth reuses the
+  existing **Headers tab** (e.g. `Authorization: Bearer …`) — no new auth UI.
+  Method, PARAMS, and BODY are hidden (as they are for WebSocket/SSE).
+- New `McpPanel` (`features/mcp/presentation/widgets/mcp_panel.dart`), shown by
+  `ResponseArea` when `kind == mcp`:
+  - a **Connect** bar (uses the tab's URL + headers),
+  - a **tool list** (from `tools/list`),
+  - a **selected-tool detail**: the input JSON Schema as **read-only
+    reference** + a `JsonCodeEditor` (built via `createJsonCodeController()`)
+    for the arguments object, + a **Call** button,
+  - a **result view** + a collapsible **session log**.
+- **Env resolution:** the endpoint URL, header values, and the JSON arguments
+  all run through `ActiveEnvironmentHelper.variablesFor(...)` + the resolver, so
+  `{{var}}` (and dynamic `{{$...}}`) work everywhere — matching how
+  `SendRequest` resolves.
+
+### 5. Boundaries
+
+- MCP traffic does **not** write to HTTP history or response time-travel — it's
+  a separate protocol, exactly like realtime. Tools, results, and the session
+  log are **live-only** (not persisted). Only the endpoint URL + `kind` +
+  headers persist, via the existing tab config Hive model.
+- Theming: the `McpPanel` reads all sizes/colors/weights/shapes from the
+  `context.app*` extensions — no hardcoded values, per the project mandate.
+
+### 6. Feature layout
+
+```
+lib/features/mcp/
+  domain/entities/    # McpSession, McpTool, McpToolResult (pure Dart)
+  presentation/
+    bloc/             # mcp_bloc.dart, mcp_event.dart, mcp_state.dart
+    widgets/          # mcp_panel.dart
+lib/core/network/
+  mcp_service.dart    # JSON-RPC over Streamable HTTP (dio), web-safe
+  request_kind.dart   # + mcp(3)
+```
+
+(Bloc-over-service by design — no `data/` layer, matching `realtime`.)
+
+## Testing
+
+- `McpService` unit tests with an **injected mock dio adapter**: the
+  `initialize` handshake (session-id + protocol-version capture), `application/
+  json` **and** `text/event-stream` response shapes, `tools/list` parsing, and
+  `tools/call` success + `isError` result + JSON-RPC error responses.
+- `McpBloc` `bloc_test`: connect → list → call happy path, plus connect-error
+  and call-error paths.
+- `McpPanel` widget smoke test + an overflow guard (per the project's
+  per-panel test convention).
+
+## Docs
+
+- New wiki page "MCP requests" in `Getman.wiki.git` + a `_Sidebar.md` entry,
+  kept verbatim-accurate to UI labels (per the "keep the wiki in sync"
+  mandate).
+
+## Deliberately deferred (post-v1)
+
+- Resources and prompts.
+- Server-initiated SSE notifications / subscriptions (the standalone GET
+  stream).
+- A generated argument **form** from JSON Schema (v1 uses a raw JSON args
+  editor seeded by the schema reference).
+- stdio / local-process transport (would need the same web-platform gating as
+  the auto-updater).
+- Exposing Getman collections *as* an MCP server.

--- a/lib/core/di/injection_container.dart
+++ b/lib/core/di/injection_container.dart
@@ -4,6 +4,7 @@ import 'package:getman/core/navigation/url_focus_registry.dart';
 import 'package:getman/core/network/cookie_interceptor.dart';
 import 'package:getman/core/network/cookie_store.dart';
 import 'package:getman/core/network/in_memory_cookie_store.dart';
+import 'package:getman/core/network/mcp_service.dart';
 import 'package:getman/core/network/network_service.dart';
 import 'package:getman/core/network/realtime_service.dart';
 import 'package:getman/core/storage/hive_boxes.dart';
@@ -40,6 +41,7 @@ import 'package:getman/features/history/domain/repositories/history_repository.d
 import 'package:getman/features/history/domain/usecases/history_usecases.dart';
 import 'package:getman/features/history/presentation/bloc/history_bloc.dart';
 import 'package:getman/features/home/domain/usecases/tab_dirty_checker.dart';
+import 'package:getman/features/mcp/presentation/bloc/mcp_bloc.dart';
 import 'package:getman/features/realtime/presentation/bloc/realtime_bloc.dart';
 import 'package:getman/features/settings/data/datasources/settings_local_data_source.dart';
 import 'package:getman/features/settings/data/models/settings_model.dart';
@@ -242,6 +244,9 @@ Future<SettingsEntity> init({String? storageDirectoryOverride}) async {
     // Features - Realtime (WebSocket / SSE)
     ..registerLazySingleton(RealtimeService.new)
     ..registerLazySingleton(() => RealtimeBloc(service: sl()))
+    // Features - MCP (Model Context Protocol client over Streamable HTTP)
+    ..registerLazySingleton(McpService.new)
+    ..registerLazySingleton(() => McpBloc(service: sl()))
     // Features - Home
     ..registerLazySingleton(() => const TabDirtyChecker())
     // Features - Updates (GitHub release auto-update)

--- a/lib/core/network/mcp_service.dart
+++ b/lib/core/network/mcp_service.dart
@@ -20,8 +20,7 @@ class McpException implements Exception {
   final String message;
   final int? code;
   @override
-  String toString() =>
-      'McpException(${code == null ? '' : '$code: '}$message)';
+  String toString() => 'McpException(${code == null ? '' : '$code: '}$message)';
 }
 
 /// A live MCP session over Streamable HTTP. One per connected tab.
@@ -43,15 +42,15 @@ class McpService {
   final Dio _dio;
 
   static Dio _buildDio() => Dio(
-        BaseOptions(
-          connectTimeout: const Duration(seconds: 30),
-          receiveTimeout: const Duration(seconds: 60),
-          // MCP servers may answer with a JSON-RPC error at HTTP 200, or with
-          // 4xx/5xx — read every status so we can surface the body either way.
-          validateStatus: (_) => true,
-          responseType: ResponseType.stream,
-        ),
-      );
+    BaseOptions(
+      connectTimeout: const Duration(seconds: 30),
+      receiveTimeout: const Duration(seconds: 60),
+      // MCP servers may answer with a JSON-RPC error at HTTP 200, or with
+      // 4xx/5xx — read every status so we can surface the body either way.
+      validateStatus: (_) => true,
+      responseType: ResponseType.stream,
+    ),
+  );
 
   /// Performs the `initialize` handshake, captures the `Mcp-Session-Id`
   /// header, sends the `notifications/initialized` notification, and returns a
@@ -130,17 +129,16 @@ class _HttpMcpConnection implements McpConnection {
       {'jsonrpc': '2.0', 'id': ++_nextId, 'method': method, 'params': params};
 
   Options _options() => Options(
-        responseType: ResponseType.stream,
-        headers: {
-          ..._headers,
-          'Content-Type': 'application/json',
-          'Accept': 'application/json, text/event-stream',
-          if (_session.sessionId.isNotEmpty)
-            'Mcp-Session-Id': _session.sessionId,
-          if (_session.protocolVersion.isNotEmpty)
-            'MCP-Protocol-Version': _session.protocolVersion,
-        },
-      );
+    responseType: ResponseType.stream,
+    headers: {
+      ..._headers,
+      'Content-Type': 'application/json',
+      'Accept': 'application/json, text/event-stream',
+      if (_session.sessionId.isNotEmpty) 'Mcp-Session-Id': _session.sessionId,
+      if (_session.protocolVersion.isNotEmpty)
+        'MCP-Protocol-Version': _session.protocolVersion,
+    },
+  );
 
   /// Sends a JSON-RPC request and returns `(result, responseHeaders)`. Throws
   /// [McpException] on a JSON-RPC `error` or a missing/invalid result.
@@ -201,8 +199,7 @@ class _HttpMcpConnection implements McpConnection {
         response.headers.map[Headers.contentTypeHeader] ??
         body.headers[Headers.contentTypeHeader] ??
         const <String>[];
-    final contentType =
-        headerValues.isNotEmpty ? headerValues.first : '';
+    final contentType = headerValues.isNotEmpty ? headerValues.first : '';
 
     if (contentType.contains('text/event-stream')) {
       final parser = SseParser();

--- a/lib/core/network/mcp_service.dart
+++ b/lib/core/network/mcp_service.dart
@@ -156,7 +156,14 @@ class _HttpMcpConnection implements McpConnection {
     );
     final message = await _readMessage(response, envelope['id'] as int);
     if (message == null) {
-      throw McpException('Empty response from server for $method');
+      final ct =
+          response.headers.map[Headers.contentTypeHeader]?.join(',') ??
+          response.data?.headers[Headers.contentTypeHeader]?.join(',') ??
+          '';
+      throw McpException(
+        'Empty/unparseable response for $method '
+        '(HTTP ${response.statusCode}, content-type "$ct")',
+      );
     }
     final error = message['error'];
     if (error is Map<String, dynamic>) {

--- a/lib/core/network/mcp_service.dart
+++ b/lib/core/network/mcp_service.dart
@@ -1,0 +1,242 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+import 'package:getman/core/network/sse_parser.dart';
+import 'package:getman/features/mcp/domain/entities/mcp_session.dart';
+import 'package:getman/features/mcp/domain/entities/mcp_tool.dart';
+import 'package:getman/features/mcp/domain/entities/mcp_tool_result.dart';
+
+/// MCP protocol version Getman negotiates in `initialize`.
+const String kMcpProtocolVersion = '2025-06-18';
+
+/// Client identity sent in `initialize.params.clientInfo`.
+const String _kClientName = 'Getman';
+const String _kClientVersion = '1.0';
+
+/// A JSON-RPC error returned by an MCP server, or a transport-level failure.
+class McpException implements Exception {
+  McpException(this.message, {this.code});
+  final String message;
+  final int? code;
+  @override
+  String toString() =>
+      'McpException(${code == null ? '' : '$code: '}$message)';
+}
+
+/// A live MCP session over Streamable HTTP. One per connected tab.
+abstract class McpConnection {
+  McpSession get session;
+  Future<List<McpTool>> listTools();
+  Future<McpToolResult> callTool(
+    String name,
+    Map<String, dynamic> arguments, {
+    CancelToken? cancelToken,
+  });
+  Future<void> close();
+}
+
+/// Opens MCP connections over Streamable HTTP (JSON-RPC 2.0). Pure `dio`, so it
+/// is web-safe (no `dart:io`). The [Dio] is injectable for tests.
+class McpService {
+  McpService({Dio? dio}) : _dio = dio ?? _buildDio();
+  final Dio _dio;
+
+  static Dio _buildDio() => Dio(
+        BaseOptions(
+          connectTimeout: const Duration(seconds: 30),
+          receiveTimeout: const Duration(seconds: 60),
+          // MCP servers may answer with a JSON-RPC error at HTTP 200, or with
+          // 4xx/5xx — read every status so we can surface the body either way.
+          validateStatus: (_) => true,
+          responseType: ResponseType.stream,
+        ),
+      );
+
+  /// Performs the `initialize` handshake, captures the `Mcp-Session-Id`
+  /// header, sends the `notifications/initialized` notification, and returns a
+  /// ready connection.
+  Future<McpConnection> connect(
+    String url, {
+    Map<String, String> headers = const {},
+  }) async {
+    final conn = _HttpMcpConnection(_dio, url, headers);
+    await conn._initialize();
+    return conn;
+  }
+}
+
+class _HttpMcpConnection implements McpConnection {
+  _HttpMcpConnection(this._dio, this._url, this._headers);
+  final Dio _dio;
+  final String _url;
+  final Map<String, String> _headers;
+
+  McpSession _session = const McpSession(
+    sessionId: '',
+    protocolVersion: '',
+    serverName: '',
+    serverVersion: '',
+  );
+  int _nextId = 0;
+
+  @override
+  McpSession get session => _session;
+
+  Future<void> _initialize() async {
+    final (result, respHeaders) = await _request('initialize', {
+      'protocolVersion': kMcpProtocolVersion,
+      'capabilities': <String, dynamic>{},
+      'clientInfo': {'name': _kClientName, 'version': _kClientVersion},
+    });
+    _session = McpSession.fromInitializeResult(
+      result,
+      sessionId: respHeaders.value('mcp-session-id'),
+    );
+    await _notify('notifications/initialized', const {});
+  }
+
+  @override
+  Future<List<McpTool>> listTools() async {
+    final (result, _) = await _request('tools/list', const {});
+    final tools = (result['tools'] as List?) ?? const [];
+    return tools
+        .whereType<Map<String, dynamic>>()
+        .map(McpTool.fromJson)
+        .toList();
+  }
+
+  @override
+  Future<McpToolResult> callTool(
+    String name,
+    Map<String, dynamic> arguments, {
+    CancelToken? cancelToken,
+  }) async {
+    final (result, _) = await _request(
+      'tools/call',
+      {'name': name, 'arguments': arguments},
+      cancelToken: cancelToken,
+    );
+    return McpToolResult.fromJson(result);
+  }
+
+  @override
+  Future<void> close() async {
+    // v1: nothing to release (each call is a discrete POST). Session
+    // termination via HTTP DELETE is deferred.
+  }
+
+  Map<String, dynamic> _envelope(String method, Map<String, dynamic> params) =>
+      {'jsonrpc': '2.0', 'id': ++_nextId, 'method': method, 'params': params};
+
+  Options _options() => Options(
+        responseType: ResponseType.stream,
+        headers: {
+          ..._headers,
+          'Content-Type': 'application/json',
+          'Accept': 'application/json, text/event-stream',
+          if (_session.sessionId.isNotEmpty)
+            'Mcp-Session-Id': _session.sessionId,
+          if (_session.protocolVersion.isNotEmpty)
+            'MCP-Protocol-Version': _session.protocolVersion,
+        },
+      );
+
+  /// Sends a JSON-RPC request and returns `(result, responseHeaders)`. Throws
+  /// [McpException] on a JSON-RPC `error` or a missing/invalid result.
+  Future<(Map<String, dynamic>, Headers)> _request(
+    String method,
+    Map<String, dynamic> params, {
+    CancelToken? cancelToken,
+  }) async {
+    final envelope = _envelope(method, params);
+    final response = await _dio.post<ResponseBody>(
+      _url,
+      data: jsonEncode(envelope),
+      options: _options(),
+      cancelToken: cancelToken,
+    );
+    final message = await _readMessage(response, envelope['id'] as int);
+    if (message == null) {
+      throw McpException('Empty response from server for $method');
+    }
+    final error = message['error'];
+    if (error is Map<String, dynamic>) {
+      throw McpException(
+        (error['message'] as String?) ?? 'Unknown error',
+        code: error['code'] as int?,
+      );
+    }
+    final result = (message['result'] as Map?)?.cast<String, dynamic>();
+    if (result == null) {
+      throw McpException('Malformed JSON-RPC response for $method');
+    }
+    return (result, response.headers);
+  }
+
+  /// Fire-and-forget JSON-RPC notification (no id, no response body expected).
+  Future<void> _notify(String method, Map<String, dynamic> params) async {
+    final response = await _dio.post<ResponseBody>(
+      _url,
+      data: jsonEncode({'jsonrpc': '2.0', 'method': method, 'params': params}),
+      options: _options(),
+    );
+    // Drain so the connection is released; the body is ignored (202 Accepted).
+    await _drain(response.data);
+  }
+
+  /// Reads a JSON-RPC message from either an `application/json` body or a
+  /// `text/event-stream` body, returning the message whose `id` matches
+  /// [expectedId] (or the first message that has no id match for json).
+  Future<Map<String, dynamic>?> _readMessage(
+    Response<ResponseBody> response,
+    int expectedId,
+  ) async {
+    final body = response.data;
+    if (body == null) return null;
+    final text = await _drain(body);
+    // In real Dio (streaming), Content-Type appears in both Response.headers
+    // and ResponseBody.headers. In tests, only one side may be set.
+    final headerValues =
+        response.headers.map[Headers.contentTypeHeader] ??
+        body.headers[Headers.contentTypeHeader] ??
+        const <String>[];
+    final contentType =
+        headerValues.isNotEmpty ? headerValues.first : '';
+
+    if (contentType.contains('text/event-stream')) {
+      final parser = SseParser();
+      final events = [...parser.addChunk(text), ...parser.flush()];
+      for (final raw in events) {
+        final decoded = _tryDecode(raw);
+        if (decoded != null && decoded['id'] == expectedId) return decoded;
+      }
+      // Fall back to the last decodable event if no id matched.
+      for (final raw in events.reversed) {
+        final decoded = _tryDecode(raw);
+        if (decoded != null) return decoded;
+      }
+      return null;
+    }
+
+    return _tryDecode(text);
+  }
+
+  Map<String, dynamic>? _tryDecode(String raw) {
+    if (raw.trim().isEmpty) return null;
+    try {
+      final decoded = jsonDecode(raw);
+      return decoded is Map<String, dynamic> ? decoded : null;
+    } on FormatException {
+      return null;
+    }
+  }
+
+  /// Drains a streamed [ResponseBody] to a UTF-8 string.
+  Future<String> _drain(ResponseBody? body) async {
+    if (body == null) return '';
+    final bytes = <int>[];
+    await body.stream.forEach(bytes.addAll);
+    return utf8.decode(bytes, allowMalformed: true);
+  }
+}

--- a/lib/core/network/request_kind.dart
+++ b/lib/core/network/request_kind.dart
@@ -1,10 +1,12 @@
-/// The protocol a request speaks. Orthogonal to the HTTP method — a WebSocket
-/// or SSE request has no method. Persisted as an int discriminator (Hive field
-/// 14 on the config model, default 0 = http) so existing records read as HTTP.
+/// The protocol a request speaks. Orthogonal to the HTTP method — a WebSocket,
+/// SSE, or MCP request has no method. Persisted as an int discriminator (Hive
+/// field 14 on the config model, default 0 = http) so existing records read as
+/// HTTP.
 enum RequestKind {
   http(0),
   webSocket(1),
-  sse(2)
+  sse(2),
+  mcp(3)
   ;
 
   const RequestKind(this.wire);

--- a/lib/core/network/request_kind.dart
+++ b/lib/core/network/request_kind.dart
@@ -13,6 +13,14 @@ enum RequestKind {
 
   final int wire;
 
+  /// Short uppercase label for the kind badge (collections tree, etc.).
+  String get label => switch (this) {
+    RequestKind.http => 'HTTP',
+    RequestKind.webSocket => 'WS',
+    RequestKind.sse => 'SSE',
+    RequestKind.mcp => 'MCP',
+  };
+
   static RequestKind fromWire(int? value) {
     for (final k in RequestKind.values) {
       if (k.wire == value) return k;

--- a/lib/core/theme/extensions/app_layout.dart
+++ b/lib/core/theme/extensions/app_layout.dart
@@ -43,6 +43,7 @@ class AppLayout extends ThemeExtension<AppLayout> {
     required this.splitterLineSize,
     required this.foldGutterWidth,
     required this.quickListMaxHeight,
+    required this.mcpEditorPaneHeight,
   });
   final double pagePadding;
   final double sectionSpacing;
@@ -97,6 +98,10 @@ class AppLayout extends ThemeExtension<AppLayout> {
   /// quick environment switcher — caps the list so the modal stays bounded.
   final double quickListMaxHeight;
 
+  /// Height of each JSON code editor pane (input schema + arguments) in the
+  /// MCP tool detail panel.
+  final double mcpEditorPaneHeight;
+
   @override
   AppLayout copyWith({
     bool? isCompact,
@@ -140,6 +145,7 @@ class AppLayout extends ThemeExtension<AppLayout> {
     double? splitterLineSize,
     double? foldGutterWidth,
     double? quickListMaxHeight,
+    double? mcpEditorPaneHeight,
   }) {
     return AppLayout(
       isCompact: isCompact ?? this.isCompact,
@@ -188,6 +194,7 @@ class AppLayout extends ThemeExtension<AppLayout> {
       splitterLineSize: splitterLineSize ?? this.splitterLineSize,
       foldGutterWidth: foldGutterWidth ?? this.foldGutterWidth,
       quickListMaxHeight: quickListMaxHeight ?? this.quickListMaxHeight,
+      mcpEditorPaneHeight: mcpEditorPaneHeight ?? this.mcpEditorPaneHeight,
     );
   }
 
@@ -252,6 +259,7 @@ class AppLayout extends ThemeExtension<AppLayout> {
       splitterLineSize: l(splitterLineSize, other.splitterLineSize),
       foldGutterWidth: l(foldGutterWidth, other.foldGutterWidth),
       quickListMaxHeight: l(quickListMaxHeight, other.quickListMaxHeight),
+      mcpEditorPaneHeight: l(mcpEditorPaneHeight, other.mcpEditorPaneHeight),
     );
   }
 
@@ -297,6 +305,7 @@ class AppLayout extends ThemeExtension<AppLayout> {
     splitterLineSize: 3,
     foldGutterWidth: 20,
     quickListMaxHeight: 360,
+    mcpEditorPaneHeight: 160,
   );
 
   static const compact = AppLayout(
@@ -341,5 +350,6 @@ class AppLayout extends ThemeExtension<AppLayout> {
     splitterLineSize: 2,
     foldGutterWidth: 16,
     quickListMaxHeight: 280,
+    mcpEditorPaneHeight: 160,
   );
 }

--- a/lib/features/collections/presentation/widgets/collection_node_row.dart
+++ b/lib/features/collections/presentation/widgets/collection_node_row.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:getman/core/network/request_kind.dart';
 import 'package:getman/core/theme/app_theme.dart';
 import 'package:getman/core/theme/responsive.dart';
 import 'package:getman/core/ui/widgets/method_badge.dart';
@@ -216,7 +217,12 @@ class _CollectionNodeRowState extends State<CollectionNodeRow> {
                       else
                         SizedBox(width: layout.smallIconSize),
                       MethodBadge(
-                        method: node.config?.method ?? 'GET',
+                        // Non-HTTP kinds (WS/SSE/MCP) have no method — show the
+                        // protocol label instead of a misleading "GET".
+                        method: switch (node.config?.kind ?? RequestKind.http) {
+                          RequestKind.http => node.config?.method ?? 'GET',
+                          final kind => kind.label,
+                        },
                         small: true,
                       ),
                       const SizedBox(width: 8),

--- a/lib/features/mcp/domain/entities/mcp_session.dart
+++ b/lib/features/mcp/domain/entities/mcp_session.dart
@@ -1,0 +1,39 @@
+import 'package:equatable/equatable.dart';
+
+/// An established MCP session: the negotiated protocol version, the server's
+/// self-reported identity, and the transport session id (from the
+/// `Mcp-Session-Id` response header). Pure data — no transport concerns.
+class McpSession extends Equatable {
+  const McpSession({
+    required this.sessionId,
+    required this.protocolVersion,
+    required this.serverName,
+    required this.serverVersion,
+  });
+
+  /// Builds a session from an `initialize` JSON-RPC result, with the transport
+  /// [sessionId] supplied separately (it rides on the HTTP response header, not
+  /// the JSON-RPC body). Missing fields default to empty strings.
+  factory McpSession.fromInitializeResult(
+    Map<String, dynamic> result, {
+    String? sessionId,
+  }) {
+    final info = (result['serverInfo'] as Map?)?.cast<String, dynamic>() ??
+        const <String, dynamic>{};
+    return McpSession(
+      sessionId: sessionId ?? '',
+      protocolVersion: (result['protocolVersion'] as String?) ?? '',
+      serverName: (info['name'] as String?) ?? '',
+      serverVersion: (info['version'] as String?) ?? '',
+    );
+  }
+
+  final String sessionId;
+  final String protocolVersion;
+  final String serverName;
+  final String serverVersion;
+
+  @override
+  List<Object?> get props =>
+      [sessionId, protocolVersion, serverName, serverVersion];
+}

--- a/lib/features/mcp/domain/entities/mcp_session.dart
+++ b/lib/features/mcp/domain/entities/mcp_session.dart
@@ -18,7 +18,8 @@ class McpSession extends Equatable {
     Map<String, dynamic> result, {
     String? sessionId,
   }) {
-    final info = (result['serverInfo'] as Map?)?.cast<String, dynamic>() ??
+    final info =
+        (result['serverInfo'] as Map?)?.cast<String, dynamic>() ??
         const <String, dynamic>{};
     return McpSession(
       sessionId: sessionId ?? '',
@@ -34,6 +35,10 @@ class McpSession extends Equatable {
   final String serverVersion;
 
   @override
-  List<Object?> get props =>
-      [sessionId, protocolVersion, serverName, serverVersion];
+  List<Object?> get props => [
+    sessionId,
+    protocolVersion,
+    serverName,
+    serverVersion,
+  ];
 }

--- a/lib/features/mcp/domain/entities/mcp_tool.dart
+++ b/lib/features/mcp/domain/entities/mcp_tool.dart
@@ -10,12 +10,12 @@ class McpTool extends Equatable {
   });
 
   factory McpTool.fromJson(Map<String, dynamic> json) => McpTool(
-        name: (json['name'] as String?) ?? '',
-        description: (json['description'] as String?) ?? '',
-        inputSchema:
-            (json['inputSchema'] as Map?)?.cast<String, dynamic>() ??
-                const <String, dynamic>{},
-      );
+    name: (json['name'] as String?) ?? '',
+    description: (json['description'] as String?) ?? '',
+    inputSchema:
+        (json['inputSchema'] as Map?)?.cast<String, dynamic>() ??
+        const <String, dynamic>{},
+  );
 
   final String name;
   final String description;

--- a/lib/features/mcp/domain/entities/mcp_tool.dart
+++ b/lib/features/mcp/domain/entities/mcp_tool.dart
@@ -1,0 +1,26 @@
+import 'package:equatable/equatable.dart';
+
+/// A tool advertised by an MCP server via `tools/list`. [inputSchema] is the
+/// tool's raw JSON Schema (kept verbatim; not modeled further in v1).
+class McpTool extends Equatable {
+  const McpTool({
+    required this.name,
+    required this.description,
+    required this.inputSchema,
+  });
+
+  factory McpTool.fromJson(Map<String, dynamic> json) => McpTool(
+        name: (json['name'] as String?) ?? '',
+        description: (json['description'] as String?) ?? '',
+        inputSchema:
+            (json['inputSchema'] as Map?)?.cast<String, dynamic>() ??
+                const <String, dynamic>{},
+      );
+
+  final String name;
+  final String description;
+  final Map<String, dynamic> inputSchema;
+
+  @override
+  List<Object?> get props => [name, description, inputSchema];
+}

--- a/lib/features/mcp/domain/entities/mcp_tool_result.dart
+++ b/lib/features/mcp/domain/entities/mcp_tool_result.dart
@@ -1,0 +1,36 @@
+import 'package:equatable/equatable.dart';
+
+/// The result of a `tools/call`. [textBlocks] are the `type: "text"` content
+/// items (the common case); [rawBlocks] preserves every content item verbatim
+/// so non-text blocks (images, resources) can still be shown as raw JSON.
+class McpToolResult extends Equatable {
+  const McpToolResult({
+    required this.isError,
+    required this.textBlocks,
+    required this.rawBlocks,
+  });
+
+  factory McpToolResult.fromJson(Map<String, dynamic> result) {
+    final content = (result['content'] as List?) ?? const [];
+    final raw = content
+        .whereType<Map>()
+        .map((m) => m.cast<String, dynamic>())
+        .toList();
+    final text = raw
+        .where((m) => m['type'] == 'text')
+        .map((m) => (m['text'] as String?) ?? '')
+        .toList();
+    return McpToolResult(
+      isError: (result['isError'] as bool?) ?? false,
+      textBlocks: text,
+      rawBlocks: raw,
+    );
+  }
+
+  final bool isError;
+  final List<String> textBlocks;
+  final List<Map<String, dynamic>> rawBlocks;
+
+  @override
+  List<Object?> get props => [isError, textBlocks, rawBlocks];
+}

--- a/lib/features/mcp/domain/entities/mcp_tool_result.dart
+++ b/lib/features/mcp/domain/entities/mcp_tool_result.dart
@@ -13,7 +13,7 @@ class McpToolResult extends Equatable {
   factory McpToolResult.fromJson(Map<String, dynamic> result) {
     final content = (result['content'] as List?) ?? const [];
     final raw = content
-        .whereType<Map>()
+        .whereType<Map<dynamic, dynamic>>()
         .map((m) => m.cast<String, dynamic>())
         .toList();
     final text = raw

--- a/lib/features/mcp/domain/mcp_argument_resolver.dart
+++ b/lib/features/mcp/domain/mcp_argument_resolver.dart
@@ -1,0 +1,24 @@
+import 'package:getman/core/utils/environment_resolver.dart';
+
+/// Recursively resolves `{{var}}` (and dynamic `{{$...}}`) tokens in a single
+/// JSON argument [value] against [vars]. Only `String` leaves are substituted;
+/// `Map`/`List` are walked; all other types pass through unchanged. Resolving
+/// per-value (not over the raw JSON text) keeps the document structurally valid
+/// even when a substituted value contains quotes or braces.
+dynamic resolveMcpArgValue(dynamic value, Map<String, String> vars) {
+  if (value is String) return EnvironmentResolver.resolve(value, vars);
+  if (value is Map<String, dynamic>) {
+    return value.map((k, v) => MapEntry(k, resolveMcpArgValue(v, vars)));
+  }
+  if (value is List<dynamic>) {
+    return value.map((e) => resolveMcpArgValue(e, vars)).toList();
+  }
+  return value;
+}
+
+/// Resolves `{{var}}` tokens in every value of an MCP tool-call [arguments]
+/// object. See [resolveMcpArgValue] for the per-value rules.
+Map<String, dynamic> resolveMcpArguments(
+  Map<String, dynamic> arguments,
+  Map<String, String> vars,
+) => arguments.map((k, v) => MapEntry(k, resolveMcpArgValue(v, vars)));

--- a/lib/features/mcp/presentation/bloc/mcp_bloc.dart
+++ b/lib/features/mcp/presentation/bloc/mcp_bloc.dart
@@ -101,7 +101,11 @@ class McpBloc extends Bloc<McpEvent, McpState> {
     emit(
       state.withSession(
         event.tabId,
-        base.copyWith(calling: true, selectedTool: event.toolName),
+        base.copyWith(
+          calling: true,
+          selectedTool: event.toolName,
+          lastResult: base.lastResult,
+        ),
       ),
     );
     try {
@@ -127,6 +131,7 @@ class McpBloc extends Bloc<McpEvent, McpState> {
             calling: false,
             errorMessage: e.toString(),
             log: [...after.log, 'Call failed: $e'],
+            lastResult: after.lastResult,
           ),
         ),
       );

--- a/lib/features/mcp/presentation/bloc/mcp_bloc.dart
+++ b/lib/features/mcp/presentation/bloc/mcp_bloc.dart
@@ -1,0 +1,148 @@
+import 'dart:developer';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:getman/core/network/mcp_service.dart';
+import 'package:getman/features/mcp/presentation/bloc/mcp_event.dart';
+import 'package:getman/features/mcp/presentation/bloc/mcp_state.dart';
+
+/// Owns one live [McpConnection] per tab and its derived state. Mirrors
+/// RealtimeBloc's teardown discipline: a connection is closed on disconnect, on
+/// reconnect for the same tab, and on bloc close.
+class McpBloc extends Bloc<McpEvent, McpState> {
+  McpBloc({required McpService service})
+    : _service = service,
+      super(const McpState()) {
+    on<McpConnectRequested>(_onConnect);
+    on<McpDisconnectRequested>(_onDisconnect);
+    on<McpToolSelected>(_onToolSelected);
+    on<McpToolCallRequested>(_onCallTool);
+  }
+
+  final McpService _service;
+  final Map<String, McpConnection> _connections = {};
+
+  Future<void> _onConnect(
+    McpConnectRequested event,
+    Emitter<McpState> emit,
+  ) async {
+    await _teardown(event.tabId);
+    emit(
+      state.withSession(
+        event.tabId,
+        const McpTabSession(status: McpConnectionStatus.connecting),
+      ),
+    );
+    try {
+      final conn = await _service.connect(event.url, headers: event.headers);
+      _connections[event.tabId] = conn;
+      final tools = await conn.listTools();
+      final serverLabel =
+          '${conn.session.serverName} (${conn.session.protocolVersion})';
+      emit(
+        state.withSession(
+          event.tabId,
+          McpTabSession(
+            status: McpConnectionStatus.connected,
+            session: conn.session,
+            tools: tools,
+            log: [
+              'Connected to $serverLabel',
+              'Listed ${tools.length} tool(s)',
+            ],
+          ),
+        ),
+      );
+    } on Object catch (e) {
+      log('MCP connect failed: $e', name: 'McpBloc');
+      await _teardown(event.tabId);
+      emit(
+        state.withSession(
+          event.tabId,
+          McpTabSession(
+            status: McpConnectionStatus.error,
+            errorMessage: e.toString(),
+            log: ['Connect failed: $e'],
+          ),
+        ),
+      );
+    }
+  }
+
+  Future<void> _onDisconnect(
+    McpDisconnectRequested event,
+    Emitter<McpState> emit,
+  ) async {
+    await _teardown(event.tabId);
+    emit(
+      state.withSession(
+        event.tabId,
+        const McpTabSession(),
+      ),
+    );
+  }
+
+  void _onToolSelected(McpToolSelected event, Emitter<McpState> emit) {
+    final s = state.sessionFor(event.tabId);
+    emit(
+      state.withSession(
+        event.tabId,
+        s.copyWith(selectedTool: event.toolName),
+      ),
+    );
+  }
+
+  Future<void> _onCallTool(
+    McpToolCallRequested event,
+    Emitter<McpState> emit,
+  ) async {
+    final conn = _connections[event.tabId];
+    if (conn == null) return;
+    final base = state.sessionFor(event.tabId);
+    emit(
+      state.withSession(
+        event.tabId,
+        base.copyWith(calling: true, selectedTool: event.toolName),
+      ),
+    );
+    try {
+      final result = await conn.callTool(event.toolName, event.arguments);
+      final after = state.sessionFor(event.tabId);
+      emit(
+        state.withSession(
+          event.tabId,
+          after.copyWith(
+            calling: false,
+            lastResult: result,
+            log: [...after.log, 'Called ${event.toolName}'],
+          ),
+        ),
+      );
+    } on Object catch (e) {
+      log('MCP tool call failed: $e', name: 'McpBloc');
+      final after = state.sessionFor(event.tabId);
+      emit(
+        state.withSession(
+          event.tabId,
+          after.copyWith(
+            calling: false,
+            errorMessage: e.toString(),
+            log: [...after.log, 'Call failed: $e'],
+          ),
+        ),
+      );
+    }
+  }
+
+  Future<void> _teardown(String tabId) async {
+    await _connections.remove(tabId)?.close();
+  }
+
+  @override
+  Future<void> close() async {
+    for (final conn in _connections.values) {
+      await conn.close();
+    }
+    _connections.clear();
+    return super.close();
+  }
+}

--- a/lib/features/mcp/presentation/bloc/mcp_event.dart
+++ b/lib/features/mcp/presentation/bloc/mcp_event.dart
@@ -1,0 +1,48 @@
+import 'package:equatable/equatable.dart';
+
+abstract class McpEvent extends Equatable {
+  const McpEvent();
+  @override
+  List<Object?> get props => [];
+}
+
+class McpConnectRequested extends McpEvent {
+  const McpConnectRequested({
+    required this.tabId,
+    required this.url,
+    this.headers = const {},
+  });
+  final String tabId;
+  final String url;
+  final Map<String, String> headers;
+  @override
+  List<Object?> get props => [tabId, url, headers];
+}
+
+class McpDisconnectRequested extends McpEvent {
+  const McpDisconnectRequested(this.tabId);
+  final String tabId;
+  @override
+  List<Object?> get props => [tabId];
+}
+
+class McpToolSelected extends McpEvent {
+  const McpToolSelected({required this.tabId, required this.toolName});
+  final String tabId;
+  final String toolName;
+  @override
+  List<Object?> get props => [tabId, toolName];
+}
+
+class McpToolCallRequested extends McpEvent {
+  const McpToolCallRequested({
+    required this.tabId,
+    required this.toolName,
+    required this.arguments,
+  });
+  final String tabId;
+  final String toolName;
+  final Map<String, dynamic> arguments;
+  @override
+  List<Object?> get props => [tabId, toolName, arguments];
+}

--- a/lib/features/mcp/presentation/bloc/mcp_state.dart
+++ b/lib/features/mcp/presentation/bloc/mcp_state.dart
@@ -1,0 +1,76 @@
+import 'package:equatable/equatable.dart';
+import 'package:getman/features/mcp/domain/entities/mcp_session.dart';
+import 'package:getman/features/mcp/domain/entities/mcp_tool.dart';
+import 'package:getman/features/mcp/domain/entities/mcp_tool_result.dart';
+
+enum McpConnectionStatus { disconnected, connecting, connected, error }
+
+/// The MCP state for one tab: connection status, server session, advertised
+/// tools, the selected tool, the last call result, and a debug log of traffic.
+class McpTabSession extends Equatable {
+  const McpTabSession({
+    this.status = McpConnectionStatus.disconnected,
+    this.session,
+    this.tools = const [],
+    this.selectedTool,
+    this.lastResult,
+    this.calling = false,
+    this.errorMessage,
+    this.log = const [],
+  });
+
+  final McpConnectionStatus status;
+  final McpSession? session;
+  final List<McpTool> tools;
+  final String? selectedTool;
+  final McpToolResult? lastResult;
+  final bool calling;
+  final String? errorMessage;
+  final List<String> log;
+
+  McpTabSession copyWith({
+    McpConnectionStatus? status,
+    McpSession? session,
+    List<McpTool>? tools,
+    String? selectedTool,
+    McpToolResult? lastResult,
+    bool? calling,
+    String? errorMessage,
+    List<String>? log,
+  }) => McpTabSession(
+    status: status ?? this.status,
+    session: session ?? this.session,
+    tools: tools ?? this.tools,
+    selectedTool: selectedTool ?? this.selectedTool,
+    lastResult: lastResult,
+    calling: calling ?? this.calling,
+    errorMessage: errorMessage,
+    log: log ?? this.log,
+  );
+
+  @override
+  List<Object?> get props => [
+    status,
+    session,
+    tools,
+    selectedTool,
+    lastResult,
+    calling,
+    errorMessage,
+    log,
+  ];
+}
+
+class McpState extends Equatable {
+  const McpState({this.sessions = const {}});
+  final Map<String, McpTabSession> sessions;
+
+  McpTabSession sessionFor(String tabId) =>
+      sessions[tabId] ?? const McpTabSession();
+
+  McpState withSession(String tabId, McpTabSession session) =>
+      McpState(sessions: {...sessions, tabId: session});
+
+  @override
+  List<Object?> get props => [sessions];
+}

--- a/lib/features/mcp/presentation/widgets/mcp_connect_button.dart
+++ b/lib/features/mcp/presentation/widgets/mcp_connect_button.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:getman/core/domain/entities/request_config_entity.dart';
+import 'package:getman/core/theme/app_theme.dart';
+import 'package:getman/core/utils/environment_resolver.dart';
+import 'package:getman/features/mcp/presentation/bloc/mcp_bloc.dart';
+import 'package:getman/features/mcp/presentation/bloc/mcp_event.dart';
+import 'package:getman/features/mcp/presentation/bloc/mcp_state.dart';
+import 'package:getman/features/tabs/domain/entities/request_tab_entity.dart';
+import 'package:getman/features/tabs/presentation/bloc/tabs_bloc.dart';
+
+/// CONNECT / DISCONNECT button for MCP requests, driven by the MCP connection
+/// status for this tab. Resolves `{{var}}` in the endpoint URL + headers at
+/// press time (the URL bar does not rebuild on URL edits, so read the live
+/// config from TabsBloc).
+class McpConnectButton extends StatelessWidget {
+  const McpConnectButton({
+    required this.tabId,
+    required this.config,
+    required this.isNarrow,
+    required this.activeVars,
+    super.key,
+  });
+  final String tabId;
+  final HttpRequestConfigEntity config;
+  final bool isNarrow;
+  final Map<String, String> activeVars;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final layout = context.appLayout;
+    return BlocBuilder<McpBloc, McpState>(
+      buildWhen: (p, n) =>
+          p.sessionFor(tabId).status != n.sessionFor(tabId).status,
+      builder: (context, mcp) {
+        final status = mcp.sessionFor(tabId).status;
+        final connected = status == McpConnectionStatus.connected;
+        final connecting = status == McpConnectionStatus.connecting;
+        return context.appDecoration.wrapInteractive(
+          child: ElevatedButton(
+            key: const ValueKey('mcp_connect_button'),
+            onPressed: connecting
+                ? null
+                : () {
+                    final bloc = context.read<McpBloc>();
+                    if (connected) {
+                      bloc.add(McpDisconnectRequested(tabId));
+                      return;
+                    }
+                    final current = context
+                            .read<TabsBloc>()
+                            .state
+                            .tabs
+                            .byId(tabId)
+                            ?.config ??
+                        config;
+                    bloc.add(
+                      McpConnectRequested(
+                        tabId: tabId,
+                        url: EnvironmentResolver.resolve(
+                          current.url,
+                          activeVars,
+                        ),
+                        headers: EnvironmentResolver.resolveMap(
+                          current.headers,
+                          activeVars,
+                        ),
+                      ),
+                    );
+                  },
+            style: ElevatedButton.styleFrom(
+              backgroundColor: connected ? theme.colorScheme.error : null,
+              foregroundColor: connected ? theme.colorScheme.onError : null,
+              padding: EdgeInsets.symmetric(
+                horizontal: isNarrow ? 12 : layout.buttonPaddingHorizontal,
+                vertical: isNarrow ? 10 : layout.buttonPaddingVertical,
+              ),
+              minimumSize: Size.zero,
+              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            ),
+            child: Text(
+              connected
+                  ? (isNarrow ? 'STOP' : 'DISCONNECT')
+                  : (connecting ? '...' : 'CONNECT'),
+              style: TextStyle(
+                fontSize: layout.fontSizeTitle,
+                fontWeight: context.appTypography.displayWeight,
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/mcp/presentation/widgets/mcp_connect_button.dart
+++ b/lib/features/mcp/presentation/widgets/mcp_connect_button.dart
@@ -48,7 +48,8 @@ class McpConnectButton extends StatelessWidget {
                       bloc.add(McpDisconnectRequested(tabId));
                       return;
                     }
-                    final current = context
+                    final current =
+                        context
                             .read<TabsBloc>()
                             .state
                             .tabs

--- a/lib/features/mcp/presentation/widgets/mcp_connect_button.dart
+++ b/lib/features/mcp/presentation/widgets/mcp_connect_button.dart
@@ -59,10 +59,12 @@ class McpConnectButton extends StatelessWidget {
                     bloc.add(
                       McpConnectRequested(
                         tabId: tabId,
+                        // Trim: a stray trailing space/newline in the URL would
+                        // be percent-encoded into the path and 404 the server.
                         url: EnvironmentResolver.resolve(
                           current.url,
                           activeVars,
-                        ),
+                        ).trim(),
                         headers: EnvironmentResolver.resolveMap(
                           current.headers,
                           activeVars,

--- a/lib/features/mcp/presentation/widgets/mcp_panel.dart
+++ b/lib/features/mcp/presentation/widgets/mcp_panel.dart
@@ -4,12 +4,33 @@ import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:getman/core/theme/app_theme.dart';
+import 'package:getman/core/utils/environment_resolver.dart';
+import 'package:getman/core/utils/request_variable_resolver.dart';
+import 'package:getman/features/collections/presentation/bloc/collections_bloc.dart';
+import 'package:getman/features/environments/presentation/bloc/environments_bloc.dart';
 import 'package:getman/features/mcp/domain/entities/mcp_tool.dart';
 import 'package:getman/features/mcp/presentation/bloc/mcp_bloc.dart';
 import 'package:getman/features/mcp/presentation/bloc/mcp_event.dart';
 import 'package:getman/features/mcp/presentation/bloc/mcp_state.dart';
+import 'package:getman/features/settings/presentation/bloc/settings_bloc.dart';
+import 'package:getman/features/tabs/domain/entities/request_tab_entity.dart';
+import 'package:getman/features/tabs/presentation/bloc/tabs_bloc.dart';
 import 'package:getman/features/tabs/presentation/widgets/json_code_editor.dart';
 import 'package:re_editor/re_editor.dart';
+
+/// Recursively resolves `{{var}}` tokens in JSON argument values.
+/// Only String leaves are substituted; non-string values pass through
+/// unchanged.
+dynamic _resolveArg(dynamic value, Map<String, String> vars) {
+  if (value is String) return EnvironmentResolver.resolve(value, vars);
+  if (value is Map<String, dynamic>) {
+    return value.map((k, v) => MapEntry(k, _resolveArg(v, vars)));
+  }
+  if (value is List<dynamic>) {
+    return value.map((e) => _resolveArg(e, vars)).toList();
+  }
+  return value;
+}
 
 /// Post-connect MCP UI for one tab: tool list, the selected tool's schema +
 /// JSON arguments editor + CALL, the last result, and a session log.
@@ -50,6 +71,21 @@ class _McpPanelState extends State<McpPanel> {
         : const JsonEncoder.withIndent('  ').convert(tool.inputSchema);
   }
 
+  /// Returns the merged variable map (collection vars overlaid by active
+  /// environment) for the current tab — same approach as url_bar.dart.
+  Map<String, String> _activeVariables(BuildContext context) {
+    final envState = context.read<EnvironmentsBloc>().state;
+    final settings = context.read<SettingsBloc>().state.settings;
+    final collections = context.read<CollectionsBloc>().state.collections;
+    final tab = context.read<TabsBloc>().state.tabs.byId(widget.tabId);
+    return RequestVariableResolver.variablesFor(
+      environments: envState.environments,
+      activeEnvironmentId: settings.activeEnvironmentId,
+      collections: collections,
+      collectionNodeId: tab?.collectionNodeId,
+    );
+  }
+
   void _call(BuildContext context, String toolName) {
     final raw = _args.text.trim().isEmpty ? '{}' : _args.text;
     Map<String, dynamic>? parsed;
@@ -64,11 +100,15 @@ class _McpPanelState extends State<McpPanel> {
       return;
     }
     setState(() => _argsError = null);
+    final activeVars = _activeVariables(context);
+    final resolved = parsed.map(
+      (k, v) => MapEntry(k, _resolveArg(v, activeVars)),
+    );
     context.read<McpBloc>().add(
       McpToolCallRequested(
         tabId: widget.tabId,
         toolName: toolName,
-        arguments: parsed,
+        arguments: resolved,
       ),
     );
   }
@@ -236,7 +276,7 @@ class _ToolDetail extends StatelessWidget {
           ),
           SizedBox(height: layout.inputPaddingVertical),
           SizedBox(
-            height: 160,
+            height: layout.mcpEditorPaneHeight,
             child: JsonCodeEditor(
               controller: schemaController,
               readOnly: true,
@@ -250,7 +290,7 @@ class _ToolDetail extends StatelessWidget {
           ),
           SizedBox(height: layout.inputPaddingVertical),
           SizedBox(
-            height: 160,
+            height: layout.mcpEditorPaneHeight,
             child: JsonCodeEditor(
               controller: argsController,
               autofocus: false,

--- a/lib/features/mcp/presentation/widgets/mcp_panel.dart
+++ b/lib/features/mcp/presentation/widgets/mcp_panel.dart
@@ -1,0 +1,278 @@
+import 'dart:convert';
+
+import 'package:collection/collection.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:getman/core/theme/app_theme.dart';
+import 'package:getman/features/mcp/domain/entities/mcp_tool.dart';
+import 'package:getman/features/mcp/presentation/bloc/mcp_bloc.dart';
+import 'package:getman/features/mcp/presentation/bloc/mcp_event.dart';
+import 'package:getman/features/mcp/presentation/bloc/mcp_state.dart';
+import 'package:getman/features/tabs/presentation/widgets/json_code_editor.dart';
+import 'package:re_editor/re_editor.dart';
+
+/// Post-connect MCP UI for one tab: tool list, the selected tool's schema +
+/// JSON arguments editor + CALL, the last result, and a session log.
+/// Connecting itself is driven by the URL-bar CONNECT button.
+class McpPanel extends StatefulWidget {
+  const McpPanel({required this.tabId, super.key});
+  final String tabId;
+
+  @override
+  State<McpPanel> createState() => _McpPanelState();
+}
+
+class _McpPanelState extends State<McpPanel> {
+  final CodeLineEditingController _args = createJsonCodeController();
+  final CodeLineEditingController _schema = createJsonCodeController();
+  String? _argsError;
+  String? _editingTool;
+
+  @override
+  void dispose() {
+    _args.dispose();
+    _schema.dispose();
+    super.dispose();
+  }
+
+  void _syncForTool(McpTool? tool) {
+    if (tool?.name == _editingTool) return;
+    _editingTool = tool?.name;
+    _args.text = '{}';
+    _argsError = null;
+    _schema.text = tool == null
+        ? ''
+        : tool.inputSchema.isEmpty
+        ? '(no input schema)'
+        : const JsonEncoder.withIndent('  ').convert(tool.inputSchema);
+  }
+
+  void _call(BuildContext context, String toolName) {
+    final raw = _args.text.trim().isEmpty ? '{}' : _args.text;
+    Map<String, dynamic>? parsed;
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is Map<String, dynamic>) parsed = decoded;
+    } on FormatException {
+      parsed = null;
+    }
+    if (parsed == null) {
+      setState(() => _argsError = 'Arguments must be a JSON object');
+      return;
+    }
+    setState(() => _argsError = null);
+    context.read<McpBloc>().add(
+      McpToolCallRequested(
+        tabId: widget.tabId,
+        toolName: toolName,
+        arguments: parsed,
+      ),
+    );
+  }
+
+  String _resultText(McpTabSession s) {
+    final r = s.lastResult;
+    if (r == null) return '';
+    if (r.textBlocks.isNotEmpty) return r.textBlocks.join('\n');
+    if (r.rawBlocks.isNotEmpty) {
+      return const JsonEncoder.withIndent('  ').convert(r.rawBlocks);
+    }
+    return r.isError ? '(error, no content)' : '(no content)';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<McpBloc, McpState>(
+      buildWhen: (p, n) =>
+          p.sessionFor(widget.tabId) != n.sessionFor(widget.tabId),
+      builder: (context, state) {
+        final s = state.sessionFor(widget.tabId);
+        final layout = context.appLayout;
+        final typo = context.appTypography;
+        final theme = Theme.of(context);
+
+        if (s.status != McpConnectionStatus.connected) {
+          return Center(
+            child: Padding(
+              padding: EdgeInsets.all(layout.pagePadding),
+              child: Text(
+                switch (s.status) {
+                  McpConnectionStatus.connecting => 'Connecting…',
+                  McpConnectionStatus.error =>
+                    s.errorMessage ?? 'Connection error',
+                  _ => 'Not connected — press CONNECT to list tools',
+                },
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  color: s.status == McpConnectionStatus.error
+                      ? theme.colorScheme.error
+                      : theme.colorScheme.onSurface,
+                  fontWeight: typo.bodyWeight,
+                ),
+              ),
+            ),
+          );
+        }
+
+        final selected = s.tools.firstWhereOrNull(
+          (t) => t.name == s.selectedTool,
+        );
+        _syncForTool(selected);
+
+        return Padding(
+          padding: EdgeInsets.all(layout.inputPadding),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(
+                'Tools (${s.tools.length})',
+                style: TextStyle(fontWeight: typo.titleWeight),
+              ),
+              SizedBox(height: layout.inputPaddingVertical),
+              // Tool selection chips.
+              Wrap(
+                spacing: layout.inputPaddingVertical,
+                runSpacing: layout.inputPaddingVertical,
+                children: s.tools
+                    .map(
+                      (t) => ChoiceChip(
+                        label: Text(t.name),
+                        selected: t.name == s.selectedTool,
+                        onSelected: (_) => context.read<McpBloc>().add(
+                          McpToolSelected(
+                            tabId: widget.tabId,
+                            toolName: t.name,
+                          ),
+                        ),
+                      ),
+                    )
+                    .toList(),
+              ),
+              SizedBox(height: layout.inputPadding),
+              if (selected != null)
+                Expanded(
+                  child: _ToolDetail(
+                    tool: selected,
+                    argsController: _args,
+                    schemaController: _schema,
+                    argsError: _argsError,
+                    calling: s.calling,
+                    resultText: _resultText(s),
+                    onCall: () => _call(context, selected.name),
+                  ),
+                )
+              else
+                Expanded(
+                  child: Center(
+                    child: Text(
+                      'Select a tool above',
+                      style: TextStyle(
+                        color: theme.colorScheme.onSurface.withValues(
+                          alpha: 0.5,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _ToolDetail extends StatelessWidget {
+  const _ToolDetail({
+    required this.tool,
+    required this.argsController,
+    required this.schemaController,
+    required this.argsError,
+    required this.calling,
+    required this.resultText,
+    required this.onCall,
+  });
+
+  final McpTool tool;
+  final CodeLineEditingController argsController;
+  final CodeLineEditingController schemaController;
+  final String? argsError;
+  final bool calling;
+  final String resultText;
+  final VoidCallback onCall;
+
+  @override
+  Widget build(BuildContext context) {
+    final layout = context.appLayout;
+    final typo = context.appTypography;
+    final theme = Theme.of(context);
+
+    return SingleChildScrollView(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          if (tool.description.isNotEmpty) ...[
+            Text(
+              tool.description,
+              style: TextStyle(fontWeight: typo.bodyWeight),
+            ),
+            SizedBox(height: layout.inputPaddingVertical),
+          ],
+          Text(
+            'Input schema',
+            style: TextStyle(fontWeight: typo.titleWeight),
+          ),
+          SizedBox(height: layout.inputPaddingVertical),
+          SizedBox(
+            height: 160,
+            child: JsonCodeEditor(
+              controller: schemaController,
+              readOnly: true,
+              autofocus: false,
+            ),
+          ),
+          SizedBox(height: layout.inputPadding),
+          Text(
+            'Arguments (JSON)',
+            style: TextStyle(fontWeight: typo.titleWeight),
+          ),
+          SizedBox(height: layout.inputPaddingVertical),
+          SizedBox(
+            height: 160,
+            child: JsonCodeEditor(
+              controller: argsController,
+              autofocus: false,
+            ),
+          ),
+          if (argsError != null) ...[
+            SizedBox(height: layout.inputPaddingVertical),
+            Text(
+              argsError!,
+              style: TextStyle(color: theme.colorScheme.error),
+            ),
+          ],
+          SizedBox(height: layout.inputPadding),
+          Align(
+            alignment: Alignment.centerLeft,
+            child: context.appDecoration.wrapInteractive(
+              child: ElevatedButton(
+                key: const ValueKey('mcp_call_button'),
+                onPressed: calling ? null : onCall,
+                child: Text(
+                  calling ? 'CALLING…' : 'CALL',
+                  style: TextStyle(fontWeight: typo.displayWeight),
+                ),
+              ),
+            ),
+          ),
+          if (resultText.isNotEmpty) ...[
+            SizedBox(height: layout.inputPadding),
+            Text('Result', style: TextStyle(fontWeight: typo.titleWeight)),
+            SizedBox(height: layout.inputPaddingVertical),
+            SelectableText(resultText),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/mcp/presentation/widgets/mcp_panel.dart
+++ b/lib/features/mcp/presentation/widgets/mcp_panel.dart
@@ -4,33 +4,16 @@ import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:getman/core/theme/app_theme.dart';
-import 'package:getman/core/utils/environment_resolver.dart';
-import 'package:getman/core/utils/request_variable_resolver.dart';
-import 'package:getman/features/collections/presentation/bloc/collections_bloc.dart';
-import 'package:getman/features/environments/presentation/bloc/environments_bloc.dart';
+import 'package:getman/core/ui/widgets/tab_variable_context_builder.dart';
+import 'package:getman/core/utils/layered_variable_context.dart';
 import 'package:getman/features/mcp/domain/entities/mcp_tool.dart';
+import 'package:getman/features/mcp/domain/mcp_argument_resolver.dart';
 import 'package:getman/features/mcp/presentation/bloc/mcp_bloc.dart';
 import 'package:getman/features/mcp/presentation/bloc/mcp_event.dart';
 import 'package:getman/features/mcp/presentation/bloc/mcp_state.dart';
-import 'package:getman/features/settings/presentation/bloc/settings_bloc.dart';
-import 'package:getman/features/tabs/domain/entities/request_tab_entity.dart';
-import 'package:getman/features/tabs/presentation/bloc/tabs_bloc.dart';
 import 'package:getman/features/tabs/presentation/widgets/json_code_editor.dart';
+import 'package:getman/features/tabs/presentation/widgets/variable_code_autocomplete.dart';
 import 'package:re_editor/re_editor.dart';
-
-/// Recursively resolves `{{var}}` tokens in JSON argument values.
-/// Only String leaves are substituted; non-string values pass through
-/// unchanged.
-dynamic _resolveArg(dynamic value, Map<String, String> vars) {
-  if (value is String) return EnvironmentResolver.resolve(value, vars);
-  if (value is Map<String, dynamic>) {
-    return value.map((k, v) => MapEntry(k, _resolveArg(v, vars)));
-  }
-  if (value is List<dynamic>) {
-    return value.map((e) => _resolveArg(e, vars)).toList();
-  }
-  return value;
-}
 
 /// Post-connect MCP UI for one tab: tool list, the selected tool's schema +
 /// JSON arguments editor + CALL, the last result, and a session log.
@@ -44,16 +27,62 @@ class McpPanel extends StatefulWidget {
 }
 
 class _McpPanelState extends State<McpPanel> {
-  final CodeLineEditingController _args = createJsonCodeController();
+  // The arguments editor is variable-aware: its span builder reads the live
+  // variable context + token colours via closures at paint time, so an env or
+  // theme change recolours `{{var}}` tokens on the next forceRepaint — the same
+  // wiring the request body editor uses.
+  late final CodeLineEditingController _args;
   final CodeLineEditingController _schema = createJsonCodeController();
+  final CodeLineEditingController _result = createJsonCodeController();
   String? _argsError;
   String? _editingTool;
+  String _lastResultText = '';
+
+  LayeredVariableContext _argsVarContext = LayeredVariableContext.empty;
+  Color _resolvedColor = Colors.transparent;
+  Color _unresolvedColor = Colors.transparent;
+
+  @override
+  void initState() {
+    super.initState();
+    _args = createJsonCodeController(
+      variablesProvider: () => _argsVarContext.allVariables,
+      resolvedColor: () => _resolvedColor,
+      unresolvedColor: () => _unresolvedColor,
+    );
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // Theme is available here (not in initState). Recolour `{{var}}` tokens
+    // when the variable palette changes (dark/light or theme switch).
+    final palette = context.appPalette;
+    if (_resolvedColor != palette.variableResolved ||
+        _unresolvedColor != palette.variableUnresolved) {
+      _resolvedColor = palette.variableResolved;
+      _unresolvedColor = palette.variableUnresolved;
+      _args.forceRepaint();
+    }
+  }
 
   @override
   void dispose() {
     _args.dispose();
     _schema.dispose();
+    _result.dispose();
     super.dispose();
+  }
+
+  /// Stores the latest layered variable context (env + collection + dynamic)
+  /// for the args editor's span builder and repaints visible lines so an env or
+  /// collection switch recolours tokens without waiting for a keystroke.
+  void _syncArgsVarContext(LayeredVariableContext ctx) {
+    if (_argsVarContext == ctx) return;
+    _argsVarContext = ctx;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _args.forceRepaint();
+    });
   }
 
   // Fix 2: _syncForTool is no longer called from within build(). It is
@@ -71,21 +100,6 @@ class _McpPanelState extends State<McpPanel> {
         : const JsonEncoder.withIndent('  ').convert(tool.inputSchema);
   }
 
-  /// Returns the merged variable map (collection vars overlaid by active
-  /// environment) for the current tab — same approach as url_bar.dart.
-  Map<String, String> _activeVariables(BuildContext context) {
-    final envState = context.read<EnvironmentsBloc>().state;
-    final settings = context.read<SettingsBloc>().state.settings;
-    final collections = context.read<CollectionsBloc>().state.collections;
-    final tab = context.read<TabsBloc>().state.tabs.byId(widget.tabId);
-    return RequestVariableResolver.variablesFor(
-      environments: envState.environments,
-      activeEnvironmentId: settings.activeEnvironmentId,
-      collections: collections,
-      collectionNodeId: tab?.collectionNodeId,
-    );
-  }
-
   void _call(BuildContext context, String toolName) {
     final raw = _args.text.trim().isEmpty ? '{}' : _args.text;
     Map<String, dynamic>? parsed;
@@ -100,10 +114,8 @@ class _McpPanelState extends State<McpPanel> {
       return;
     }
     setState(() => _argsError = null);
-    final activeVars = _activeVariables(context);
-    final resolved = parsed.map(
-      (k, v) => MapEntry(k, _resolveArg(v, activeVars)),
-    );
+    // Resolve `{{var}}` against the same live context that highlights them.
+    final resolved = resolveMcpArguments(parsed, _argsVarContext.allVariables);
     context.read<McpBloc>().add(
       McpToolCallRequested(
         tabId: widget.tabId,
@@ -168,6 +180,18 @@ class _McpPanelState extends State<McpPanel> {
           });
         }
 
+        // Push the latest result into its read-only editor off-build, for the
+        // same reason — only when it actually changed.
+        final resultText = _resultText(s);
+        if (resultText != _lastResultText) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (mounted) {
+              _result.text = resultText;
+              _lastResultText = resultText;
+            }
+          });
+        }
+
         return Padding(
           padding: EdgeInsets.all(layout.inputPadding),
           child: Column(
@@ -202,11 +226,33 @@ class _McpPanelState extends State<McpPanel> {
                 Expanded(
                   child: _ToolDetail(
                     tool: selected,
-                    argsController: _args,
+                    argsEditor: SizedBox(
+                      height: layout.mcpEditorPaneHeight,
+                      // Feeds live env/collection variables to the args editor's
+                      // highlighter (and, via _syncArgsVarContext, to CALL-time
+                      // resolution). Rebuilds only on env/collection change.
+                      child: TabVariableContextBuilder(
+                        tabId: widget.tabId,
+                        builder: (context, ctx) {
+                          _syncArgsVarContext(ctx);
+                          // Wrap with the `{{` variable autocomplete dropdown,
+                          // same as the request body editor.
+                          return wrapBodyWithVariableAutocomplete(
+                            contextProvider: () => ctx,
+                            child: JsonCodeEditor(
+                              controller: _args,
+                              autofocus: false,
+                            ),
+                          );
+                        },
+                      ),
+                    ),
                     schemaController: _schema,
+                    resultController: _result,
                     argsError: _argsError,
                     calling: s.calling,
-                    resultText: _resultText(s),
+                    hasResult: resultText.isNotEmpty,
+                    resultIsError: s.lastResult?.isError ?? false,
                     log: s.log,
                     onCall: () => _call(context, selected.name),
                   ),
@@ -235,21 +281,25 @@ class _McpPanelState extends State<McpPanel> {
 class _ToolDetail extends StatelessWidget {
   const _ToolDetail({
     required this.tool,
-    required this.argsController,
+    required this.argsEditor,
     required this.schemaController,
+    required this.resultController,
     required this.argsError,
     required this.calling,
-    required this.resultText,
+    required this.hasResult,
+    required this.resultIsError,
     required this.log,
     required this.onCall,
   });
 
   final McpTool tool;
-  final CodeLineEditingController argsController;
+  final Widget argsEditor;
   final CodeLineEditingController schemaController;
+  final CodeLineEditingController resultController;
   final String? argsError;
   final bool calling;
-  final String resultText;
+  final bool hasResult;
+  final bool resultIsError;
   final List<String> log;
   final VoidCallback onCall;
 
@@ -289,13 +339,7 @@ class _ToolDetail extends StatelessWidget {
             style: TextStyle(fontWeight: typo.titleWeight),
           ),
           SizedBox(height: layout.inputPaddingVertical),
-          SizedBox(
-            height: layout.mcpEditorPaneHeight,
-            child: JsonCodeEditor(
-              controller: argsController,
-              autofocus: false,
-            ),
-          ),
+          argsEditor,
           if (argsError != null) ...[
             SizedBox(height: layout.inputPaddingVertical),
             Text(
@@ -317,11 +361,25 @@ class _ToolDetail extends StatelessWidget {
               ),
             ),
           ),
-          if (resultText.isNotEmpty) ...[
+          if (hasResult) ...[
             SizedBox(height: layout.inputPadding),
-            Text('Result', style: TextStyle(fontWeight: typo.titleWeight)),
+            Text(
+              resultIsError ? 'Result (error)' : 'Result',
+              style: TextStyle(
+                fontWeight: typo.titleWeight,
+                color: resultIsError ? theme.colorScheme.error : null,
+              ),
+            ),
             SizedBox(height: layout.inputPaddingVertical),
-            SelectableText(resultText),
+            SizedBox(
+              height: layout.mcpEditorPaneHeight,
+              child: JsonCodeEditor(
+                key: const ValueKey('mcp_result_view'),
+                controller: resultController,
+                readOnly: true,
+                autofocus: false,
+              ),
+            ),
           ],
           // Fix 1: collapsible session log, shown when log is non-empty.
           // Lives inside the SingleChildScrollView — no RenderFlex overflow.

--- a/lib/features/mcp/presentation/widgets/mcp_panel.dart
+++ b/lib/features/mcp/presentation/widgets/mcp_panel.dart
@@ -35,6 +35,9 @@ class _McpPanelState extends State<McpPanel> {
     super.dispose();
   }
 
+  // Fix 2: _syncForTool is no longer called from within build(). It is
+  // scheduled via addPostFrameCallback so controller.text mutations
+  // (which call notifyListeners) never fire mid-build.
   void _syncForTool(McpTool? tool) {
     if (tool?.name == _editingTool) return;
     _editingTool = tool?.name;
@@ -117,7 +120,13 @@ class _McpPanelState extends State<McpPanel> {
         final selected = s.tools.firstWhereOrNull(
           (t) => t.name == s.selectedTool,
         );
-        _syncForTool(selected);
+        // Schedule off-build: avoids notifyListeners mid-build when the
+        // selected tool changes and the controller text needs updating.
+        if (selected?.name != _editingTool) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (mounted) setState(() => _syncForTool(selected));
+          });
+        }
 
         return Padding(
           padding: EdgeInsets.all(layout.inputPadding),
@@ -158,6 +167,7 @@ class _McpPanelState extends State<McpPanel> {
                     argsError: _argsError,
                     calling: s.calling,
                     resultText: _resultText(s),
+                    log: s.log,
                     onCall: () => _call(context, selected.name),
                   ),
                 )
@@ -190,6 +200,7 @@ class _ToolDetail extends StatelessWidget {
     required this.argsError,
     required this.calling,
     required this.resultText,
+    required this.log,
     required this.onCall,
   });
 
@@ -199,6 +210,7 @@ class _ToolDetail extends StatelessWidget {
   final String? argsError;
   final bool calling;
   final String resultText;
+  final List<String> log;
   final VoidCallback onCall;
 
   @override
@@ -270,6 +282,39 @@ class _ToolDetail extends StatelessWidget {
             Text('Result', style: TextStyle(fontWeight: typo.titleWeight)),
             SizedBox(height: layout.inputPaddingVertical),
             SelectableText(resultText),
+          ],
+          // Fix 1: collapsible session log, shown when log is non-empty.
+          // Lives inside the SingleChildScrollView — no RenderFlex overflow.
+          if (log.isNotEmpty) ...[
+            SizedBox(height: layout.inputPaddingVertical),
+            ExpansionTile(
+              key: const ValueKey('mcp_session_log'),
+              title: Text(
+                'Session log',
+                style: TextStyle(fontWeight: typo.titleWeight),
+              ),
+              children: [
+                for (final entry in log)
+                  Align(
+                    alignment: Alignment.centerLeft,
+                    child: Padding(
+                      padding: EdgeInsets.symmetric(
+                        vertical: layout.inputPaddingVertical / 2,
+                        horizontal: layout.inputPadding,
+                      ),
+                      child: Text(
+                        entry,
+                        style: TextStyle(
+                          fontFamily: typo.codeFontFamily,
+                          color: theme.colorScheme.onSurface.withValues(
+                            alpha: 0.8,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+              ],
+            ),
           ],
         ],
       ),

--- a/lib/features/tabs/presentation/widgets/request_kind_method_selector.dart
+++ b/lib/features/tabs/presentation/widgets/request_kind_method_selector.dart
@@ -58,6 +58,7 @@ class RequestKindMethodSelector extends StatelessWidget {
                   child: Text('WS'),
                 ),
                 DropdownMenuItem(value: RequestKind.sse, child: Text('SSE')),
+                DropdownMenuItem(value: RequestKind.mcp, child: Text('MCP')),
               ],
               onChanged: (k) {
                 if (k != null && tab.config.kind != k) {

--- a/lib/features/tabs/presentation/widgets/response_area.dart
+++ b/lib/features/tabs/presentation/widgets/response_area.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:getman/core/network/request_kind.dart';
+import 'package:getman/features/mcp/presentation/widgets/mcp_panel.dart';
 import 'package:getman/features/realtime/presentation/widgets/realtime_panel.dart';
 import 'package:getman/features/tabs/domain/entities/request_tab_entity.dart';
 import 'package:getman/features/tabs/presentation/bloc/tabs_bloc.dart';
@@ -8,8 +9,8 @@ import 'package:getman/features/tabs/presentation/bloc/tabs_state.dart';
 import 'package:getman/features/tabs/presentation/widgets/response_section.dart';
 import 'package:re_editor/re_editor.dart';
 
-/// Shows the HTTP [ResponseSection] or, for WebSocket/SSE requests, the live
-/// [RealtimePanel] — switching on the tab's request kind.
+/// Shows the HTTP [ResponseSection], [McpPanel] for MCP requests, or the live
+/// [RealtimePanel] for WebSocket/SSE — switching on the tab's request kind.
 class ResponseArea extends StatelessWidget {
   const ResponseArea({
     required this.tabId,
@@ -35,6 +36,9 @@ class ResponseArea extends StatelessWidget {
             responseController: responseController,
             showMetadata: showMetadata,
           );
+        }
+        if (kind == RequestKind.mcp) {
+          return McpPanel(tabId: tabId);
         }
         return RealtimePanel(tabId: tabId);
       },

--- a/lib/features/tabs/presentation/widgets/url_bar.dart
+++ b/lib/features/tabs/presentation/widgets/url_bar.dart
@@ -19,6 +19,7 @@ import 'package:getman/features/collections/presentation/bloc/collections_state.
 import 'package:getman/features/environments/domain/logic/active_environment_helper.dart';
 import 'package:getman/features/environments/presentation/bloc/environments_bloc.dart';
 import 'package:getman/features/environments/presentation/bloc/environments_state.dart';
+import 'package:getman/features/mcp/presentation/widgets/mcp_connect_button.dart';
 import 'package:getman/features/settings/presentation/bloc/settings_bloc.dart';
 import 'package:getman/features/settings/presentation/bloc/settings_event.dart';
 import 'package:getman/features/settings/presentation/bloc/settings_state.dart';
@@ -427,6 +428,13 @@ class _UrlBarState extends State<UrlBar> {
                                         ),
                                 ),
                               ),
+                            )
+                          else if (tab.config.kind == RequestKind.mcp)
+                            McpConnectButton(
+                              tabId: tab.tabId,
+                              config: tab.config,
+                              isNarrow: isNarrow,
+                              activeVars: _activeVariables(context),
                             )
                           else
                             RealtimeButton(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,6 +21,7 @@ import 'package:getman/features/environments/presentation/bloc/environments_bloc
 import 'package:getman/features/environments/presentation/bloc/environments_event.dart';
 import 'package:getman/features/history/presentation/bloc/history_bloc.dart';
 import 'package:getman/features/home/domain/usecases/tab_dirty_checker.dart';
+import 'package:getman/features/mcp/presentation/bloc/mcp_bloc.dart';
 import 'package:getman/features/realtime/presentation/bloc/realtime_bloc.dart';
 import 'package:getman/features/settings/domain/entities/settings_entity.dart';
 import 'package:getman/features/settings/domain/usecases/settings_usecases.dart';
@@ -214,6 +215,7 @@ class MyApp extends StatelessWidget {
           ),
           BlocProvider(create: (_) => di.sl<RulesBloc>()),
           BlocProvider(create: (_) => di.sl<RealtimeBloc>()),
+          BlocProvider(create: (_) => di.sl<McpBloc>()),
         ],
         child: NetworkSettingsListener(
           child: WorkspaceSyncListener(

--- a/test/core/network/mcp_service_test.dart
+++ b/test/core/network/mcp_service_test.dart
@@ -152,7 +152,7 @@ void main() {
       // tools/call (SSE)
       resp(_sseBody({
         'jsonrpc': '2.0',
-        'id': 3,
+        'id': 2,
         'result': {
           'content': [
             {'type': 'text', 'text': 'hello'},

--- a/test/core/network/mcp_service_test.dart
+++ b/test/core/network/mcp_service_test.dart
@@ -59,46 +59,51 @@ void main() {
     ).thenAnswer((_) async => responses[i++]);
   }
 
-  Response<ResponseBody> resp(ResponseBody body, {Map<String, List<String>>? headers}) =>
-      Response<ResponseBody>(
-        data: body,
-        statusCode: body.statusCode,
-        headers: Headers.fromMap(headers ?? {}),
-        requestOptions: RequestOptions(path: '/'),
-      );
+  Response<ResponseBody> resp(
+    ResponseBody body, {
+    Map<String, List<String>>? headers,
+  }) => Response<ResponseBody>(
+    data: body,
+    statusCode: body.statusCode,
+    headers: Headers.fromMap(headers ?? {}),
+    requestOptions: RequestOptions(path: '/'),
+  );
 
-  test('connect performs the initialize handshake and captures session id',
-      () async {
-    stubPosts([
-      resp(
-        _jsonBody({
-          'jsonrpc': '2.0',
-          'id': 1,
-          'result': {
-            'protocolVersion': '2025-06-18',
-            'serverInfo': {'name': 'demo', 'version': '9.9'},
+  test(
+    'connect performs the initialize handshake and captures session id',
+    () async {
+      stubPosts([
+        resp(
+          _jsonBody({
+            'jsonrpc': '2.0',
+            'id': 1,
+            'result': {
+              'protocolVersion': '2025-06-18',
+              'serverInfo': {'name': 'demo', 'version': '9.9'},
+            },
+          }),
+          headers: {
+            'mcp-session-id': ['sess-1'],
           },
-        }),
-        headers: {
-          'mcp-session-id': ['sess-1'],
-        },
-      ),
-      resp(_jsonBody({'jsonrpc': '2.0'}), headers: {}), // initialized notif (202-ish)
-    ]);
+        ),
+        // initialized notif (202-ish)
+        resp(_jsonBody({'jsonrpc': '2.0'}), headers: {}),
+      ]);
 
-    final conn = await service.connect('https://mcp.dev/');
-    expect(conn.session.sessionId, 'sess-1');
-    expect(conn.session.serverName, 'demo');
-    // initialize POST + initialized notification POST = 2 calls.
-    verify(
-      () => dio.post<ResponseBody>(
-        any(),
-        data: any(named: 'data'),
-        options: any(named: 'options'),
-        cancelToken: any(named: 'cancelToken'),
-      ),
-    ).called(2);
-  });
+      final conn = await service.connect('https://mcp.dev/');
+      expect(conn.session.sessionId, 'sess-1');
+      expect(conn.session.serverName, 'demo');
+      // initialize POST + initialized notification POST = 2 calls.
+      verify(
+        () => dio.post<ResponseBody>(
+          any(),
+          data: any(named: 'data'),
+          options: any(named: 'options'),
+          cancelToken: any(named: 'cancelToken'),
+        ),
+      ).called(2);
+    },
+  );
 
   test('listTools parses tools from an application/json response', () async {
     stubPosts([
@@ -112,20 +117,28 @@ void main() {
             'serverInfo': {'name': 'demo', 'version': '1'},
           },
         }),
-        headers: {'mcp-session-id': ['s1']},
+        headers: {
+          'mcp-session-id': ['s1'],
+        },
       ),
       // initialized notification ack
       resp(_jsonBody({'jsonrpc': '2.0'})),
       // tools/list
-      resp(_jsonBody({
-        'jsonrpc': '2.0',
-        'id': 2,
-        'result': {
-          'tools': [
-            {'name': 'add', 'description': 'Add', 'inputSchema': {'type': 'object'}},
-          ],
-        },
-      })),
+      resp(
+        _jsonBody({
+          'jsonrpc': '2.0',
+          'id': 2,
+          'result': {
+            'tools': [
+              {
+                'name': 'add',
+                'description': 'Add',
+                'inputSchema': {'type': 'object'},
+              },
+            ],
+          },
+        }),
+      ),
     ]);
 
     final conn = await service.connect('https://mcp.dev/');
@@ -145,21 +158,25 @@ void main() {
             'serverInfo': {'name': 'demo', 'version': '1'},
           },
         }),
-        headers: {'mcp-session-id': ['s1']},
+        headers: {
+          'mcp-session-id': ['s1'],
+        },
       ),
       // initialized notification ack
       resp(_jsonBody({'jsonrpc': '2.0'})),
       // tools/call (SSE)
-      resp(_sseBody({
-        'jsonrpc': '2.0',
-        'id': 2,
-        'result': {
-          'content': [
-            {'type': 'text', 'text': 'hello'},
-          ],
-          'isError': false,
-        },
-      })),
+      resp(
+        _sseBody({
+          'jsonrpc': '2.0',
+          'id': 2,
+          'result': {
+            'content': [
+              {'type': 'text', 'text': 'hello'},
+            ],
+            'isError': false,
+          },
+        }),
+      ),
     ]);
 
     final conn = await service.connect('https://mcp.dev/');
@@ -180,16 +197,20 @@ void main() {
             'serverInfo': {'name': 'demo', 'version': '1'},
           },
         }),
-        headers: {'mcp-session-id': ['s1']},
+        headers: {
+          'mcp-session-id': ['s1'],
+        },
       ),
       // initialized notification ack
       resp(_jsonBody({'jsonrpc': '2.0'})),
       // error response
-      resp(_jsonBody({
-        'jsonrpc': '2.0',
-        'id': 2,
-        'error': {'code': -32601, 'message': 'Method not found'},
-      })),
+      resp(
+        _jsonBody({
+          'jsonrpc': '2.0',
+          'id': 2,
+          'error': {'code': -32601, 'message': 'Method not found'},
+        }),
+      ),
     ]);
 
     final conn = await service.connect('https://mcp.dev/');

--- a/test/core/network/mcp_service_test.dart
+++ b/test/core/network/mcp_service_test.dart
@@ -1,0 +1,205 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/core/network/mcp_service.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockDio extends Mock implements Dio {}
+
+ResponseBody _jsonBody(Map<String, dynamic> json, {int status = 200}) {
+  final bytes = Uint8List.fromList(utf8.encode(jsonEncode(json)));
+  return ResponseBody(
+    Stream<Uint8List>.value(bytes),
+    status,
+    headers: {
+      Headers.contentTypeHeader: ['application/json'],
+    },
+  );
+}
+
+ResponseBody _sseBody(Map<String, dynamic> json, {int status = 200}) {
+  final frame = 'event: message\ndata: ${jsonEncode(json)}\n\n';
+  final bytes = Uint8List.fromList(utf8.encode(frame));
+  return ResponseBody(
+    Stream<Uint8List>.value(bytes),
+    status,
+    headers: {
+      Headers.contentTypeHeader: ['text/event-stream'],
+    },
+  );
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(Options());
+    registerFallbackValue(CancelToken());
+  });
+
+  late _MockDio dio;
+  late McpService service;
+
+  setUp(() {
+    dio = _MockDio();
+    service = McpService(dio: dio);
+  });
+
+  // Queues a sequence of POST responses; the Nth POST returns responses[N].
+  void stubPosts(List<Response<ResponseBody>> responses) {
+    var i = 0;
+    when(
+      () => dio.post<ResponseBody>(
+        any(),
+        data: any(named: 'data'),
+        options: any(named: 'options'),
+        cancelToken: any(named: 'cancelToken'),
+      ),
+    ).thenAnswer((_) async => responses[i++]);
+  }
+
+  Response<ResponseBody> resp(ResponseBody body, {Map<String, List<String>>? headers}) =>
+      Response<ResponseBody>(
+        data: body,
+        statusCode: body.statusCode,
+        headers: Headers.fromMap(headers ?? {}),
+        requestOptions: RequestOptions(path: '/'),
+      );
+
+  test('connect performs the initialize handshake and captures session id',
+      () async {
+    stubPosts([
+      resp(
+        _jsonBody({
+          'jsonrpc': '2.0',
+          'id': 1,
+          'result': {
+            'protocolVersion': '2025-06-18',
+            'serverInfo': {'name': 'demo', 'version': '9.9'},
+          },
+        }),
+        headers: {
+          'mcp-session-id': ['sess-1'],
+        },
+      ),
+      resp(_jsonBody({'jsonrpc': '2.0'}), headers: {}), // initialized notif (202-ish)
+    ]);
+
+    final conn = await service.connect('https://mcp.dev/');
+    expect(conn.session.sessionId, 'sess-1');
+    expect(conn.session.serverName, 'demo');
+    // initialize POST + initialized notification POST = 2 calls.
+    verify(
+      () => dio.post<ResponseBody>(
+        any(),
+        data: any(named: 'data'),
+        options: any(named: 'options'),
+        cancelToken: any(named: 'cancelToken'),
+      ),
+    ).called(2);
+  });
+
+  test('listTools parses tools from an application/json response', () async {
+    stubPosts([
+      // initialize
+      resp(
+        _jsonBody({
+          'jsonrpc': '2.0',
+          'id': 1,
+          'result': {
+            'protocolVersion': '2025-06-18',
+            'serverInfo': {'name': 'demo', 'version': '1'},
+          },
+        }),
+        headers: {'mcp-session-id': ['s1']},
+      ),
+      // initialized notification ack
+      resp(_jsonBody({'jsonrpc': '2.0'})),
+      // tools/list
+      resp(_jsonBody({
+        'jsonrpc': '2.0',
+        'id': 2,
+        'result': {
+          'tools': [
+            {'name': 'add', 'description': 'Add', 'inputSchema': {'type': 'object'}},
+          ],
+        },
+      })),
+    ]);
+
+    final conn = await service.connect('https://mcp.dev/');
+    final tools = await conn.listTools();
+    expect(tools.single.name, 'add');
+  });
+
+  test('callTool parses a result delivered over text/event-stream', () async {
+    stubPosts([
+      // initialize
+      resp(
+        _jsonBody({
+          'jsonrpc': '2.0',
+          'id': 1,
+          'result': {
+            'protocolVersion': '2025-06-18',
+            'serverInfo': {'name': 'demo', 'version': '1'},
+          },
+        }),
+        headers: {'mcp-session-id': ['s1']},
+      ),
+      // initialized notification ack
+      resp(_jsonBody({'jsonrpc': '2.0'})),
+      // tools/call (SSE)
+      resp(_sseBody({
+        'jsonrpc': '2.0',
+        'id': 3,
+        'result': {
+          'content': [
+            {'type': 'text', 'text': 'hello'},
+          ],
+          'isError': false,
+        },
+      })),
+    ]);
+
+    final conn = await service.connect('https://mcp.dev/');
+    final result = await conn.callTool('echo', const {'msg': 'hi'});
+    expect(result.textBlocks, ['hello']);
+    expect(result.isError, isFalse);
+  });
+
+  test('a JSON-RPC error response throws McpException', () async {
+    stubPosts([
+      // initialize
+      resp(
+        _jsonBody({
+          'jsonrpc': '2.0',
+          'id': 1,
+          'result': {
+            'protocolVersion': '2025-06-18',
+            'serverInfo': {'name': 'demo', 'version': '1'},
+          },
+        }),
+        headers: {'mcp-session-id': ['s1']},
+      ),
+      // initialized notification ack
+      resp(_jsonBody({'jsonrpc': '2.0'})),
+      // error response
+      resp(_jsonBody({
+        'jsonrpc': '2.0',
+        'id': 2,
+        'error': {'code': -32601, 'message': 'Method not found'},
+      })),
+    ]);
+
+    final conn = await service.connect('https://mcp.dev/');
+    await expectLater(
+      conn.listTools(),
+      throwsA(
+        isA<McpException>()
+            .having((e) => e.code, 'code', -32601)
+            .having((e) => e.message, 'message', contains('Method not found')),
+      ),
+    );
+  });
+}

--- a/test/core/network/request_kind_test.dart
+++ b/test/core/network/request_kind_test.dart
@@ -15,5 +15,12 @@ void main() {
       expect(RequestKind.fromWire(99), RequestKind.http);
       expect(RequestKind.fromWire(null), RequestKind.http);
     });
+
+    test('label returns the short protocol badge text', () {
+      expect(RequestKind.http.label, 'HTTP');
+      expect(RequestKind.webSocket.label, 'WS');
+      expect(RequestKind.sse.label, 'SSE');
+      expect(RequestKind.mcp.label, 'MCP');
+    });
   });
 }

--- a/test/core/network/request_kind_test.dart
+++ b/test/core/network/request_kind_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/core/network/request_kind.dart';
+
+void main() {
+  group('RequestKind', () {
+    test('mcp has wire value 3', () {
+      expect(RequestKind.mcp.wire, 3);
+    });
+
+    test('fromWire(3) resolves to mcp', () {
+      expect(RequestKind.fromWire(3), RequestKind.mcp);
+    });
+
+    test('unknown wire falls back to http', () {
+      expect(RequestKind.fromWire(99), RequestKind.http);
+      expect(RequestKind.fromWire(null), RequestKind.http);
+    });
+  });
+}

--- a/test/features/mcp/di_registration_test.dart
+++ b/test/features/mcp/di_registration_test.dart
@@ -1,0 +1,26 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/core/di/injection_container.dart' as di;
+import 'package:getman/core/network/mcp_service.dart';
+import 'package:getman/features/mcp/presentation/bloc/mcp_bloc.dart';
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('getman_di_mcp_test');
+  });
+
+  tearDown(() async {
+    await di.reset();
+    if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+  });
+
+  test('McpService and McpBloc are registered after init', () async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    await di.init(storageDirectoryOverride: tempDir.path);
+    expect(di.sl.isRegistered<McpService>(), isTrue);
+    expect(di.sl<McpBloc>(), isA<McpBloc>());
+  });
+}

--- a/test/features/mcp/domain/entities/mcp_entities_test.dart
+++ b/test/features/mcp/domain/entities/mcp_entities_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/features/mcp/domain/entities/mcp_session.dart';
+import 'package:getman/features/mcp/domain/entities/mcp_tool.dart';
+import 'package:getman/features/mcp/domain/entities/mcp_tool_result.dart';
+
+void main() {
+  group('McpSession.fromInitializeResult', () {
+    test('reads server info + protocol version, sessionId from header', () {
+      final s = McpSession.fromInitializeResult(
+        const {
+          'protocolVersion': '2025-06-18',
+          'serverInfo': {'name': 'demo', 'version': '1.2.3'},
+        },
+        sessionId: 'abc-123',
+      );
+      expect(s.sessionId, 'abc-123');
+      expect(s.protocolVersion, '2025-06-18');
+      expect(s.serverName, 'demo');
+      expect(s.serverVersion, '1.2.3');
+    });
+
+    test('tolerates missing fields with safe defaults', () {
+      final s = McpSession.fromInitializeResult(const {});
+      expect(s.sessionId, '');
+      expect(s.serverName, '');
+      expect(s.protocolVersion, '');
+    });
+  });
+
+  group('McpTool.fromJson', () {
+    test('parses name, description, and raw input schema', () {
+      final t = McpTool.fromJson(const {
+        'name': 'add',
+        'description': 'Adds numbers',
+        'inputSchema': {
+          'type': 'object',
+          'properties': {
+            'a': {'type': 'number'},
+          },
+        },
+      });
+      expect(t.name, 'add');
+      expect(t.description, 'Adds numbers');
+      expect(t.inputSchema['type'], 'object');
+    });
+
+    test('defaults description to empty and schema to empty map', () {
+      final t = McpTool.fromJson(const {'name': 'noop'});
+      expect(t.description, '');
+      expect(t.inputSchema, isEmpty);
+    });
+  });
+
+  group('McpToolResult.fromJson', () {
+    test('collects text blocks and isError flag', () {
+      final r = McpToolResult.fromJson(const {
+        'isError': true,
+        'content': [
+          {'type': 'text', 'text': 'boom'},
+          {'type': 'text', 'text': 'second'},
+        ],
+      });
+      expect(r.isError, isTrue);
+      expect(r.textBlocks, ['boom', 'second']);
+    });
+
+    test('keeps non-text blocks as raw maps and defaults isError to false', () {
+      final r = McpToolResult.fromJson(const {
+        'content': [
+          {'type': 'image', 'data': 'xxx', 'mimeType': 'image/png'},
+        ],
+      });
+      expect(r.isError, isFalse);
+      expect(r.textBlocks, isEmpty);
+      expect(r.rawBlocks.single['type'], 'image');
+    });
+  });
+}

--- a/test/features/mcp/domain/mcp_argument_resolver_test.dart
+++ b/test/features/mcp/domain/mcp_argument_resolver_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/features/mcp/domain/mcp_argument_resolver.dart';
+
+void main() {
+  group('resolveMcpArguments', () {
+    const vars = {'base': 'api.dev', 'id': '42'};
+
+    test('substitutes {{var}} in string leaves', () {
+      final out = resolveMcpArguments(const {
+        'url': 'https://{{base}}/v1',
+      }, vars);
+      expect(out['url'], 'https://api.dev/v1');
+    });
+
+    test('recurses into nested maps and lists', () {
+      final out = resolveMcpArguments(const {
+        'nested': {'who': '{{base}}'},
+        'list': ['{{id}}', 'static'],
+      }, vars);
+      expect((out['nested'] as Map)['who'], 'api.dev');
+      expect(out['list'], ['42', 'static']);
+    });
+
+    test('passes non-string values through unchanged', () {
+      final out = resolveMcpArguments(const {
+        'n': 7,
+        'b': true,
+        'nil': null,
+      }, vars);
+      expect(out['n'], 7);
+      expect(out['b'], true);
+      expect(out['nil'], isNull);
+    });
+
+    test('leaves unknown variables verbatim', () {
+      final out = resolveMcpArguments(const {'x': '{{missing}}'}, vars);
+      expect(out['x'], '{{missing}}');
+    });
+
+    test(r'resolves dynamic variables like {{$timestamp}}', () {
+      final out = resolveMcpArguments(const {'t': r'{{$timestamp}}'}, vars);
+      // A dynamic timestamp resolves to digits, not the literal token.
+      expect(out['t'], isNot(r'{{$timestamp}}'));
+      expect(int.tryParse(out['t'] as String), isNotNull);
+    });
+  });
+}

--- a/test/features/mcp/presentation/bloc/mcp_bloc_test.dart
+++ b/test/features/mcp/presentation/bloc/mcp_bloc_test.dart
@@ -1,0 +1,126 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/core/network/mcp_service.dart';
+import 'package:getman/features/mcp/domain/entities/mcp_session.dart';
+import 'package:getman/features/mcp/domain/entities/mcp_tool.dart';
+import 'package:getman/features/mcp/domain/entities/mcp_tool_result.dart';
+import 'package:getman/features/mcp/presentation/bloc/mcp_bloc.dart';
+import 'package:getman/features/mcp/presentation/bloc/mcp_event.dart';
+import 'package:getman/features/mcp/presentation/bloc/mcp_state.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockService extends Mock implements McpService {}
+
+class _MockConnection extends Mock implements McpConnection {}
+
+void main() {
+  late _MockService service;
+  late _MockConnection conn;
+
+  const tool = McpTool(name: 'add', description: 'Add', inputSchema: {});
+  const session = McpSession(
+    sessionId: 's1',
+    protocolVersion: '2025-06-18',
+    serverName: 'demo',
+    serverVersion: '1',
+  );
+
+  setUp(() {
+    service = _MockService();
+    conn = _MockConnection();
+    when(() => conn.session).thenReturn(session);
+    when(() => conn.listTools()).thenAnswer((_) async => [tool]);
+    when(() => conn.close()).thenAnswer((_) async {});
+  });
+
+  blocTest<McpBloc, McpState>(
+    'connect → connected with tools',
+    build: () {
+      when(
+        () => service.connect(any(), headers: any(named: 'headers')),
+      ).thenAnswer((_) async => conn);
+      return McpBloc(service: service);
+    },
+    act: (b) => b.add(
+      const McpConnectRequested(tabId: 't1', url: 'https://mcp.dev/'),
+    ),
+    verify: (b) {
+      final s = b.state.sessionFor('t1');
+      expect(s.status, McpConnectionStatus.connected);
+      expect(s.tools.single.name, 'add');
+      expect(s.session?.serverName, 'demo');
+    },
+  );
+
+  blocTest<McpBloc, McpState>(
+    'connect failure → error status with message',
+    build: () {
+      when(
+        () => service.connect(any(), headers: any(named: 'headers')),
+      ).thenThrow(McpException('nope', code: -1));
+      return McpBloc(service: service);
+    },
+    act: (b) => b.add(
+      const McpConnectRequested(tabId: 't1', url: 'https://mcp.dev/'),
+    ),
+    verify: (b) {
+      final s = b.state.sessionFor('t1');
+      expect(s.status, McpConnectionStatus.error);
+      expect(s.errorMessage, contains('nope'));
+    },
+  );
+
+  blocTest<McpBloc, McpState>(
+    'call tool → lastResult populated',
+    build: () {
+      when(
+        () => service.connect(any(), headers: any(named: 'headers')),
+      ).thenAnswer((_) async => conn);
+      when(
+        () =>
+            conn.callTool(any(), any(), cancelToken: any(named: 'cancelToken')),
+      ).thenAnswer(
+        (_) async => const McpToolResult(
+          isError: false,
+          textBlocks: ['42'],
+          rawBlocks: [],
+        ),
+      );
+      return McpBloc(service: service);
+    },
+    act: (b) async {
+      b.add(const McpConnectRequested(tabId: 't1', url: 'https://mcp.dev/'));
+      await Future<void>.delayed(Duration.zero);
+      b.add(
+        const McpToolCallRequested(
+          tabId: 't1',
+          toolName: 'add',
+          arguments: {'a': 1, 'b': 2},
+        ),
+      );
+    },
+    verify: (b) {
+      expect(b.state.sessionFor('t1').lastResult?.textBlocks, ['42']);
+    },
+  );
+
+  blocTest<McpBloc, McpState>(
+    'disconnect closes the connection and resets status',
+    build: () {
+      when(
+        () => service.connect(any(), headers: any(named: 'headers')),
+      ).thenAnswer((_) async => conn);
+      return McpBloc(service: service);
+    },
+    act: (b) async {
+      b.add(const McpConnectRequested(tabId: 't1', url: 'https://mcp.dev/'));
+      await Future<void>.delayed(Duration.zero);
+      b.add(const McpDisconnectRequested('t1'));
+    },
+    verify: (b) {
+      expect(b.state.sessionFor('t1').status, McpConnectionStatus.disconnected);
+      verify(() => conn.close()).called(1);
+    },
+  );
+}

--- a/test/features/mcp/presentation/bloc/mcp_bloc_test.dart
+++ b/test/features/mcp/presentation/bloc/mcp_bloc_test.dart
@@ -1,5 +1,4 @@
 import 'package:bloc_test/bloc_test.dart';
-import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:getman/core/network/mcp_service.dart';
 import 'package:getman/features/mcp/domain/entities/mcp_session.dart';
@@ -121,6 +120,44 @@ void main() {
     verify: (b) {
       expect(b.state.sessionFor('t1').status, McpConnectionStatus.disconnected);
       verify(() => conn.close()).called(1);
+    },
+  );
+
+  blocTest<McpBloc, McpState>(
+    'selecting a tool clears lastResult and sets selectedTool',
+    build: () {
+      when(
+        () => service.connect(any(), headers: any(named: 'headers')),
+      ).thenAnswer((_) async => conn);
+      when(
+        () =>
+            conn.callTool(any(), any(), cancelToken: any(named: 'cancelToken')),
+      ).thenAnswer(
+        (_) async => const McpToolResult(
+          isError: false,
+          textBlocks: ['prior'],
+          rawBlocks: [],
+        ),
+      );
+      return McpBloc(service: service);
+    },
+    act: (b) async {
+      b.add(const McpConnectRequested(tabId: 't1', url: 'https://mcp.dev/'));
+      await Future<void>.delayed(Duration.zero);
+      b.add(
+        const McpToolCallRequested(
+          tabId: 't1',
+          toolName: 'add',
+          arguments: {'a': 1},
+        ),
+      );
+      await Future<void>.delayed(Duration.zero);
+      b.add(const McpToolSelected(tabId: 't1', toolName: 'add'));
+    },
+    verify: (b) {
+      final s = b.state.sessionFor('t1');
+      expect(s.lastResult, isNull);
+      expect(s.selectedTool, 'add');
     },
   );
 }

--- a/test/features/mcp/presentation/widgets/mcp_connect_button_test.dart
+++ b/test/features/mcp/presentation/widgets/mcp_connect_button_test.dart
@@ -1,0 +1,194 @@
+// Widget tests for McpConnectButton: CONNECT/DISCONNECT state, dispatch on
+// press. Mirrors realtime_button_test.dart in structure.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/core/domain/entities/request_config_entity.dart';
+import 'package:getman/core/network/request_kind.dart';
+import 'package:getman/core/theme/themes/brutalist/brutalist_theme.dart';
+import 'package:getman/features/mcp/presentation/bloc/mcp_bloc.dart';
+import 'package:getman/features/mcp/presentation/bloc/mcp_event.dart';
+import 'package:getman/features/mcp/presentation/bloc/mcp_state.dart';
+import 'package:getman/features/mcp/presentation/widgets/mcp_connect_button.dart';
+import 'package:getman/features/tabs/domain/entities/panel_entity.dart';
+import 'package:getman/features/tabs/domain/entities/request_tab_entity.dart';
+import 'package:getman/features/tabs/domain/repositories/tabs_repository.dart';
+import 'package:getman/features/tabs/domain/usecases/send_request_use_case.dart';
+import 'package:getman/features/tabs/presentation/bloc/tabs_bloc.dart';
+import 'package:getman/features/tabs/presentation/bloc/tabs_event.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockTabsRepository extends Mock implements TabsRepository {}
+
+class _MockSendRequestUseCase extends Mock implements SendRequestUseCase {}
+
+class _MockMcpBloc extends Mock implements McpBloc {}
+
+class _FakeConfig extends Fake implements HttpRequestConfigEntity {}
+
+class _FakePanel extends Fake implements PanelEntity {}
+
+class _FakeMcpEvent extends Fake implements McpEvent {}
+
+Future<TabsBloc> _loadedTabsBloc(
+  _MockTabsRepository repository,
+  _MockSendRequestUseCase useCase,
+  HttpRequestTabEntity tab,
+) async {
+  when(() => repository.getPanels()).thenAnswer(
+    (_) async => [
+      PanelEntity(
+        id: 'p1',
+        name: 'Panel 1',
+        tabs: [tab],
+        activeTabId: tab.tabId,
+      ),
+    ],
+  );
+  when(() => repository.getActivePanelId()).thenAnswer((_) async => 'p1');
+  final bloc = TabsBloc(repository: repository, sendRequestUseCase: useCase)
+    ..add(const LoadTabs());
+  await bloc.stream.firstWhere((s) => !s.isLoading && s.tabs.isNotEmpty);
+  return bloc;
+}
+
+_MockMcpBloc _buildMcpBloc({
+  String tabId = 'mc',
+  McpConnectionStatus status = McpConnectionStatus.disconnected,
+}) {
+  final mock = _MockMcpBloc();
+  final session = McpTabSession(status: status);
+  final state = McpState(
+    sessions: status == McpConnectionStatus.disconnected
+        ? const {}
+        : {tabId: session},
+  );
+  when(() => mock.state).thenReturn(state);
+  when(() => mock.stream).thenAnswer((_) => const Stream.empty());
+  when(() => mock.add(any())).thenReturn(null);
+  return mock;
+}
+
+Future<void> _pump(
+  WidgetTester tester, {
+  required TabsBloc tabsBloc,
+  required _MockMcpBloc mcpBloc,
+  required String tabId,
+  required HttpRequestConfigEntity config,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      theme: brutalistTheme(Brightness.light),
+      home: Scaffold(
+        body: MultiBlocProvider(
+          providers: [
+            BlocProvider<TabsBloc>.value(value: tabsBloc),
+            BlocProvider<McpBloc>.value(value: mcpBloc),
+          ],
+          child: McpConnectButton(
+            tabId: tabId,
+            config: config,
+            isNarrow: false,
+            activeVars: const {},
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  late _MockTabsRepository repository;
+  late _MockSendRequestUseCase sendRequestUseCase;
+
+  setUpAll(() {
+    registerFallbackValue(_FakeConfig());
+    registerFallbackValue(_FakePanel());
+    registerFallbackValue(_FakeMcpEvent());
+    registerFallbackValue(
+      const HttpRequestTabEntity(
+        tabId: 'fallback',
+        config: HttpRequestConfigEntity(id: 'fallback'),
+      ),
+    );
+    registerFallbackValue(
+      const McpConnectRequested(tabId: 'x', url: 'https://x'),
+    );
+    registerFallbackValue(const McpDisconnectRequested('x'));
+  });
+
+  setUp(() {
+    repository = _MockTabsRepository();
+    sendRequestUseCase = _MockSendRequestUseCase();
+    when(() => repository.saveTabs(any())).thenAnswer((_) async {});
+    when(() => repository.putTab(any())).thenAnswer((_) async {});
+    when(() => repository.deleteTabs(any())).thenAnswer((_) async {});
+    when(() => repository.saveTabOrder(any())).thenAnswer((_) async {});
+    when(() => repository.putPanel(any())).thenAnswer((_) async {});
+    when(() => repository.deletePanels(any())).thenAnswer((_) async {});
+    when(() => repository.savePanelMeta(any(), any())).thenAnswer((_) async {});
+  });
+
+  testWidgets('shows CONNECT when disconnected and dispatches connect',
+      (tester) async {
+    const tabId = 'mc1';
+    const config = HttpRequestConfigEntity(
+      id: tabId,
+      url: 'https://mcp.dev/',
+      kind: RequestKind.mcp,
+    );
+    const tab = HttpRequestTabEntity(tabId: tabId, config: config);
+    final tabsBloc = await _loadedTabsBloc(repository, sendRequestUseCase, tab);
+    addTearDown(tabsBloc.close);
+
+    final mcpBloc = _buildMcpBloc(tabId: tabId);
+
+    await _pump(
+      tester,
+      tabsBloc: tabsBloc,
+      mcpBloc: mcpBloc,
+      tabId: tabId,
+      config: config,
+    );
+
+    expect(find.text('CONNECT'), findsOneWidget);
+    expect(find.text('DISCONNECT'), findsNothing);
+
+    await tester.tap(find.byKey(const ValueKey('mcp_connect_button')));
+    await tester.pump();
+
+    verify(
+      () => mcpBloc.add(any(that: isA<McpConnectRequested>())),
+    ).called(1);
+  });
+
+  testWidgets('shows DISCONNECT when connected', (tester) async {
+    const tabId = 'mc2';
+    const config = HttpRequestConfigEntity(
+      id: tabId,
+      url: 'https://mcp.dev/',
+      kind: RequestKind.mcp,
+    );
+    const tab = HttpRequestTabEntity(tabId: tabId, config: config);
+    final tabsBloc = await _loadedTabsBloc(repository, sendRequestUseCase, tab);
+    addTearDown(tabsBloc.close);
+
+    final mcpBloc = _buildMcpBloc(
+      tabId: tabId,
+      status: McpConnectionStatus.connected,
+    );
+
+    await _pump(
+      tester,
+      tabsBloc: tabsBloc,
+      mcpBloc: mcpBloc,
+      tabId: tabId,
+      config: config,
+    );
+
+    expect(find.text('DISCONNECT'), findsOneWidget);
+    expect(find.text('CONNECT'), findsNothing);
+  });
+}

--- a/test/features/mcp/presentation/widgets/mcp_connect_button_test.dart
+++ b/test/features/mcp/presentation/widgets/mcp_connect_button_test.dart
@@ -131,8 +131,9 @@ void main() {
     when(() => repository.savePanelMeta(any(), any())).thenAnswer((_) async {});
   });
 
-  testWidgets('shows CONNECT when disconnected and dispatches connect',
-      (tester) async {
+  testWidgets('shows CONNECT when disconnected and dispatches connect', (
+    tester,
+  ) async {
     const tabId = 'mc1';
     const config = HttpRequestConfigEntity(
       id: tabId,

--- a/test/features/mcp/presentation/widgets/mcp_panel_test.dart
+++ b/test/features/mcp/presentation/widgets/mcp_panel_test.dart
@@ -8,20 +8,60 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:getman/core/theme/theme_registry.dart';
+import 'package:getman/features/collections/presentation/bloc/collections_bloc.dart';
+import 'package:getman/features/collections/presentation/bloc/collections_event.dart';
+import 'package:getman/features/collections/presentation/bloc/collections_state.dart';
+import 'package:getman/features/environments/presentation/bloc/environments_bloc.dart';
+import 'package:getman/features/environments/presentation/bloc/environments_event.dart';
+import 'package:getman/features/environments/presentation/bloc/environments_state.dart';
 import 'package:getman/features/mcp/domain/entities/mcp_tool.dart';
 import 'package:getman/features/mcp/domain/entities/mcp_tool_result.dart';
 import 'package:getman/features/mcp/presentation/bloc/mcp_bloc.dart';
 import 'package:getman/features/mcp/presentation/bloc/mcp_event.dart';
 import 'package:getman/features/mcp/presentation/bloc/mcp_state.dart';
 import 'package:getman/features/mcp/presentation/widgets/mcp_panel.dart';
+import 'package:getman/features/settings/presentation/bloc/settings_bloc.dart';
+import 'package:getman/features/settings/presentation/bloc/settings_event.dart';
+import 'package:getman/features/settings/presentation/bloc/settings_state.dart';
+import 'package:getman/features/tabs/presentation/bloc/tabs_bloc.dart';
+import 'package:getman/features/tabs/presentation/bloc/tabs_event.dart';
+import 'package:getman/features/tabs/presentation/bloc/tabs_state.dart';
 import 'package:mocktail/mocktail.dart';
 
 class _MockMcpBloc extends MockBloc<McpEvent, McpState> implements McpBloc {}
 
+class _MockSettingsBloc extends MockBloc<SettingsEvent, SettingsState>
+    implements SettingsBloc {}
+
+class _MockEnvironmentsBloc
+    extends MockBloc<EnvironmentsEvent, EnvironmentsState>
+    implements EnvironmentsBloc {}
+
+class _MockCollectionsBloc extends MockBloc<CollectionsEvent, CollectionsState>
+    implements CollectionsBloc {}
+
+class _MockTabsBloc extends MockBloc<TabsEvent, TabsState>
+    implements TabsBloc {}
+
 void main() {
   late _MockMcpBloc mcp;
+  late _MockSettingsBloc settings;
+  late _MockEnvironmentsBloc environments;
+  late _MockCollectionsBloc collections;
+  late _MockTabsBloc tabs;
 
-  setUp(() => mcp = _MockMcpBloc());
+  setUp(() {
+    mcp = _MockMcpBloc();
+    // The args editor's TabVariableContextBuilder reads these blocs at build.
+    settings = _MockSettingsBloc();
+    environments = _MockEnvironmentsBloc();
+    collections = _MockCollectionsBloc();
+    tabs = _MockTabsBloc();
+    when(() => settings.state).thenReturn(SettingsState.initial());
+    when(() => environments.state).thenReturn(const EnvironmentsState());
+    when(() => collections.state).thenReturn(CollectionsState());
+    when(() => tabs.state).thenReturn(const TabsState());
+  });
 
   Widget harness(McpState state) {
     when(() => mcp.state).thenReturn(state);
@@ -32,8 +72,14 @@ void main() {
       // positional arg.
       theme: resolveTheme('classic')(Brightness.light),
       home: Scaffold(
-        body: BlocProvider<McpBloc>.value(
-          value: mcp,
+        body: MultiBlocProvider(
+          providers: [
+            BlocProvider<McpBloc>.value(value: mcp),
+            BlocProvider<SettingsBloc>.value(value: settings),
+            BlocProvider<EnvironmentsBloc>.value(value: environments),
+            BlocProvider<CollectionsBloc>.value(value: collections),
+            BlocProvider<TabsBloc>.value(value: tabs),
+          ],
           child: const SizedBox(
             width: 800,
             height: 600,
@@ -76,7 +122,10 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('add'), findsWidgets);
     expect(find.text('echo'), findsWidgets);
-    expect(find.textContaining('result text'), findsWidgets);
+    // The result renders in a read-only JSON code editor (not plain text), so
+    // assert the Result section + its editor are present.
+    expect(find.text('Result'), findsOneWidget);
+    expect(find.byKey(const ValueKey('mcp_result_view')), findsOneWidget);
     expect(tester.takeException(), isNull); // no RenderFlex overflow
   });
 

--- a/test/features/mcp/presentation/widgets/mcp_panel_test.dart
+++ b/test/features/mcp/presentation/widgets/mcp_panel_test.dart
@@ -1,4 +1,5 @@
-// Widget tests for McpPanel: disconnected hint, tool list + no overflow.
+// Widget tests for McpPanel: disconnected hint, tool list + no overflow,
+// and session log expansion.
 // Fixtures verified against the real entity/state signatures in mcp_state.dart,
 // mcp_tool.dart, and mcp_tool_result.dart.
 
@@ -78,4 +79,34 @@ void main() {
     expect(find.textContaining('result text'), findsWidgets);
     expect(tester.takeException(), isNull); // no RenderFlex overflow
   });
+
+  testWidgets(
+    'connected with session log shows log entries after expansion',
+    (tester) async {
+      await tester.pumpWidget(
+        harness(
+          const McpState(
+            sessions: {
+              't1': McpTabSession(
+                status: McpConnectionStatus.connected,
+                tools: [
+                  McpTool(name: 'add', description: 'Add', inputSchema: {}),
+                ],
+                selectedTool: 'add',
+                log: ['→ initialize', '← tools/list'],
+              ),
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      // The log tile may be below the viewport — scroll it into view first.
+      await tester.ensureVisible(find.text('Session log'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Session log'));
+      await tester.pumpAndSettle();
+      expect(find.text('→ initialize'), findsOneWidget);
+      expect(tester.takeException(), isNull); // no RenderFlex overflow
+    },
+  );
 }

--- a/test/features/mcp/presentation/widgets/mcp_panel_test.dart
+++ b/test/features/mcp/presentation/widgets/mcp_panel_test.dart
@@ -1,0 +1,81 @@
+// Widget tests for McpPanel: disconnected hint, tool list + no overflow.
+// Fixtures verified against the real entity/state signatures in mcp_state.dart,
+// mcp_tool.dart, and mcp_tool_result.dart.
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/core/theme/theme_registry.dart';
+import 'package:getman/features/mcp/domain/entities/mcp_tool.dart';
+import 'package:getman/features/mcp/domain/entities/mcp_tool_result.dart';
+import 'package:getman/features/mcp/presentation/bloc/mcp_bloc.dart';
+import 'package:getman/features/mcp/presentation/bloc/mcp_event.dart';
+import 'package:getman/features/mcp/presentation/bloc/mcp_state.dart';
+import 'package:getman/features/mcp/presentation/widgets/mcp_panel.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockMcpBloc extends MockBloc<McpEvent, McpState> implements McpBloc {}
+
+void main() {
+  late _MockMcpBloc mcp;
+
+  setUp(() => mcp = _MockMcpBloc());
+
+  Widget harness(McpState state) {
+    when(() => mcp.state).thenReturn(state);
+    when(() => mcp.stream).thenAnswer((_) => const Stream.empty());
+    return MaterialApp(
+      // resolveTheme returns AppThemeBuilder = ThemeData Function(Brightness,
+      // {bool isCompact, bool reduceEffects}); named args, so no second
+      // positional arg.
+      theme: resolveTheme('classic')(Brightness.light),
+      home: Scaffold(
+        body: BlocProvider<McpBloc>.value(
+          value: mcp,
+          child: const SizedBox(
+            width: 800,
+            height: 600,
+            child: McpPanel(tabId: 't1'),
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('disconnected shows a hint containing CONNECT', (tester) async {
+    await tester.pumpWidget(harness(const McpState()));
+    expect(find.textContaining('CONNECT'), findsWidgets);
+  });
+
+  testWidgets('connected lists tools and renders without overflow', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      harness(
+        const McpState(
+          sessions: {
+            't1': McpTabSession(
+              status: McpConnectionStatus.connected,
+              tools: [
+                McpTool(name: 'add', description: 'Add', inputSchema: {}),
+                McpTool(name: 'echo', description: 'Echo', inputSchema: {}),
+              ],
+              selectedTool: 'add',
+              lastResult: McpToolResult(
+                isError: false,
+                textBlocks: ['result text'],
+                rawBlocks: [],
+              ),
+            ),
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('add'), findsWidgets);
+    expect(find.text('echo'), findsWidgets);
+    expect(find.textContaining('result text'), findsWidgets);
+    expect(tester.takeException(), isNull); // no RenderFlex overflow
+  });
+}


### PR DESCRIPTION
## MCP client support (v1)

Adds a Model Context Protocol **client** to Getman — a new request kind that connects to an MCP server over **Streamable HTTP** (JSON-RPC 2.0), lists its **tools**, and invokes a tool with user-supplied JSON arguments. Analogous to Postman's "MCP request".

Design + plan: `docs/superpowers/specs/2026-06-24-mcp-client-design.md`, `docs/superpowers/plans/2026-06-24-mcp-client.md`.

### What's included
- **`RequestKind.mcp`** — a new protocol on the request config (persists as the existing int discriminator; no Hive migration).
- **`McpService`** — pure-`dio`, web-safe transport: `initialize` handshake (captures `Mcp-Session-Id` + protocol version), `tools/list`, `tools/call`. Handles both `application/json` and `text/event-stream` responses (reuses `SseParser`).
- **`McpBloc`** — one connection per tab, bloc-over-service (no domain/data split), mirroring `RealtimeBloc` teardown discipline.
- **UI** — an **MCP** item in the request-kind dropdown, a **CONNECT/DISCONNECT** button in the URL bar, and **`McpPanel`** (tool list, schema reference, JSON arguments editor, result view, collapsible session log) shown by `ResponseArea`.
- **Environment integration** — endpoint URL, headers, and tool **arguments** all resolve `{{var}}` / dynamic `{{$...}}`. The arguments editor highlights variables and offers the `{{` autocomplete dropdown, same as the request body.
- **Results** render in a read-only JSON code editor (monospace + highlighting + find panel).
- The collections tree shows the protocol label (**MCP**/**WS**/**SSE**) for saved non-HTTP requests instead of a misleading "GET".

### Boundaries
- MCP traffic stays out of HTTP history / response time-travel (separate protocol; live-only).
- Domain layer pure; `McpService` has no `dart:io` (web-safe).

### Deliberately out of scope (v1)
- Resources & prompts; server-initiated SSE notifications/subscriptions.
- A generated argument form from JSON Schema (raw JSON for now).
- stdio / local-process transport.
- Exposing Getman collections *as* an MCP server.

### Verification
- `fvm flutter analyze`, `fvm dart run custom_lint`, `fvm dart run bloc_tools:bloc lint lib` — all 0 issues.
- `fvm dart format` clean.
- `fvm flutter test` — **1697 passing** (incl. MCP service / bloc / widget / resolver tests).

> **Wiki:** the "MCP requests" wiki page is intentionally **not** published yet — it documents an unmerged feature. To be added when this lands (per the keep-the-wiki-in-sync mandate).

---

## 🎥 Video QA

[Gravação de tela de 25-06-2026 16:32:43.webm](https://github.com/user-attachments/assets/8a68e20d-fcea-41aa-a95c-f0bb9a42b090)

