### PR TITLE
fix(response): pre-check pdfx support so unsupported platforms fall back (fixes CI test)

### DIFF
--- a/lib/features/tabs/presentation/widgets/response/viewers/pdf_response_view.dart
+++ b/lib/features/tabs/presentation/widgets/response/viewers/pdf_response_view.dart
@@ -30,6 +30,15 @@ class _PdfResponseViewState extends State<PdfResponseView> {
 
   Future<void> _loadDocument() async {
     try {
+      // pdfx's PdfDocument.openData calls assertHasPdfSupport() WITHOUT
+      // awaiting it, so on a platform with no pdfium binding (e.g. the headless
+      // test VM / CI) that assert throws a *detached* async error no try/catch
+      // here can catch. Pre-check support (awaited) and fall back instead of
+      // ever invoking openData on an unsupported platform.
+      if (!await hasPdfSupport()) {
+        if (mounted) setState(() => _error = PlatformNotSupportedException());
+        return;
+      }
       final doc = await PdfDocument.openData(widget.bytes);
       if (!mounted) {
         await doc.close();
@@ -38,7 +47,7 @@ class _PdfResponseViewState extends State<PdfResponseView> {
       setState(
         () => _controller = PdfControllerPinch(document: Future.value(doc)),
       );
-    } on Exception catch (e) {
+    } on Object catch (e) {
       if (mounted) setState(() => _error = e);
     }
   }


### PR DESCRIPTION
## Fix the failing `pdf_response_view_test` on CI

`PdfResponseView` crashes (rather than showing its fallback) on any platform without a pdfium binding — including the headless test VM, so CI's `flutter test` fails on:

> `test/.../response/pdf_response_view_test.dart: shows fallback (no unhandled exception) when PDF load fails in test VM`

### Root cause
pdfx's `PdfDocument.openData` calls `assertHasPdfSupport()` **without awaiting it**:

```dart
static Future<PdfDocument> openData(...) {
  assertHasPdfSupport();        // ← unawaited; throws on unsupported platforms
  return PdfxPlatform.instance.openData(...);
}
```

On an unsupported platform that assert throws a **detached** async error that is never part of the `Future` our widget awaits, so the widget's `try/catch` can't catch it — it surfaces as an unhandled exception and fails the test.

### Fix
Await `hasPdfSupport()` up front and render the existing fallback before ever invoking `openData` on an unsupported platform. Real PDF load errors on supported platforms are still caught by the existing handler.

### Verification
- `flutter analyze`, `custom_lint`, `bloc_lint` — 0 issues; `dart format` clean.
- `flutter test` — full suite green, including `pdf_response_view_test` (which fails on `master`).
