### PR TITLE
fix: editor send shortcut, macOS window size persistence, drag-drop into folder

### DIFF
--- a/lib/features/collections/domain/logic/collections_tree_helper.dart
+++ b/lib/features/collections/domain/logic/collections_tree_helper.dart
@@ -144,6 +144,18 @@ class CollectionsTreeHelper {
     return [for (final node in path.sublist(0, path.length - 1)) node.id];
   }
 
+  /// The id of the node that directly contains [id] (its immediate parent), or
+  /// null when [id] is a root-level node or is not found.
+  ///
+  /// Drives "drop into the same container" for drag-and-drop: dropping a node
+  /// onto a request that lives inside a folder resolves to that folder's id, so
+  /// the dragged node lands beside it rather than falling through to the root.
+  static String? parentIdOf(List<CollectionNodeEntity> nodes, String id) {
+    final path = _pathTo(nodes, id);
+    if (path == null || path.length < 2) return null;
+    return path[path.length - 2].id;
+  }
+
   /// Append [example] to the node's saved examples (newest last). No-op if the
   /// id is missing.
   static List<CollectionNodeEntity> addExampleToNode(

--- a/lib/features/collections/presentation/widgets/collection_node_row.dart
+++ b/lib/features/collections/presentation/widgets/collection_node_row.dart
@@ -5,6 +5,7 @@ import 'package:getman/core/theme/app_theme.dart';
 import 'package:getman/core/theme/responsive.dart';
 import 'package:getman/core/ui/widgets/method_badge.dart';
 import 'package:getman/features/collections/domain/entities/collection_node_entity.dart';
+import 'package:getman/features/collections/domain/logic/collections_tree_helper.dart';
 import 'package:getman/features/collections/presentation/bloc/collections_bloc.dart';
 import 'package:getman/features/collections/presentation/bloc/collections_event.dart';
 import 'package:getman/features/collections/presentation/widgets/collection_node_menu.dart';
@@ -159,7 +160,7 @@ class _CollectionNodeRowState extends State<CollectionNodeRow> {
                   ),
             );
     } else {
-      content = SizedBox(
+      final leafInner = SizedBox(
         width: widget.rowWidth,
         height: widget.rowHeight,
         child: context.appDecoration.wrapInteractive(
@@ -260,6 +261,40 @@ class _CollectionNodeRowState extends State<CollectionNodeRow> {
           ),
         ),
       );
+
+      content = isPhone
+          ? leafInner
+          : DragTarget<String>(
+              onWillAcceptWithDetails: (details) {
+                if (details.data == node.id) return false;
+                setState(() => _isDragOver = true);
+                return true;
+              },
+              onLeave: (_) => setState(() => _isDragOver = false),
+              onAcceptWithDetails: (details) {
+                setState(() => _isDragOver = false);
+                final bloc = context.read<CollectionsBloc>();
+                // Dropping onto a request moves the dragged node into that
+                // request's containing folder (or root when it sits at the top
+                // level), so it lands beside the row instead of falling through
+                // to the list-level root drop target.
+                bloc.add(
+                  MoveNode(
+                    details.data,
+                    CollectionsTreeHelper.parentIdOf(
+                      bloc.state.collections,
+                      node.id,
+                    ),
+                  ),
+                );
+              },
+              builder: (context, candidateData, rejectedData) =>
+                  context.appMotion.treeDropHighlight(
+                    context,
+                    active: _isDragOver,
+                    child: leafInner,
+                  ),
+            );
     }
 
     if (isPhone) return content;

--- a/lib/features/tabs/presentation/widgets/json_code_editor.dart
+++ b/lib/features/tabs/presentation/widgets/json_code_editor.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:getman/core/theme/app_theme.dart';
 import 'package:getman/features/tabs/presentation/widgets/code_find_panel.dart';
 import 'package:getman/features/tabs/presentation/widgets/variable_json_span_builder.dart';
@@ -8,22 +9,41 @@ import 'package:re_highlight/re_highlight.dart';
 import 'package:re_highlight/styles/atom-one-dark.dart';
 import 'package:re_highlight/styles/atom-one-light.dart';
 
-/// re_editor's default shortcut map binds its (no-op) `save` action to Cmd+S
-/// on macOS (Ctrl+S elsewhere) and *consumes* the key. While a code editor held
-/// focus that swallowed the app's own Cmd+S before it could reach the global
-/// `SaveRequestIntent` — so on macOS Cmd+S did nothing and only the leaked
-/// Ctrl+S saved. Dropping the `save` activator (re_editor has no save handler
-/// anyway) lets the keystroke bubble up to the app's platform-correct shortcut.
-class _NoSaveCodeShortcutsActivatorsBuilder
-    extends CodeShortcutsActivatorsBuilder {
-  const _NoSaveCodeShortcutsActivatorsBuilder();
+/// Adapts re_editor's default shortcut map so two chords the editor would
+/// otherwise *consume* bubble up to the app's global shortcuts instead:
+///
+/// * **Cmd/Ctrl+S** — re_editor binds it to a no-op `save` action and swallows
+///   the key, so the app's own `SaveRequestIntent` never fired (on macOS Cmd+S
+///   did nothing; only the leaked Ctrl+S saved). We drop the `save` activator
+///   entirely.
+/// * **Cmd/Ctrl+Enter** — re_editor lists it under `newLine`, so while the body
+///   editor held focus the app's `SendRequestIntent` never fired (the chord
+///   just inserted a newline). We strip that one activator from `newLine` while
+///   keeping plain Enter / Shift+Enter / numpad-Enter for normal newlines.
+@visibleForTesting
+class AppCodeShortcutsActivatorsBuilder extends CodeShortcutsActivatorsBuilder {
+  const AppCodeShortcutsActivatorsBuilder();
 
   static const _defaults = DefaultCodeShortcutsActivatorsBuilder();
 
   @override
   List<ShortcutActivator>? build(CodeShortcutType type) {
     if (type == CodeShortcutType.save) return null;
-    return _defaults.build(type);
+    final activators = _defaults.build(type);
+    if (type == CodeShortcutType.newLine && activators != null) {
+      return activators.where((a) => !_isSendRequestChord(a)).toList();
+    }
+    return activators;
+  }
+
+  /// The app binds Cmd+Enter (macOS) / Ctrl+Enter (elsewhere) to sending the
+  /// request. Matches exactly that chord so it is removed from `newLine`;
+  /// Shift/Alt or numpad-Enter variants are left alone.
+  static bool _isSendRequestChord(ShortcutActivator activator) {
+    if (activator is! SingleActivator) return false;
+    if (activator.trigger != LogicalKeyboardKey.enter) return false;
+    if (activator.shift || activator.alt) return false;
+    return activator.meta || activator.control;
   }
 }
 
@@ -143,10 +163,10 @@ class JsonCodeEditor extends StatelessWidget {
         readOnly: readOnly,
         wordWrap: wordWrap,
         autofocus: autofocus,
-        // Drop re_editor's built-in Cmd/Ctrl+S so the app's own save shortcut
-        // fires (see [_NoSaveCodeShortcutsActivatorsBuilder]).
-        shortcutsActivatorsBuilder:
-            const _NoSaveCodeShortcutsActivatorsBuilder(),
+        // Let the app's global Cmd/Ctrl+S (save) and Cmd/Ctrl+Enter (send)
+        // shortcuts fire even while this editor has focus
+        // (see [AppCodeShortcutsActivatorsBuilder]).
+        shortcutsActivatorsBuilder: const AppCodeShortcutsActivatorsBuilder(),
         findBuilder: (context, controller, readOnly) =>
             CodeFindPanel(controller: controller, readOnly: readOnly),
         // Token colours come from [jsonHighlightSpanBuilder] on the controller,

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -13,6 +13,14 @@ class MainFlutterWindow: NSWindow {
     self.contentViewController = flutterViewController
     self.setFrame(windowFrame, display: true)
 
+    // Remember the window's size and position across launches. `setFrameUsingName`
+    // restores the frame saved from a previous session (no-op on first run, so the
+    // XIB default size above still applies), and `setFrameAutosaveName` makes AppKit
+    // persist the frame to NSUserDefaults whenever the user resizes or moves it.
+    let autosaveName = NSWindow.FrameAutosaveName("GetmanMainWindow")
+    _ = self.setFrameUsingName(autosaveName)
+    _ = self.setFrameAutosaveName(autosaveName)
+
     RegisterGeneratedPlugins(registry: flutterViewController)
     workspaceBookmarkPlugin.register(
       registrar: flutterViewController.registrar(forPlugin: "WorkspaceBookmarkPlugin"))

--- a/test/collections_tree_helper_test.dart
+++ b/test/collections_tree_helper_test.dart
@@ -430,4 +430,47 @@ void main() {
       expect(ids, isNot(contains('child')));
     });
   });
+
+  group('parentIdOf', () {
+    test('returns null for a root-level node (folder or leaf)', () {
+      final nodes = [folder('a', 'A'), leaf('b', 'B')];
+      expect(CollectionsTreeHelper.parentIdOf(nodes, 'a'), isNull);
+      expect(CollectionsTreeHelper.parentIdOf(nodes, 'b'), isNull);
+    });
+
+    test('returns null for an unknown id', () {
+      final nodes = [
+        folder('a', 'A', children: [leaf('b', 'B')]),
+      ];
+      expect(CollectionsTreeHelper.parentIdOf(nodes, 'zzz'), isNull);
+    });
+
+    test('returns the containing folder id for a leaf inside a folder', () {
+      final nodes = [
+        folder('f1', 'Folder1', children: [leaf('r1', 'R1'), leaf('r2', 'R2')]),
+      ];
+      // Dropping onto r2 (inside Folder1) must resolve to Folder1, not root.
+      expect(CollectionsTreeHelper.parentIdOf(nodes, 'r2'), 'f1');
+    });
+
+    test('returns the nearest folder id for a deeply nested node', () {
+      final nodes = [
+        folder(
+          'root',
+          'Root',
+          children: [
+            folder('mid', 'Mid', children: [leaf('deep', 'Deep')]),
+          ],
+        ),
+      ];
+      expect(CollectionsTreeHelper.parentIdOf(nodes, 'deep'), 'mid');
+    });
+
+    test('returns the parent folder id for a nested folder', () {
+      final nodes = [
+        folder('root', 'Root', children: [folder('child', 'Child')]),
+      ];
+      expect(CollectionsTreeHelper.parentIdOf(nodes, 'child'), 'root');
+    });
+  });
 }

--- a/test/features/collections/presentation/widgets/collection_node_row_test.dart
+++ b/test/features/collections/presentation/widgets/collection_node_row_test.dart
@@ -7,6 +7,7 @@ import 'package:getman/features/collections/domain/entities/collection_node_enti
 import 'package:getman/features/collections/domain/repositories/collections_repository.dart';
 import 'package:getman/features/collections/domain/usecases/collections_usecases.dart';
 import 'package:getman/features/collections/presentation/bloc/collections_bloc.dart';
+import 'package:getman/features/collections/presentation/bloc/collections_event.dart';
 import 'package:getman/features/collections/presentation/widgets/collection_node_row.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -134,6 +135,76 @@ void main() {
       reason: 'star must not match the surface/background color',
     );
   });
+
+  // Regression: leaf request rows had no DragTarget, so dropping a request onto
+  // another request inside a folder fell through to the list-level root target
+  // and moved it to the ROOT. A leaf drop must land in the target's folder.
+  testWidgets(
+    'dropping a request onto a request inside a folder moves it into that '
+    'folder, not to the root',
+    (tester) async {
+      const draggedId = 'dragged';
+      final tree = <CollectionNodeEntity>[
+        const CollectionNodeEntity(
+          id: 'f1',
+          name: 'Folder1',
+          children: [requestNode], // req-1 lives inside Folder1
+        ),
+        const CollectionNodeEntity(
+          id: draggedId,
+          name: 'Dragged',
+          isFolder: false,
+          config: HttpRequestConfigEntity(id: draggedId),
+        ),
+      ];
+      when(() => repo.getCollections()).thenAnswer((_) async => tree);
+
+      final bloc = buildBloc()..add(const LoadCollections());
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: resolveTheme('brutalist')(Brightness.light, isCompact: false),
+          home: Scaffold(
+            body: BlocProvider<CollectionsBloc>.value(
+              value: bloc,
+              child: const CollectionNodeRow(
+                node: requestNode, // the leaf that lives inside Folder1
+                isExpanded: false,
+                depth: 1,
+                onToggle: _noop,
+                rowWidth: 300,
+                rowHeight: 44,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final dragTarget = tester.widget<DragTarget<String>>(
+        find.byType(DragTarget<String>),
+      );
+      dragTarget.onAcceptWithDetails!(
+        DragTargetDetails<String>(data: draggedId, offset: Offset.zero),
+      );
+      // Let the MoveNode handler emit, then fire the bloc's debounced-save
+      // timer so no timer is left pending when the widget tree is disposed.
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 3));
+
+      final folder = bloc.state.collections.firstWhere((n) => n.id == 'f1');
+      expect(
+        folder.children.map((c) => c.id),
+        containsAll(<String>['req-1', draggedId]),
+        reason: 'dragged request should land inside Folder1',
+      );
+      expect(
+        bloc.state.collections.map((n) => n.id),
+        isNot(contains(draggedId)),
+        reason: 'dragged request should no longer be at the root',
+      );
+    },
+  );
 }
 
 void _noop() {}

--- a/test/features/tabs/presentation/widgets/json_code_editor_shortcuts_test.dart
+++ b/test/features/tabs/presentation/widgets/json_code_editor_shortcuts_test.dart
@@ -1,0 +1,156 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/core/theme/theme_registry.dart';
+import 'package:getman/features/tabs/presentation/widgets/json_code_editor.dart';
+import 'package:re_editor/re_editor.dart';
+
+void main() {
+  const builder = AppCodeShortcutsActivatorsBuilder();
+  const defaults = DefaultCodeShortcutsActivatorsBuilder();
+
+  tearDown(() => debugDefaultTargetPlatformOverride = null);
+
+  test('drops re_editor save so the app Cmd/Ctrl+S save can fire', () {
+    expect(builder.build(CodeShortcutType.save), isNull);
+  });
+
+  test('leaves unrelated shortcuts (copy) untouched', () {
+    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+    expect(
+      builder.build(CodeShortcutType.copy),
+      equals(defaults.build(CodeShortcutType.copy)),
+    );
+  });
+
+  group('newLine strips the platform send-request chord (Cmd/Ctrl+Enter)', () {
+    test('macOS: Cmd+Enter is removed, plain Enter stays', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+      final activators = builder.build(CodeShortcutType.newLine)!;
+      // Cmd+Enter must bubble up to the global SendRequestIntent.
+      expect(
+        activators,
+        isNot(
+          contains(const SingleActivator(LogicalKeyboardKey.enter, meta: true)),
+        ),
+      );
+      // Plain Enter still inserts a newline in the editor.
+      expect(
+        activators,
+        contains(const SingleActivator(LogicalKeyboardKey.enter)),
+      );
+      // Shift+Enter (a distinct newline chord) is untouched.
+      expect(
+        activators,
+        contains(
+          const SingleActivator(LogicalKeyboardKey.enter, shift: true),
+        ),
+      );
+    });
+
+    test('non-macOS: Ctrl+Enter is removed, plain Enter stays', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+      final activators = builder.build(CodeShortcutType.newLine)!;
+      expect(
+        activators,
+        isNot(
+          contains(
+            const SingleActivator(LogicalKeyboardKey.enter, control: true),
+          ),
+        ),
+      );
+      expect(
+        activators,
+        contains(const SingleActivator(LogicalKeyboardKey.enter)),
+      );
+    });
+  });
+
+  // End-to-end: with the editor focused, Cmd+Enter must reach the app's global
+  // send shortcut (it used to be swallowed by re_editor as a newline), while
+  // plain Enter must still insert a newline in the editor.
+  Future<CodeLineEditingController> pumpEditorUnderSendShortcut(
+    WidgetTester tester,
+  ) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+    final controller = createJsonCodeController();
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: resolveTheme('classic')(Brightness.light, isCompact: false),
+        home: Shortcuts(
+          shortcuts: const {
+            SingleActivator(LogicalKeyboardKey.enter, meta: true):
+                _SendIntent(),
+          },
+          child: Actions(
+            actions: {
+              _SendIntent: CallbackAction<_SendIntent>(
+                onInvoke: (_) {
+                  _sendCount++;
+                  return null;
+                },
+              ),
+            },
+            child: Scaffold(body: JsonCodeEditor(controller: controller)),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    // Ensure the code editor holds focus before sending keys.
+    await tester.tap(find.byType(JsonCodeEditor));
+    await tester.pumpAndSettle();
+    return controller;
+  }
+
+  testWidgets('Cmd+Enter in the editor fires the app send shortcut', (
+    tester,
+  ) async {
+    _sendCount = 0;
+    final controller = await pumpEditorUnderSendShortcut(tester);
+
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.meta);
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.enter);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.enter);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.meta);
+    await tester.pumpAndSettle();
+    // Reset within the body: the testWidgets invariant check runs before
+    // tearDown, and it forbids a leaked foundation debug override.
+    debugDefaultTargetPlatformOverride = null;
+
+    expect(_sendCount, 1, reason: 'send shortcut should fire from the editor');
+    expect(
+      controller.text,
+      isEmpty,
+      reason: 'Cmd+Enter must not insert a newline',
+    );
+  });
+
+  testWidgets('plain Enter in the editor inserts a newline and does not send', (
+    tester,
+  ) async {
+    _sendCount = 0;
+    final controller = await pumpEditorUnderSendShortcut(tester);
+
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.enter);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.enter);
+    await tester.pumpAndSettle();
+    debugDefaultTargetPlatformOverride = null;
+
+    expect(_sendCount, 0, reason: 'plain Enter must not trigger send');
+    expect(
+      controller.text,
+      contains('\n'),
+      reason: 'plain Enter should still insert a newline',
+    );
+  });
+}
+
+int _sendCount = 0;
+
+class _SendIntent extends Intent {
+  const _SendIntent();
+}


### PR DESCRIPTION
## Summary

Three user-reported UX bug fixes:

### 1. Cmd/Ctrl+Enter now sends the request from inside the body editor
re_editor (0.9.0) binds `Cmd+Enter` (macOS) / `Ctrl+Enter` (other) under its `newLine` action and **consumes** the key, so while the code editor held focus the chord just inserted a newline and never reached the app's global `SendRequestIntent`. The `_NoSaveCodeShortcutsActivatorsBuilder` is renamed to `AppCodeShortcutsActivatorsBuilder` and now strips that chord out of `newLine` (alongside the existing `Cmd/Ctrl+S` handling) so it bubbles up to the app. Plain / Shift / numpad Enter still insert newlines.

### 2. macOS window remembers its size & position across restarts
The window size was hardcoded (800×600 XIB) and re-applied every launch — nothing was persisted. `MainFlutterWindow.swift` now uses AppKit frame autosave (`setFrameUsingName` + `setFrameAutosaveName("GetmanMainWindow")`), restoring the saved frame on launch and persisting it to `NSUserDefaults` on resize/move. First run still falls back to the XIB default.

### 3. Dropping a request onto an item inside a folder keeps it in that folder
Leaf (request) rows were `Draggable` but had **no** `DragTarget`, so dropping a request onto another request that lives inside a folder fell through to the list-level root target and moved it to the **root**. Leaf rows are now wrapped in a `DragTarget` that resolves the drop to the target's containing folder via the new pure helper `CollectionsTreeHelper.parentIdOf` (or root when the target is itself top-level). The bloc's existing self/descendant guards still prevent orphaning.

## Tests
- `parentIdOf` unit tests (root / nested / missing / folder cases)
- Shortcut-filter unit tests (macOS + non-macOS) **and** an end-to-end key-simulation test: Cmd+Enter in a focused editor fires send and inserts no newline; plain Enter still inserts a newline and does not send
- Drag-drop regression widget test: dropping onto a request inside a folder lands it in that folder, not root

## Verification
- `flutter analyze`, `custom_lint`, getman_lints fixtures, `bloc_lint`, `dart format` — all clean (pre-commit gate passed)
- `flutter test` — full suite green (1769 tests)
- `flutter build macos --debug` — compiles (confirms the Swift change builds)
- Wiki Collections page updated to document the new drop behavior

> Note: the macOS window-size fix was verified to compile; runtime persistence (resize → quit → relaunch) should be confirmed manually on a desktop session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jb6KcLZHy4ptXCG9HtawW5
