### PR TITLE
Spec C — GitHub Pull Request integration (gh CLI)

### DIFF
--- a/docs/superpowers/plans/2026-07-14-git-pr-integration.md
+++ b/docs/superpowers/plans/2026-07-14-git-pr-integration.md
@@ -1,0 +1,1716 @@
+# Git Pull Request Integration (Spec C) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create GitHub pull requests and list the repo's open PRs (state +
+checks) from inside Getman, via the `gh` CLI, without storing any credential.
+
+**Architecture:** Three layers, mirroring Spec A/B. `GhService` (`lib/core/git/`,
+the sole `dart:io` importer for `gh`, web-stubbed) shells out to `gh`. A domain
+`PullRequestService` abstraction wraps it (+ the existing `BranchService` for the
+push step); `PullRequestsBloc` depends only on that abstraction (required by the
+`bloc_depends_on_abstractions` custom_lint rule). The dialog is reached from the
+branch-chip menu; the after-create chip refresh is a widget-layer nudge, never
+bloc→bloc.
+
+**Tech Stack:** Flutter, flutter_bloc, get_it, equatable, mocktail, bloc_test,
+`Process.run('gh', ...)` (no shell → no injection).
+
+**Spec:** `docs/superpowers/specs/2026-07-14-git-pr-integration-design.md`
+
+## Global Constraints
+
+- Always invoke Flutter as `fvm flutter ...` / `fvm dart ...`. Never plain `flutter`.
+- **Done-bar (all must be clean, separate passes):** `fvm flutter analyze`, `fvm dart run custom_lint`, `fvm dart run bloc_tools:bloc lint lib < /dev/null` (an update banner hides the verdict under a plain `tail` — grep for "issues found"), `( cd tools/getman_lints/example && fvm dart run custom_lint )`, `fvm dart format lib test tools`, and a 100% green `fvm flutter test`. Run analyze over the **whole repo**.
+- **`dart:io` only in `*_io.dart` files** (`platform_io_outside_io_files`). `gh_service_io.dart` is the only place `gh` is executed.
+- **Blocs must not import `data/`** (`bloc_depends_on_abstractions`). `PullRequestsBloc` depends on the domain `PullRequestService` abstraction only.
+- **Domain layer is pure Dart + equatable** (`domain_no_infrastructure_imports`): no `package:flutter/`, `dart:io`, `dart:ui`, `package:dio/`, `package:hive_ce/`, or any sibling `data/` path.
+- **No bloc→bloc coupling.** Cross-bloc coordination happens in a widget that holds both.
+- **No `GetIt`/`sl<T>()` in widgets** (`avoid_get_it_in_widgets`). Widgets reach services via `BlocProvider` / `RepositoryProvider`.
+- **No hardcoded sizes/colors/radii/weights** in widgets — read `context.appLayout`, `context.appPalette`, `context.appShape`, `context.appTypography`, `context.appDecoration`. No `Colors.black/white/red` literals (`avoid_hardcoded_brand_colors`); destructive/error tint via `colorScheme.error`.
+- **Blocs log with `dart:developer`'s `log(msg, name: '<BlocName>')`**, never `debugPrint`.
+- **Every `Equatable` class lists all its fields in `props`** (`equatable_props_complete`; the `// ignore:` for it, if needed, sits directly above the class declaration).
+- **Snackbars via `showAppSnackBar(context, ...)`**, never inline `SnackBar`.
+- Imports are `package:getman/...` — no relative imports; directives sorted alphabetically.
+- Getman **stores no credentials** and never edits git config. Auth is whatever `gh auth` already provides.
+- **Widget-test gotcha:** construct blocs INSIDE the `testWidgets` body, never in `setUp` (a bloc built in `setUp` sits outside the fake-async zone; its `await`s never resolve under `pumpAndSettle`). Provide `brutalistTheme(Brightness.light)` so `context.appLayout` etc. resolve.
+- **Non-interactive `gh`:** every `gh` call runs via `Process.run` (non-tty), so `gh` never prompts on stdin — it errors instead, which we surface. We push before `gh pr create` precisely so `gh` never needs to prompt for a remote.
+- Lines ≤ 80 chars.
+
+---
+
+## File Structure
+
+**Create:**
+- `lib/core/git/gh_service.dart` — abstract `GhService` + `PullRequestInfo` + `GhException` + the conditional export (createPr returns the URL string).
+- `lib/core/git/gh_service_io.dart` — `_GhService` (shells out to `gh`).
+- `lib/core/git/gh_service_stub.dart` — web no-op.
+- `lib/core/git/gh_output_parser.dart` — **pure Dart** (no `dart:io`) parsers `parsePrList` / `rollupChecks` / `parsePrUrl`, imported by `gh_service_io.dart` and unit-tested directly (a test must not import the `dart:io` shell).
+- `lib/core/utils/open_url.dart` — `Future<bool> openUrl(String)` over the existing `url_launcher` dependency (cross-platform; no `dart:io`, no new dependency).
+- `lib/features/collections/domain/entities/pull_request.dart` — `PullRequestEntity`, enums `PrState`/`PrChecks`, `GhAvailability`, `PullRequestRef`.
+- `lib/features/collections/domain/pull_request_service.dart` — abstract `PullRequestService`.
+- `lib/features/collections/data/services/gh_pull_request_service.dart` — `GhPullRequestService implements PullRequestService`.
+- `lib/features/collections/presentation/bloc/pull_requests_bloc.dart` / `pull_requests_event.dart` / `pull_requests_state.dart`.
+- `lib/features/collections/presentation/widgets/pull_requests_dialog.dart`.
+- Tests alongside each.
+
+**Modify:**
+- `lib/core/di/injection_container.dart` — register `GhService`, `PullRequestService`, `PullRequestsBloc`.
+- `lib/main.dart` — provide `PullRequestsBloc` in the `MultiBlocProvider`.
+- `lib/features/collections/presentation/widgets/branch_chip.dart` — add the `PULL REQUESTS…` menu item.
+
+---
+
+## Global constants used across tasks
+
+Verbatim UI labels (also documented in the wiki, Task 8):
+`PULL REQUESTS…`, `CREATE PULL REQUEST…`, `REFRESH`, `CREATE`, `CANCEL`,
+`OPEN IN BROWSER`, `Create as draft`, `GitHub CLI (gh) not found`,
+`INSTALL GH`, `Sign in with the GitHub CLI`, `No open pull requests.`,
+`PR TITLE`, `Base branch`, `PR body (optional)`.
+
+---
+
+## Task 1: GhService — availability, auth, exceptions, and the conditional export
+
+**Files:**
+- Create: `lib/core/git/gh_service.dart`, `gh_service_io.dart`, `gh_service_stub.dart`
+- Test: `test/core/git/gh_service_io_test.dart`
+
+**Interfaces:**
+- Produces: `abstract class GhService` with `Future<bool> isAvailable()`, `Future<bool> isAuthenticated(String root)`; `GhService createGhService()` (conditional export); `class GhException implements Exception { GhException(String message, {int? exitCode}); final String message; final int? exitCode; }`; and the value type `class PullRequestInfo` (fields defined here, used in Task 2). `createPr` (Task 3) returns `Future<String>` (the PR URL). `listPrs` (Task 2) returns `Future<List<PullRequestInfo>>`. `defaultBranch` (Task 2) returns `Future<String?>`.
+
+- [ ] **Step 1: Write the abstract service + types + conditional export**
+
+Create `lib/core/git/gh_service.dart`:
+
+```dart
+import 'package:getman/core/git/gh_service_stub.dart'
+    if (dart.library.io) 'package:getman/core/git/gh_service_io.dart';
+
+/// Talks to GitHub through the `gh` CLI. The single `dart:io` boundary for
+/// `gh` lives in `gh_service_io.dart`; web builds get the stub. Rides on the
+/// user's existing `gh auth` — Getman stores no credentials.
+abstract class GhService {
+  /// `gh --version` succeeds.
+  Future<bool> isAvailable();
+
+  /// `gh auth status` succeeds in [root] (a repo dir picks up its host).
+  Future<bool> isAuthenticated(String root);
+
+  /// Opens a PR for the current branch. Returns the PR URL printed by
+  /// `gh pr create`. Throws [GhException] on any failure (incl. gh trying to
+  /// prompt for a remote — we push first so it never should).
+  Future<String> createPr(
+    String root, {
+    required String base,
+    required String title,
+    required String body,
+    required bool draft,
+  });
+
+  /// Open PRs for the repo in [root], newest first as gh returns them.
+  Future<List<PullRequestInfo>> listPrs(String root);
+
+  /// The repo's default branch name (for the create form's base default), or
+  /// null if it can't be determined.
+  Future<String?> defaultBranch(String root);
+}
+
+GhService createGhService() => createGhServiceImpl();
+
+/// One open pull request as reported by `gh pr list --json`. Primitive/string
+/// fields only — the domain layer maps [state]/[checks] to its own enums.
+class PullRequestInfo {
+  const PullRequestInfo({
+    required this.number,
+    required this.title,
+    required this.state,
+    required this.url,
+    required this.isDraft,
+    required this.checks,
+  });
+
+  final int number;
+  final String title;
+
+  /// Raw gh state: `OPEN` / `MERGED` / `CLOSED`.
+  final String state;
+  final String url;
+  final bool isDraft;
+
+  /// Rolled-up check verdict: `none` / `pending` / `passing` / `failing`.
+  final String checks;
+}
+
+class GhException implements Exception {
+  GhException(this.message, {this.exitCode});
+  final String message;
+  final int? exitCode;
+
+  @override
+  String toString() => 'GhException($exitCode): $message';
+}
+```
+
+- [ ] **Step 2: Write the web stub**
+
+Create `lib/core/git/gh_service_stub.dart`:
+
+```dart
+import 'package:getman/core/git/gh_service.dart';
+
+GhService createGhServiceImpl() => _StubGhService();
+
+/// Web build: `gh` is a desktop binary, so every call is a no-op that reports
+/// "not available".
+class _StubGhService implements GhService {
+  @override
+  Future<bool> isAvailable() async => false;
+
+  @override
+  Future<bool> isAuthenticated(String root) async => false;
+
+  @override
+  Future<String> createPr(
+    String root, {
+    required String base,
+    required String title,
+    required String body,
+    required bool draft,
+  }) async => throw GhException('gh is unavailable on web');
+
+  @override
+  Future<List<PullRequestInfo>> listPrs(String root) async => const [];
+
+  @override
+  Future<String?> defaultBranch(String root) async => null;
+}
+```
+
+- [ ] **Step 3: Write the io implementation (availability + auth only for now)**
+
+Create `lib/core/git/gh_service_io.dart`:
+
+```dart
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:getman/core/git/gh_service.dart';
+
+GhService createGhServiceImpl() => _GhService();
+
+class _GhService implements GhService {
+  Future<ProcessResult> _run(
+    String root,
+    List<String> args, {
+    bool allowFailure = false,
+  }) async {
+    final result = await Process.run(
+      'gh',
+      args,
+      workingDirectory: root,
+      stdoutEncoding: utf8,
+      stderrEncoding: utf8,
+    );
+    if (!allowFailure && result.exitCode != 0) {
+      final err = (result.stderr as String).trim();
+      throw GhException(
+        err.isEmpty ? 'gh ${args.first} failed' : err,
+        exitCode: result.exitCode,
+      );
+    }
+    return result;
+  }
+
+  @override
+  Future<bool> isAvailable() async {
+    try {
+      final r = await Process.run('gh', ['--version']);
+      return r.exitCode == 0;
+    } on Object {
+      return false;
+    }
+  }
+
+  @override
+  Future<bool> isAuthenticated(String root) async {
+    try {
+      final r = await _run(root, ['auth', 'status'], allowFailure: true);
+      return r.exitCode == 0;
+    } on Object {
+      return false;
+    }
+  }
+
+  @override
+  Future<String> createPr(
+    String root, {
+    required String base,
+    required String title,
+    required String body,
+    required bool draft,
+  }) async {
+    // Filled in Task 3.
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<List<PullRequestInfo>> listPrs(String root) async {
+    // Filled in Task 2.
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<String?> defaultBranch(String root) async {
+    // Filled in Task 2.
+    throw UnimplementedError();
+  }
+}
+```
+
+- [ ] **Step 4: Write the test**
+
+Create `test/core/git/gh_service_io_test.dart`:
+
+```dart
+@TestOn('vm')
+library;
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/core/git/gh_service.dart';
+
+void main() {
+  late GhService gh;
+  late Directory tmp;
+
+  Future<bool> ghPresent() async => gh.isAvailable();
+
+  setUp(() async {
+    gh = createGhService();
+    tmp = await Directory.systemTemp.createTemp('getman_gh_test');
+  });
+
+  tearDown(() async {
+    if (tmp.existsSync()) await tmp.delete(recursive: true);
+  });
+
+  test('isAvailable reflects whether the gh binary runs', () async {
+    // Either result is valid depending on the machine; the call must not throw.
+    expect(await gh.isAvailable(), isA<bool>());
+  });
+
+  test('isAuthenticated is false in a non-repo dir when gh is present or '
+      'absent (never throws)', () async {
+    // In a bare temp dir with no gh host context, auth status is false; and if
+    // gh is missing the catch returns false. Either way: no throw, a bool.
+    final result = await gh.isAuthenticated(tmp.path);
+    expect(result, isA<bool>());
+    if (!await ghPresent()) expect(result, isFalse);
+  });
+
+  test('GhException carries the exit code and message', () {
+    final e = GhException('boom', exitCode: 3);
+    expect(e.message, 'boom');
+    expect(e.exitCode, 3);
+    expect(e.toString(), contains('boom'));
+  });
+}
+```
+
+- [ ] **Step 5: Run the tests, verify green**
+
+Run: `fvm flutter test test/core/git/gh_service_io_test.dart`
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Gate + commit**
+
+```bash
+fvm dart format lib test && fvm flutter analyze && fvm dart run custom_lint
+git add lib/core/git/gh_service.dart lib/core/git/gh_service_io.dart \
+        lib/core/git/gh_service_stub.dart test/core/git/gh_service_io_test.dart
+git commit -m "feat(git): GhService scaffold — availability, auth, gh exception"
+```
+
+---
+
+## Task 2: GhService — listPrs + defaultBranch (gh --json parsing)
+
+**Files:**
+- Create: `lib/core/git/gh_output_parser.dart` (pure Dart parsers)
+- Modify: `lib/core/git/gh_service_io.dart`
+- Test: `test/core/git/gh_output_parser_test.dart`
+
+**Interfaces:**
+- Consumes: `PullRequestInfo` (Task 1).
+- Produces: top-level pure functions in `gh_output_parser.dart` —
+  `List<PullRequestInfo> parsePrList(String json)`,
+  `String rollupChecks(Object? statusCheckRollup)`; `listPrs`/`defaultBranch`
+  in `_GhService` wired to `gh` and delegating to the parser.
+
+- [ ] **Step 1: Write the failing parser tests**
+
+Create `test/core/git/gh_output_parser_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/core/git/gh_output_parser.dart';
+
+void main() {
+  test('parsePrList maps fields and rolls up passing checks', () {
+    const json = '''
+    [
+      {"number":123,"title":"feat: x","state":"OPEN",
+       "url":"https://github.com/o/r/pull/123","isDraft":false,
+       "statusCheckRollup":[
+         {"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"},
+         {"__typename":"StatusContext","state":"SUCCESS"}]}
+    ]''';
+    final prs = parsePrList(json);
+    expect(prs.single.number, 123);
+    expect(prs.single.title, 'feat: x');
+    expect(prs.single.state, 'OPEN');
+    expect(prs.single.url, endsWith('/pull/123'));
+    expect(prs.single.isDraft, isFalse);
+    expect(prs.single.checks, 'passing');
+  });
+
+  test('rollupChecks: empty rollup is none', () {
+    expect(rollupChecks(const <Object?>[]), 'none');
+    expect(rollupChecks(null), 'none');
+  });
+
+  test('rollupChecks: an unfinished check is pending', () {
+    final rollup = [
+      {'__typename': 'CheckRun', 'status': 'IN_PROGRESS'},
+      {'__typename': 'CheckRun', 'status': 'COMPLETED', 'conclusion': 'SUCCESS'},
+    ];
+    expect(rollupChecks(rollup), 'pending');
+  });
+
+  test('rollupChecks: a completed failure (all finished) is failing', () {
+    final rollup = [
+      {'__typename': 'CheckRun', 'status': 'COMPLETED', 'conclusion': 'FAILURE'},
+      {'__typename': 'StatusContext', 'state': 'SUCCESS'},
+    ];
+    expect(rollupChecks(rollup), 'failing');
+  });
+
+  test('rollupChecks: draft PR still parses', () {
+    const json = '''
+    [{"number":9,"title":"wip","state":"OPEN","url":"u","isDraft":true,
+      "statusCheckRollup":[]}]''';
+    expect(parsePrList(json).single.isDraft, isTrue);
+    expect(parsePrList(json).single.checks, 'none');
+  });
+}
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run: `fvm flutter test test/core/git/gh_output_parser_test.dart`
+Expected: FAIL — `parsePrList`/`rollupChecks` undefined.
+
+- [ ] **Step 3: Implement the parser + wire the gh calls**
+
+Create `lib/core/git/gh_output_parser.dart` (pure Dart — no `dart:io`) with
+these top-level functions, and have `gh_service_io.dart` import it
+(`import 'package:getman/core/git/gh_output_parser.dart';`) and delegate:
+
+```dart
+import 'dart:convert';
+
+import 'package:getman/core/git/gh_service.dart';
+
+/// Reduces a `statusCheckRollup` array to `none`/`pending`/`passing`/`failing`.
+/// A check is unfinished when a CheckRun's `status` != `COMPLETED` or a
+/// StatusContext's `state` is `PENDING`/`EXPECTED`. Pending wins over failing
+/// wins over passing.
+String rollupChecks(Object? statusCheckRollup) {
+  if (statusCheckRollup is! List || statusCheckRollup.isEmpty) return 'none';
+  var anyPending = false;
+  var anyFailing = false;
+  for (final raw in statusCheckRollup) {
+    if (raw is! Map) continue;
+    final type = raw['__typename'];
+    if (type == 'CheckRun') {
+      final status = raw['status'] as String?;
+      if (status != 'COMPLETED') {
+        anyPending = true;
+      } else {
+        final c = raw['conclusion'] as String?;
+        if (c != 'SUCCESS' && c != 'NEUTRAL' && c != 'SKIPPED') {
+          anyFailing = true;
+        }
+      }
+    } else {
+      // StatusContext
+      final state = raw['state'] as String?;
+      if (state == 'PENDING' || state == 'EXPECTED') {
+        anyPending = true;
+      } else if (state != 'SUCCESS') {
+        anyFailing = true;
+      }
+    }
+  }
+  if (anyPending) return 'pending';
+  if (anyFailing) return 'failing';
+  return 'passing';
+}
+
+/// Parses `gh pr list --json number,title,state,url,isDraft,statusCheckRollup`.
+List<PullRequestInfo> parsePrList(String jsonText) {
+  final decoded = jsonDecode(jsonText);
+  if (decoded is! List) return const [];
+  return [
+    for (final raw in decoded)
+      if (raw is Map)
+        PullRequestInfo(
+          number: (raw['number'] as num?)?.toInt() ?? 0,
+          title: raw['title'] as String? ?? '',
+          state: raw['state'] as String? ?? 'OPEN',
+          url: raw['url'] as String? ?? '',
+          isDraft: raw['isDraft'] as bool? ?? false,
+          checks: rollupChecks(raw['statusCheckRollup']),
+        ),
+  ];
+}
+```
+
+Then in `_GhService`:
+
+```dart
+  @override
+  Future<List<PullRequestInfo>> listPrs(String root) async {
+    final r = await _run(root, [
+      'pr',
+      'list',
+      '--state',
+      'open',
+      '--json',
+      'number,title,state,url,isDraft,statusCheckRollup',
+    ]);
+    return parsePrList(r.stdout as String);
+  }
+
+  @override
+  Future<String?> defaultBranch(String root) async {
+    final r = await _run(root, [
+      'repo',
+      'view',
+      '--json',
+      'defaultBranchRef',
+    ], allowFailure: true);
+    if (r.exitCode != 0) return null;
+    final decoded = jsonDecode(r.stdout as String);
+    if (decoded is! Map) return null;
+    final ref = decoded['defaultBranchRef'];
+    if (ref is! Map) return null;
+    return ref['name'] as String?;
+  }
+```
+
+`parsePrList`/`rollupChecks` are top-level functions in the pure
+`gh_output_parser.dart`; `_GhService` calls them. `dart:convert` is imported by
+the parser file (shown above).
+
+- [ ] **Step 4: Run tests, verify green**
+
+Run: `fvm flutter test test/core/git/gh_output_parser_test.dart`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Gate + commit**
+
+```bash
+fvm dart format lib test && fvm flutter analyze && fvm dart run custom_lint
+git add lib/core/git/gh_output_parser.dart lib/core/git/gh_service_io.dart \
+        test/core/git/gh_output_parser_test.dart
+git commit -m "feat(git): gh pr list + defaultBranch parsing (statusCheckRollup)"
+```
+
+---
+
+## Task 3: GhService — createPr
+
+**Files:**
+- Modify: `lib/core/git/gh_output_parser.dart` (add `parsePrUrl`), `lib/core/git/gh_service_io.dart` (wire `createPr`)
+- Test: extend `test/core/git/gh_output_parser_test.dart`
+
+**Interfaces:**
+- Produces: `String parsePrUrl(String stdout)` (top-level in the pure parser,
+  returns the last https URL gh printed) and the wired `createPr`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `test/core/git/gh_output_parser_test.dart`:
+
+```dart
+  test('parsePrUrl returns the PR url gh printed on the last line', () {
+    const out = 'Warning: 3 uncommitted changes\n'
+        'https://github.com/o/r/pull/456\n';
+    expect(parsePrUrl(out), 'https://github.com/o/r/pull/456');
+  });
+
+  test('parsePrUrl returns empty when no url is present', () {
+    expect(parsePrUrl('nothing here'), '');
+  });
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `fvm flutter test test/core/git/gh_output_parser_test.dart`
+Expected: FAIL — `parsePrUrl` undefined.
+
+- [ ] **Step 3: Implement**
+
+Top-level in `gh_output_parser.dart`:
+
+```dart
+/// The last `https://…` token gh printed — that is the created PR's URL.
+String parsePrUrl(String stdout) {
+  final match = RegExp(r'https://\S+').allMatches(stdout).toList();
+  return match.isEmpty ? '' : match.last.group(0)!.trim();
+}
+```
+
+Wire `createPr` in `_GhService`:
+
+```dart
+  @override
+  Future<String> createPr(
+    String root, {
+    required String base,
+    required String title,
+    required String body,
+    required bool draft,
+  }) async {
+    final r = await _run(root, [
+      'pr',
+      'create',
+      '--base',
+      base,
+      '--title',
+      title,
+      '--body',
+      body,
+      if (draft) '--draft',
+    ]);
+    final url = parsePrUrl(r.stdout as String);
+    if (url.isEmpty) {
+      throw GhException('gh pr create did not return a PR url');
+    }
+    return url;
+  }
+```
+
+- [ ] **Step 4: Run, verify green**
+
+Run: `fvm flutter test test/core/git/gh_output_parser_test.dart`
+Expected: PASS (7 tests total).
+
+- [ ] **Step 5: Gate + commit**
+
+```bash
+fvm dart format lib test && fvm flutter analyze && fvm dart run custom_lint
+git add lib/core/git/gh_output_parser.dart lib/core/git/gh_service_io.dart \
+        test/core/git/gh_output_parser_test.dart
+git commit -m "feat(git): gh pr create + PR url parsing"
+```
+
+---
+
+## Task 4: Domain — PullRequestEntity, enums, PullRequestService abstraction
+
+**Files:**
+- Create: `lib/features/collections/domain/entities/pull_request.dart`
+- Create: `lib/features/collections/domain/pull_request_service.dart`
+- Test: `test/features/collections/domain/pull_request_test.dart`
+
+**Interfaces:**
+- Produces: enums `PrState { open, merged, closed }`, `PrChecks { none, pending, passing, failing }`, `GhAvailability { available, notInstalled, notAuthenticated }`; `class PullRequestEntity extends Equatable {int number; String title; PrState state; String url; bool isDraft; PrChecks checks;}`; `class PullRequestRef extends Equatable {int number; String url;}`; `abstract class PullRequestService { Future<GhAvailability> availability(String root); Future<List<PullRequestEntity>> list(String root); Future<PullRequestRef> create(String root, {required String base, required String title, required String body, required bool draft}); Future<String?> defaultBase(String root); }`.
+
+- [ ] **Step 1: Write the entity test**
+
+Create `test/features/collections/domain/pull_request_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/features/collections/domain/entities/pull_request.dart';
+
+void main() {
+  test('PullRequestEntity equality is by value', () {
+    const a = PullRequestEntity(
+      number: 1,
+      title: 't',
+      state: PrState.open,
+      url: 'u',
+      isDraft: false,
+      checks: PrChecks.passing,
+    );
+    const b = PullRequestEntity(
+      number: 1,
+      title: 't',
+      state: PrState.open,
+      url: 'u',
+      isDraft: false,
+      checks: PrChecks.passing,
+    );
+    expect(a, b);
+  });
+
+  test('PullRequestRef equality is by value', () {
+    expect(
+      const PullRequestRef(number: 5, url: 'u'),
+      const PullRequestRef(number: 5, url: 'u'),
+    );
+  });
+}
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `fvm flutter test test/features/collections/domain/pull_request_test.dart`
+Expected: FAIL — file/types undefined.
+
+- [ ] **Step 3: Write the entities + enums**
+
+Create `lib/features/collections/domain/entities/pull_request.dart`:
+
+```dart
+import 'package:equatable/equatable.dart';
+
+/// A PR's lifecycle state (only `open` is listed in v1, but the mapping is
+/// total so a created PR and future scopes are covered).
+enum PrState { open, merged, closed }
+
+/// Rolled-up CI verdict for a PR's head commit.
+enum PrChecks { none, pending, passing, failing }
+
+/// Whether the `gh` CLI can be used right now.
+enum GhAvailability { available, notInstalled, notAuthenticated }
+
+class PullRequestEntity extends Equatable {
+  const PullRequestEntity({
+    required this.number,
+    required this.title,
+    required this.state,
+    required this.url,
+    required this.isDraft,
+    required this.checks,
+  });
+
+  final int number;
+  final String title;
+  final PrState state;
+  final String url;
+  final bool isDraft;
+  final PrChecks checks;
+
+  @override
+  List<Object?> get props => [number, title, state, url, isDraft, checks];
+}
+
+/// The just-created PR — its number (parsed from the url) and url.
+class PullRequestRef extends Equatable {
+  const PullRequestRef({required this.number, required this.url});
+
+  final int number;
+  final String url;
+
+  @override
+  List<Object?> get props => [number, url];
+}
+```
+
+- [ ] **Step 4: Write the service abstraction**
+
+Create `lib/features/collections/domain/pull_request_service.dart`:
+
+```dart
+import 'package:getman/features/collections/domain/entities/pull_request.dart';
+
+/// Domain gateway for GitHub pull-request operations. The data layer backs this
+/// with the `gh` CLI; the bloc depends only on this abstraction.
+abstract class PullRequestService {
+  /// Whether `gh` is installed and authenticated for [root].
+  Future<GhAvailability> availability(String root);
+
+  /// Open PRs for the repo in [root].
+  Future<List<PullRequestEntity>> list(String root);
+
+  /// Pushes the current branch (setting upstream on first push) and opens a PR.
+  Future<PullRequestRef> create(
+    String root, {
+    required String base,
+    required String title,
+    required String body,
+    required bool draft,
+  });
+
+  /// The default base branch to preselect in the create form, or null.
+  Future<String?> defaultBase(String root);
+}
+```
+
+- [ ] **Step 5: Run, verify green**
+
+Run: `fvm flutter test test/features/collections/domain/pull_request_test.dart`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Gate + commit**
+
+```bash
+fvm dart format lib test && fvm flutter analyze && fvm dart run custom_lint
+git add lib/features/collections/domain/entities/pull_request.dart \
+        lib/features/collections/domain/pull_request_service.dart \
+        test/features/collections/domain/pull_request_test.dart
+git commit -m "feat(collections): PullRequestEntity + PullRequestService domain"
+```
+
+---
+
+## Task 5: Data — GhPullRequestService + DI
+
+**Files:**
+- Create: `lib/features/collections/data/services/gh_pull_request_service.dart`
+- Modify: `lib/core/di/injection_container.dart`
+- Test: `test/features/collections/data/services/gh_pull_request_service_test.dart`
+
+**Interfaces:**
+- Consumes: `GhService` + `PullRequestInfo` (core), `BranchService` (domain, Spec B — has `push(String root)` which sets upstream on first push), `PullRequestService` + entities (Task 4).
+- Produces: `class GhPullRequestService implements PullRequestService { GhPullRequestService(GhService gh, BranchService branch); }`.
+
+Mapping rules the service owns: gh `state` string → `PrState`
+(`MERGED`→merged, `CLOSED`→closed, else open); gh `checks` string → `PrChecks`
+(`pending`/`passing`/`failing`/else none); the created PR's number is parsed
+from its url's trailing path segment.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create
+`test/features/collections/data/services/gh_pull_request_service_test.dart`:
+
+```dart
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/core/git/gh_service.dart';
+import 'package:getman/features/collections/data/services/gh_pull_request_service.dart';
+import 'package:getman/features/collections/domain/branch_service.dart';
+import 'package:getman/features/collections/domain/entities/pull_request.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockGh extends Mock implements GhService {}
+
+class _MockBranch extends Mock implements BranchService {}
+
+void main() {
+  const root = '/ws';
+  late _MockGh gh;
+  late _MockBranch branch;
+  late GhPullRequestService service;
+
+  setUp(() {
+    gh = _MockGh();
+    branch = _MockBranch();
+    service = GhPullRequestService(gh, branch);
+  });
+
+  test('availability: notInstalled when gh is absent', () async {
+    when(gh.isAvailable).thenAnswer((_) async => false);
+    expect(await service.availability(root), GhAvailability.notInstalled);
+    verifyNever(() => gh.isAuthenticated(any()));
+  });
+
+  test('availability: notAuthenticated when gh present but not logged in',
+      () async {
+    when(gh.isAvailable).thenAnswer((_) async => true);
+    when(() => gh.isAuthenticated(root)).thenAnswer((_) async => false);
+    expect(await service.availability(root), GhAvailability.notAuthenticated);
+  });
+
+  test('availability: available when installed + authenticated', () async {
+    when(gh.isAvailable).thenAnswer((_) async => true);
+    when(() => gh.isAuthenticated(root)).thenAnswer((_) async => true);
+    expect(await service.availability(root), GhAvailability.available);
+  });
+
+  test('list maps gh state + checks strings to domain enums', () async {
+    when(() => gh.listPrs(root)).thenAnswer(
+      (_) async => const [
+        PullRequestInfo(
+          number: 12,
+          title: 't',
+          state: 'OPEN',
+          url: 'https://github.com/o/r/pull/12',
+          isDraft: true,
+          checks: 'failing',
+        ),
+      ],
+    );
+    final prs = await service.list(root);
+    expect(prs.single.number, 12);
+    expect(prs.single.state, PrState.open);
+    expect(prs.single.checks, PrChecks.failing);
+    expect(prs.single.isDraft, isTrue);
+  });
+
+  test('create pushes BEFORE gh.createPr, and parses the PR number from the '
+      'url', () async {
+    final pushGate = Completer<void>();
+    var pushed = false;
+    var createdBeforePush = false;
+    when(() => branch.push(root)).thenAnswer((_) async {
+      await pushGate.future;
+      pushed = true;
+    });
+    when(
+      () => gh.createPr(
+        root,
+        base: any(named: 'base'),
+        title: any(named: 'title'),
+        body: any(named: 'body'),
+        draft: any(named: 'draft'),
+      ),
+    ).thenAnswer((_) async {
+      if (!pushed) createdBeforePush = true;
+      return 'https://github.com/o/r/pull/77';
+    });
+
+    final op = service.create(
+      root,
+      base: 'main',
+      title: 't',
+      body: 'b',
+      draft: false,
+    );
+    await Future<void>.delayed(Duration.zero);
+    pushGate.complete();
+    final ref = await op;
+
+    expect(createdBeforePush, isFalse, reason: 'push must finish before create');
+    expect(ref.number, 77);
+    expect(ref.url, endsWith('/pull/77'));
+  });
+}
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `fvm flutter test test/features/collections/data/services/gh_pull_request_service_test.dart`
+Expected: FAIL — `GhPullRequestService` undefined.
+
+- [ ] **Step 3: Implement the service**
+
+Create `lib/features/collections/data/services/gh_pull_request_service.dart`:
+
+```dart
+import 'package:getman/core/git/gh_service.dart';
+import 'package:getman/features/collections/domain/branch_service.dart';
+import 'package:getman/features/collections/domain/entities/pull_request.dart';
+import 'package:getman/features/collections/domain/pull_request_service.dart';
+
+/// `gh`-backed [PullRequestService]. Composes [GhService] with the Spec B
+/// [BranchService] so the pre-create push reuses the flush-guarded push (no
+/// duplicated mirror-race handling — PR creation itself never touches the
+/// working tree).
+class GhPullRequestService implements PullRequestService {
+  GhPullRequestService(this._gh, this._branch);
+
+  final GhService _gh;
+  final BranchService _branch;
+
+  @override
+  Future<GhAvailability> availability(String root) async {
+    if (!await _gh.isAvailable()) return GhAvailability.notInstalled;
+    if (!await _gh.isAuthenticated(root)) {
+      return GhAvailability.notAuthenticated;
+    }
+    return GhAvailability.available;
+  }
+
+  @override
+  Future<List<PullRequestEntity>> list(String root) async {
+    final raw = await _gh.listPrs(root);
+    return [for (final p in raw) _toEntity(p)];
+  }
+
+  @override
+  Future<PullRequestRef> create(
+    String root, {
+    required String base,
+    required String title,
+    required String body,
+    required bool draft,
+  }) async {
+    // Ensure the branch (and its latest commits) are on the remote first —
+    // gh pr create would otherwise prompt for a remote on stdin, which a
+    // non-interactive Process.run cannot answer. push sets upstream on the
+    // first push.
+    await _branch.push(root);
+    final url = await _gh.createPr(
+      root,
+      base: base,
+      title: title,
+      body: body,
+      draft: draft,
+    );
+    return PullRequestRef(number: _numberFromUrl(url), url: url);
+  }
+
+  @override
+  Future<String?> defaultBase(String root) => _gh.defaultBranch(root);
+
+  PullRequestEntity _toEntity(PullRequestInfo p) => PullRequestEntity(
+    number: p.number,
+    title: p.title,
+    state: switch (p.state) {
+      'MERGED' => PrState.merged,
+      'CLOSED' => PrState.closed,
+      _ => PrState.open,
+    },
+    url: p.url,
+    isDraft: p.isDraft,
+    checks: switch (p.checks) {
+      'pending' => PrChecks.pending,
+      'passing' => PrChecks.passing,
+      'failing' => PrChecks.failing,
+      _ => PrChecks.none,
+    },
+  );
+
+  int _numberFromUrl(String url) {
+    final last = url.split('/').where((s) => s.isNotEmpty).lastOrNull;
+    return int.tryParse(last ?? '') ?? 0;
+  }
+}
+```
+
+- [ ] **Step 4: Run, verify green**
+
+Run: `fvm flutter test test/features/collections/data/services/gh_pull_request_service_test.dart`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Register in DI**
+
+In `lib/core/di/injection_container.dart`, near the `BranchService` /
+`ReviewService` registrations, add (with sorted imports):
+
+```dart
+import 'package:getman/core/git/gh_service.dart';
+import 'package:getman/features/collections/data/services/gh_pull_request_service.dart';
+import 'package:getman/features/collections/domain/pull_request_service.dart';
+```
+
+```dart
+  sl.registerLazySingleton<GhService>(createGhService);
+  sl.registerLazySingleton<PullRequestService>(
+    () => GhPullRequestService(sl(), sl()),
+  );
+```
+
+- [ ] **Step 6: Gate + commit**
+
+```bash
+fvm dart format lib test && fvm flutter analyze && fvm dart run custom_lint
+git add lib/features/collections/data/services/gh_pull_request_service.dart \
+        lib/core/di/injection_container.dart \
+        test/features/collections/data/services/gh_pull_request_service_test.dart
+git commit -m "feat(collections): GhPullRequestService (push-then-create) + DI"
+```
+
+---
+
+## Task 6: PullRequestsBloc
+
+**Files:**
+- Create: `lib/features/collections/presentation/bloc/pull_requests_bloc.dart` / `pull_requests_event.dart` / `pull_requests_state.dart`
+- Modify: `lib/core/di/injection_container.dart` (register the bloc)
+- Test: `test/features/collections/presentation/bloc/pull_requests_bloc_test.dart`
+
+**Interfaces:**
+- Consumes: `PullRequestService`, entities (Task 4).
+- Produces: `PullRequestsBloc(service: PullRequestService)`; events
+  `LoadPullRequests(root)`, `CreatePullRequest(root, base, title, body, draft)`
+  (Equatable, all fields in props); state
+  `PullRequestsState {PrStatus status, GhAvailability availability, List<PullRequestEntity> prs, String? errorMessage, PullRequestRef? lastCreated}` with enum `PrStatus { loading, ready, creating, error }` and `isBusy => status == loading || status == creating`.
+
+- [ ] **Step 1: Write the state + events**
+
+Create `lib/features/collections/presentation/bloc/pull_requests_state.dart`:
+
+```dart
+import 'package:equatable/equatable.dart';
+import 'package:getman/features/collections/domain/entities/pull_request.dart';
+
+enum PrStatus { loading, ready, creating, error }
+
+class PullRequestsState extends Equatable {
+  const PullRequestsState({
+    this.status = PrStatus.loading,
+    this.availability = GhAvailability.available,
+    this.prs = const [],
+    this.errorMessage,
+    this.lastCreated,
+  });
+
+  final PrStatus status;
+  final GhAvailability availability;
+  final List<PullRequestEntity> prs;
+  final String? errorMessage;
+  final PullRequestRef? lastCreated;
+
+  bool get isBusy => status == PrStatus.loading || status == PrStatus.creating;
+
+  PullRequestsState copyWith({
+    PrStatus? status,
+    GhAvailability? availability,
+    List<PullRequestEntity>? prs,
+    String? errorMessage,
+    PullRequestRef? lastCreated,
+  }) {
+    final next = status ?? this.status;
+    return PullRequestsState(
+      status: next,
+      availability: availability ?? this.availability,
+      prs: prs ?? this.prs,
+      // Only an error state keeps a message; anything else clears it.
+      errorMessage: next == PrStatus.error
+          ? (errorMessage ?? this.errorMessage)
+          : null,
+      lastCreated: lastCreated ?? this.lastCreated,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+    status,
+    availability,
+    prs,
+    errorMessage,
+    lastCreated,
+  ];
+}
+```
+
+Create `lib/features/collections/presentation/bloc/pull_requests_event.dart`:
+
+```dart
+import 'package:equatable/equatable.dart';
+
+abstract class PullRequestsEvent extends Equatable {
+  const PullRequestsEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+/// Check availability, then (if ready) load open PRs for [root].
+class LoadPullRequests extends PullRequestsEvent {
+  const LoadPullRequests(this.root);
+  final String root;
+
+  @override
+  List<Object?> get props => [root];
+}
+
+class CreatePullRequest extends PullRequestsEvent {
+  const CreatePullRequest(
+    this.root, {
+    required this.base,
+    required this.title,
+    required this.body,
+    required this.draft,
+  });
+
+  final String root;
+  final String base;
+  final String title;
+  final String body;
+  final bool draft;
+
+  @override
+  List<Object?> get props => [root, base, title, body, draft];
+}
+```
+
+- [ ] **Step 2: Write the failing bloc tests**
+
+Create
+`test/features/collections/presentation/bloc/pull_requests_bloc_test.dart`:
+
+```dart
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/features/collections/domain/entities/pull_request.dart';
+import 'package:getman/features/collections/domain/pull_request_service.dart';
+import 'package:getman/features/collections/presentation/bloc/pull_requests_bloc.dart';
+import 'package:getman/features/collections/presentation/bloc/pull_requests_event.dart';
+import 'package:getman/features/collections/presentation/bloc/pull_requests_state.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockService extends Mock implements PullRequestService {}
+
+void main() {
+  const root = '/ws';
+  late _MockService service;
+
+  setUp(() => service = _MockService());
+
+  blocTest<PullRequestsBloc, PullRequestsState>(
+    'LoadPullRequests: available → loads PRs',
+    build: () {
+      when(() => service.availability(root))
+          .thenAnswer((_) async => GhAvailability.available);
+      when(() => service.list(root)).thenAnswer(
+        (_) async => const [
+          PullRequestEntity(
+            number: 1,
+            title: 't',
+            state: PrState.open,
+            url: 'u',
+            isDraft: false,
+            checks: PrChecks.passing,
+          ),
+        ],
+      );
+      return PullRequestsBloc(service: service);
+    },
+    act: (b) => b.add(const LoadPullRequests(root)),
+    expect: () => [
+      isA<PullRequestsState>()
+          .having((s) => s.status, 'status', PrStatus.loading),
+      isA<PullRequestsState>()
+          .having((s) => s.status, 'status', PrStatus.ready)
+          .having((s) => s.availability, 'availability',
+              GhAvailability.available)
+          .having((s) => s.prs.length, 'prs', 1),
+    ],
+  );
+
+  blocTest<PullRequestsBloc, PullRequestsState>(
+    'LoadPullRequests: notInstalled → ready with availability, no list call',
+    build: () {
+      when(() => service.availability(root))
+          .thenAnswer((_) async => GhAvailability.notInstalled);
+      return PullRequestsBloc(service: service);
+    },
+    act: (b) => b.add(const LoadPullRequests(root)),
+    expect: () => [
+      isA<PullRequestsState>()
+          .having((s) => s.status, 'status', PrStatus.loading),
+      isA<PullRequestsState>()
+          .having((s) => s.status, 'status', PrStatus.ready)
+          .having((s) => s.availability, 'availability',
+              GhAvailability.notInstalled),
+    ],
+    verify: (_) => verifyNever(() => service.list(any())),
+  );
+
+  blocTest<PullRequestsBloc, PullRequestsState>(
+    'CreatePullRequest: creates, then reloads the list',
+    build: () {
+      when(() => service.availability(root))
+          .thenAnswer((_) async => GhAvailability.available);
+      when(
+        () => service.create(
+          root,
+          base: any(named: 'base'),
+          title: any(named: 'title'),
+          body: any(named: 'body'),
+          draft: any(named: 'draft'),
+        ),
+      ).thenAnswer(
+        (_) async => const PullRequestRef(number: 9, url: 'u/pull/9'),
+      );
+      when(() => service.list(root)).thenAnswer((_) async => const []);
+      return PullRequestsBloc(service: service);
+    },
+    act: (b) => b.add(
+      const CreatePullRequest(
+        root,
+        base: 'main',
+        title: 't',
+        body: 'b',
+        draft: false,
+      ),
+    ),
+    expect: () => [
+      isA<PullRequestsState>()
+          .having((s) => s.status, 'status', PrStatus.creating),
+      isA<PullRequestsState>()
+          .having((s) => s.lastCreated?.number, 'lastCreated', 9)
+          .having((s) => s.status, 'status', PrStatus.ready),
+    ],
+    verify: (_) {
+      verify(() => service.create(root,
+          base: 'main', title: 't', body: 'b', draft: false)).called(1);
+      verify(() => service.list(root)).called(1);
+    },
+  );
+
+  blocTest<PullRequestsBloc, PullRequestsState>(
+    'a service failure surfaces as an error state',
+    build: () {
+      when(() => service.availability(root))
+          .thenAnswer((_) async => GhAvailability.available);
+      when(() => service.list(root)).thenThrow(Exception('boom'));
+      return PullRequestsBloc(service: service);
+    },
+    act: (b) => b.add(const LoadPullRequests(root)),
+    expect: () => [
+      isA<PullRequestsState>()
+          .having((s) => s.status, 'status', PrStatus.loading),
+      isA<PullRequestsState>()
+          .having((s) => s.status, 'status', PrStatus.error)
+          .having((s) => s.errorMessage, 'errorMessage', isNotNull),
+    ],
+  );
+}
+```
+
+- [ ] **Step 3: Run, verify fail**
+
+Run: `fvm flutter test test/features/collections/presentation/bloc/pull_requests_bloc_test.dart`
+Expected: FAIL — `PullRequestsBloc` undefined.
+
+- [ ] **Step 4: Implement the bloc**
+
+Create `lib/features/collections/presentation/bloc/pull_requests_bloc.dart`:
+
+```dart
+import 'dart:developer';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:getman/features/collections/domain/entities/pull_request.dart';
+import 'package:getman/features/collections/domain/pull_request_service.dart';
+import 'package:getman/features/collections/presentation/bloc/pull_requests_event.dart';
+import 'package:getman/features/collections/presentation/bloc/pull_requests_state.dart';
+
+class PullRequestsBloc extends Bloc<PullRequestsEvent, PullRequestsState> {
+  PullRequestsBloc({required PullRequestService service})
+    : _service = service,
+      super(const PullRequestsState()) {
+    on<LoadPullRequests>(_onLoad);
+    on<CreatePullRequest>(_onCreate);
+  }
+
+  final PullRequestService _service;
+
+  Future<void> _onLoad(
+    LoadPullRequests event,
+    Emitter<PullRequestsState> emit,
+  ) async {
+    if (_dropWhileBusy('LoadPullRequests')) return;
+    emit(state.copyWith(status: PrStatus.loading));
+    try {
+      final availability = await _service.availability(event.root);
+      if (availability != GhAvailability.available) {
+        emit(
+          state.copyWith(
+            status: PrStatus.ready,
+            availability: availability,
+            prs: const [],
+          ),
+        );
+        return;
+      }
+      final prs = await _service.list(event.root);
+      emit(
+        state.copyWith(
+          status: PrStatus.ready,
+          availability: availability,
+          prs: prs,
+        ),
+      );
+    } on Object catch (e) {
+      _fail(emit, e);
+    }
+  }
+
+  Future<void> _onCreate(
+    CreatePullRequest event,
+    Emitter<PullRequestsState> emit,
+  ) async {
+    if (_dropWhileBusy('CreatePullRequest')) return;
+    emit(state.copyWith(status: PrStatus.creating));
+    try {
+      final ref = await _service.create(
+        event.root,
+        base: event.base,
+        title: event.title,
+        body: event.body,
+        draft: event.draft,
+      );
+      final prs = await _service.list(event.root);
+      emit(
+        state.copyWith(
+          status: PrStatus.ready,
+          prs: prs,
+          lastCreated: ref,
+        ),
+      );
+    } on Object catch (e) {
+      _fail(emit, e);
+    }
+  }
+
+  /// Drops a second op while one is running: a concurrent gh call could race
+  /// the push/create. Every handler always emits a terminal state, so busy is
+  /// always exited — this cannot deadlock.
+  bool _dropWhileBusy(String event) {
+    if (state.isBusy) {
+      log('dropping $event while busy', name: 'PullRequestsBloc');
+      return true;
+    }
+    return false;
+  }
+
+  void _fail(Emitter<PullRequestsState> emit, Object error) {
+    log('pull-request op failed: $error', name: 'PullRequestsBloc');
+    emit(
+      state.copyWith(status: PrStatus.error, errorMessage: error.toString()),
+    );
+  }
+}
+```
+
+- [ ] **Step 5: Run, verify green**
+
+Run: `fvm flutter test test/features/collections/presentation/bloc/pull_requests_bloc_test.dart`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Register the bloc in DI**
+
+In `lib/core/di/injection_container.dart`, near the `GitSyncBloc` registration:
+
+```dart
+import 'package:getman/features/collections/presentation/bloc/pull_requests_bloc.dart';
+```
+
+```dart
+  sl.registerFactory(() => PullRequestsBloc(service: sl()));
+```
+
+- [ ] **Step 7: Gate + commit**
+
+```bash
+fvm dart format lib test && fvm flutter analyze && fvm dart run custom_lint
+fvm dart run bloc_tools:bloc lint lib < /dev/null
+git add lib/features/collections/presentation/bloc/pull_requests_bloc.dart \
+        lib/features/collections/presentation/bloc/pull_requests_event.dart \
+        lib/features/collections/presentation/bloc/pull_requests_state.dart \
+        lib/core/di/injection_container.dart \
+        test/features/collections/presentation/bloc/pull_requests_bloc_test.dart
+git commit -m "feat(collections): PullRequestsBloc over the service abstraction"
+```
+
+---
+
+## Task 7: PullRequestsDialog + branch-chip menu wiring
+
+**Files:**
+- Create: `lib/features/collections/presentation/widgets/pull_requests_dialog.dart`
+- Create: `lib/core/utils/open_url.dart` (url_launcher wrapper — code below)
+- Modify: `lib/features/collections/presentation/widgets/branch_chip.dart`
+- Modify: `lib/main.dart` (provide `PullRequestsBloc`)
+- Test: `test/features/collections/presentation/widgets/pull_requests_dialog_test.dart`
+
+**Interfaces:**
+- Consumes: `PullRequestsBloc`, its state/events (Task 6); the branch chip's existing menu.
+- Produces: `PullRequestsDialog.show(BuildContext context, {required String root})`.
+
+Behaviour: on open, dispatch `LoadPullRequests(root)`. Render one of:
+**notInstalled** → message `GitHub CLI (gh) not found` + `INSTALL GH` button
+opening `https://cli.github.com` in the browser; **notAuthenticated** →
+`Sign in with the GitHub CLI` + a hint to run `gh auth login`; **available** →
+a `REFRESH` button, `CREATE PULL REQUEST…`, and the list (`No open pull
+requests.` when empty). Each PR row shows `#<n>`, title, a draft tag if draft,
+a state dot, a checks glyph (`context.appPalette` for colours — reuse
+`statusColor`/`colorScheme` tones, never `Colors.*`), and opens its url via the
+browser on tap. `CREATE PULL REQUEST…` opens a form (base picker defaulting to
+`service.defaultBase`, `PR TITLE`, `PR body (optional)`, `Create as draft`
+toggle) that dispatches `CreatePullRequest`. A `PrStatus.error` shows a
+`GIT ERROR`-style dialog. After a create that pushed, nudge the chip: dispatch
+`LoadBranchStatus(root)` on `GitSyncBloc` (read from context — both blocs are in
+scope under the collections header).
+
+**URL opening:** the repo already depends on `url_launcher` (see
+`lib/features/tabs/presentation/widgets/response/viewers/html_open_external_io.dart`).
+Add a small cross-platform helper `lib/core/utils/open_url.dart` — no `dart:io`,
+so no `*_io.dart` gate (`url_launcher` is cross-platform):
+
+```dart
+import 'package:url_launcher/url_launcher.dart';
+
+/// Opens [url] in the system browser. Returns false (never throws) when the
+/// url is malformed or no handler is available — callers show a snackbar.
+Future<bool> openUrl(String url) async {
+  final uri = Uri.tryParse(url);
+  if (uri == null) return false;
+  try {
+    return await launchUrl(uri, mode: LaunchMode.externalApplication);
+  } on Object {
+    return false;
+  }
+}
+```
+
+- [ ] **Step 1: Write the dialog widget tests**
+
+Create
+`test/features/collections/presentation/widgets/pull_requests_dialog_test.dart`
+with, at minimum, these `testWidgets` (blocs built INSIDE each body; theme
+provided):
+
+```dart
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/core/theme/themes/brutalist/brutalist_theme.dart';
+import 'package:getman/features/collections/domain/entities/pull_request.dart';
+import 'package:getman/features/collections/presentation/bloc/pull_requests_bloc.dart';
+import 'package:getman/features/collections/presentation/bloc/pull_requests_event.dart';
+import 'package:getman/features/collections/presentation/bloc/pull_requests_state.dart';
+import 'package:getman/features/collections/presentation/widgets/pull_requests_dialog.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockBloc extends MockBloc<PullRequestsEvent, PullRequestsState>
+    implements PullRequestsBloc {}
+
+void main() {
+  const root = '/ws';
+
+  Widget host(_MockBloc bloc) => MaterialApp(
+    theme: brutalistTheme(Brightness.light),
+    home: Scaffold(
+      body: BlocProvider<PullRequestsBloc>.value(
+        value: bloc,
+        child: Builder(
+          builder: (context) => TextButton(
+            onPressed: () => PullRequestsDialog.show(context, root: root),
+            child: const Text('open'),
+          ),
+        ),
+      ),
+    ),
+  );
+
+  testWidgets('notInstalled shows the install prompt', (tester) async {
+    final bloc = _MockBloc();
+    when(() => bloc.state).thenReturn(
+      const PullRequestsState(
+        status: PrStatus.ready,
+        availability: GhAvailability.notInstalled,
+      ),
+    );
+    await tester.pumpWidget(host(bloc));
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('gh'), findsWidgets);
+    expect(find.text('INSTALL GH'), findsOneWidget);
+  });
+
+  testWidgets('a ready list renders a PR row', (tester) async {
+    final bloc = _MockBloc();
+    when(() => bloc.state).thenReturn(
+      const PullRequestsState(
+        status: PrStatus.ready,
+        availability: GhAvailability.available,
+        prs: [
+          PullRequestEntity(
+            number: 42,
+            title: 'feat: thing',
+            state: PrState.open,
+            url: 'https://github.com/o/r/pull/42',
+            isDraft: false,
+            checks: PrChecks.passing,
+          ),
+        ],
+      ),
+    );
+    await tester.pumpWidget(host(bloc));
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('42'), findsWidgets);
+    expect(find.text('feat: thing'), findsOneWidget);
+    expect(find.text('CREATE PULL REQUEST…'), findsOneWidget);
+  });
+
+  testWidgets('empty ready list shows the empty message', (tester) async {
+    final bloc = _MockBloc();
+    when(() => bloc.state).thenReturn(
+      const PullRequestsState(
+        status: PrStatus.ready,
+        availability: GhAvailability.available,
+      ),
+    );
+    await tester.pumpWidget(host(bloc));
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('No open pull requests.'), findsOneWidget);
+  });
+}
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `fvm flutter test test/features/collections/presentation/widgets/pull_requests_dialog_test.dart`
+Expected: FAIL — `PullRequestsDialog` undefined.
+
+- [ ] **Step 3: Implement the dialog**
+
+Create `lib/features/collections/presentation/widgets/pull_requests_dialog.dart`.
+Structure (read theme tokens via `context.appLayout` / `context.appTypography` /
+`context.appPalette`; no hardcoded sizes/colours; wrap async dialog/browser
+calls in `unawaited`; capture the bloc before any async gap):
+
+- `static Future<void> show(BuildContext, {required String root})` →
+  `showDialog` wrapping a `ResponsiveDialog` whose body is a
+  `BlocConsumer<PullRequestsBloc, PullRequestsState>` (listener routes
+  `PrStatus.error` → a `GIT ERROR` AlertDialog like `branch_chip.dart` does;
+  builder switches on `state.availability` / `state.status`). Dispatch
+  `LoadPullRequests(root)` from a `StatefulWidget` `initState` (so it fires once
+  on open), mirroring `review_changes_button.dart`.
+- **notInstalled** view: a column with the `GitHub CLI (gh) not found` text and
+  an `INSTALL GH` button that opens `https://cli.github.com` (via the URL
+  helper — see the implementer note above).
+- **notAuthenticated** view: `Sign in with the GitHub CLI` + `Run: gh auth
+  login` hint text, plus a `REFRESH` button dispatching `LoadPullRequests`.
+- **available** view: a header `Row` with `REFRESH` and `CREATE PULL REQUEST…`,
+  then the list (`ListView` of PR rows or `No open pull requests.`). Each row:
+  `#<number>` + title + optional `DRAFT` tag + a state/checks indicator, tapping
+  opens `pr.url`. Disable `REFRESH`/`CREATE` while `state.isBusy`.
+- **create form:** a second `showDialog` (`_CreatePrForm`) with a base
+  `DropdownButton` (seeded from `LoadBranchStatus`/`GitSyncBloc` branches or a
+  fetched `defaultBase`; simplest v1: a `TextFormField` prefilled with the
+  default base string), a `PR TITLE` field (prefill from the branch's last
+  commit is optional — leave blank is fine), a `PR body (optional)` field, and a
+  `Create as draft` `SwitchListTile`. `CREATE` dispatches
+  `CreatePullRequest(root, base:…, title:…, body:…, draft:…)` on the captured
+  bloc, then pops. After the create resolves (`lastCreated` changes), the outer
+  listener shows a snackbar `PR #<n> opened` with an `OPEN IN BROWSER` action,
+  and nudges the chip by `context.read<GitSyncBloc>().add(LoadBranchStatus(root))`.
+
+Keep the widget focused; extract `_PrRow`, `_InstallPrompt`, `_AuthPrompt`,
+`_CreatePrForm` as private widgets in the same file.
+
+- [ ] **Step 4: Wire the branch-chip menu item**
+
+In `lib/features/collections/presentation/widgets/branch_chip.dart`, add a
+`PopupMenuItem<String>` with `value: 'prs'` and child `Text('PULL REQUESTS…')`
+after the `stashes` item, and in `_onSelected` add:
+
+```dart
+      case 'prs':
+        unawaited(PullRequestsDialog.show(context, root: root));
+```
+
+Add the import
+`import 'package:getman/features/collections/presentation/widgets/pull_requests_dialog.dart';`
+and `import 'dart:async';` (for `unawaited`) if not present.
+
+- [ ] **Step 5: Provide the bloc in main.dart**
+
+In `lib/main.dart`, add to the `MultiBlocProvider` (near `GitSyncBloc`):
+
+```dart
+        BlocProvider(create: (_) => di.sl<PullRequestsBloc>()),
+```
+
+with the import. (The dialog is opened from the chip, which lives under this
+provider — so `context.read<PullRequestsBloc>()` resolves.)
+
+- [ ] **Step 6: Run the dialog tests + the collections/home suites**
+
+Run: `fvm flutter test test/features/collections test/features/home`
+Expected: PASS. If any collections/side-menu host that builds the header now
+needs a `PullRequestsBloc` provider, add a `MockPullRequestsBloc` exactly as the
+`GitSyncBloc`/`ReviewBloc` providers were added — but note the chip only reads
+`PullRequestsBloc` when the menu item is tapped, so a host that never taps
+`PULL REQUESTS…` and uses a null workspace path will not need it (verify).
+
+- [ ] **Step 7: Gate + commit**
+
+```bash
+fvm dart format lib test && fvm flutter analyze && fvm dart run custom_lint
+fvm dart run bloc_tools:bloc lint lib < /dev/null
+git add lib/features/collections/presentation/widgets/pull_requests_dialog.dart \
+        lib/features/collections/presentation/widgets/branch_chip.dart \
+        lib/main.dart \
+        test/features/collections/presentation/widgets/pull_requests_dialog_test.dart
+git commit -m "feat(git): pull requests dialog + branch-chip menu entry"
+```
+
+---
+
+## Task 8: Full gate + wiki
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-07-14-git-pr-integration.md` (tick boxes)
+- External: the `Getman.wiki.git` repo — **Version Control** page
+
+- [ ] **Step 1: Run the complete verification bar**
+
+```bash
+fvm dart format lib test tools
+fvm flutter analyze
+fvm dart run custom_lint
+( cd tools/getman_lints/example && fvm dart run custom_lint )
+fvm dart run bloc_tools:bloc lint lib < /dev/null
+fvm flutter test
+```
+
+Expected: **0 issues from every pass and 100% green tests.** These are separate
+processes — a clean `flutter analyze` does not imply custom_lint or bloc_lint.
+
+- [ ] **Step 2: Update the wiki**
+
+Clone `https://github.com/thiagomiranda3/Getman.wiki.git` (push over SSH:
+`git remote set-url origin git@github.com:thiagomiranda3/Getman.wiki.git`).
+Add a **Pull requests** section to `Version-Control.md`, with verbatim UI labels:
+
+- Reached from the branch chip → **PULL REQUESTS…**.
+- Uses the **GitHub CLI (`gh`)** — install it (link `cli.github.com`) and run
+  `gh auth login`; **Getman stores no credentials.**
+- The dialog lists **open** PRs with state + checks; a row opens it in the
+  browser; **REFRESH** re-reads.
+- **CREATE PULL REQUEST…**: base branch, **PR TITLE**, body, **Create as draft**.
+  Creating pushes the branch first (setting upstream), then opens the PR.
+- Desktop-only; requires `git` and `gh` on your PATH.
+
+Commit and push (default branch `master`).
+
+- [ ] **Step 3: Commit the ticked plan**
+
+```bash
+git add docs/superpowers/plans/2026-07-14-git-pr-integration.md
+git commit -m "docs(git): tick off the Spec C implementation plan"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** create PRs (Tasks 3,5,7) · list open PRs + state + checks
+  (Tasks 2,5,7) · gh transport, no creds (Tasks 1–3) · push-then-create (Task 5)
+  · gh-missing install prompt + gh-unauth prompt (Tasks 5,7) · branch-chip entry
+  (Task 7) · draft toggle (Tasks 3,7) · web-gating (stub Task 1, kIsWeb inherited
+  via the chip's own gate) · wiki (Task 8).
+- **Ordering:** Task 7 uses `PullRequestsDialog`; the chip edit is in the same
+  task, so no cross-task compile gap. Task 5 depends on Spec B's
+  `BranchService.push`.
+- **Naming consistency:** core `PullRequestInfo{number,title,state:String,url,
+  isDraft,checks:String}` → domain `PullRequestEntity{…,state:PrState,
+  checks:PrChecks}` via `GhPullRequestService._toEntity`; `createPr`→`String`
+  (url) → domain `PullRequestRef{number,url}`; enums `PrState`/`PrChecks`/
+  `GhAvailability`/`PrStatus` each defined once.
+- **Non-vacuity reminder:** the push-then-create ordering test (Task 5) uses a
+  Completer gate, not a bare `thenAnswer((_) async {})` — the Spec B lesson that
+  a sync-until-first-await stub satisfies `verifyInOrder` vacuously.

--- a/docs/superpowers/plans/2026-07-15-git-conflict-resolution.md
+++ b/docs/superpowers/plans/2026-07-15-git-conflict-resolution.md
@@ -1,0 +1,481 @@
+# Git Semantic Conflict Resolution — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve `git pull --rebase` conflicts inside Getman field-by-field (3-way auto-merge, prompt only on true overlaps), plus auto-fetch + a manual FETCH action.
+
+**Architecture:** Same three layers as Specs A/B/C. Core `GitService` gains conflict + fetch primitives (sole `dart:io` boundary, web-stubbed). A pure `ThreeWayMerge` engine + `ConflictService` abstraction in domain. `GitConflictService` (data) composes `GitService` + the existing `WorkspaceCollectionSerializer`. `ConflictBloc` + `ConflictResolutionDialog` in presentation, driven from the pull flow. Fetch rides on `GitSyncBloc` + a `BranchChip` timer.
+
+**Tech Stack:** Flutter, flutter_bloc, get_it, equatable, mocktail, bloc_test. `fvm flutter ...` / `fvm dart ...` always.
+
+## Global Constraints
+
+- **fvm always:** `fvm flutter analyze`, `fvm dart run custom_lint`, `fvm dart run bloc_tools:bloc lint lib < /dev/null`, `( cd tools/getman_lints/example && fvm dart run custom_lint )`, `fvm dart format lib test tools`, `fvm flutter test` — all clean before a task is done.
+- **Commits** authored `thiago.cortez81@gmail.com` + `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`. No Claude Code mention in PR bodies.
+- **No credentials stored; git config never edited.** All `dart:io` + git in `*_io.dart`; web stubs. Desktop-only (`kIsWeb` gates).
+- **Domain has zero infrastructure imports** (`domain_no_infrastructure_imports`); **blocs depend only on abstractions** (`bloc_depends_on_abstractions`); **no `sl<T>()` in widgets**; **no bloc→bloc coupling** (cross-bloc coordination in a widget); **Equatable props complete**.
+- **Non-interactive git:** `Process.run` with stdin closed; `rebase --continue` runs with `GIT_EDITOR=true` so it never opens an editor.
+- **Rebase ours/theirs are swapped vs a merge:** stage `:2` = **Incoming** (upstream), `:3` = **Yours** (your replayed commit). The engine and UI must respect this.
+
+---
+
+## File Structure
+
+- `lib/core/git/git_service.dart` — extend abstract surface + `PullOutcome`.
+- `lib/core/git/git_service_io.dart` — implement primitives (dart:io).
+- `lib/core/git/git_service_stub.dart` — web no-ops.
+- `lib/features/collections/domain/logic/three_way_merge.dart` — pure merge engine (NEW).
+- `lib/features/collections/domain/entities/file_conflict.dart` — conflict entities (NEW).
+- `lib/features/collections/domain/conflict_service.dart` — abstraction (NEW).
+- `lib/features/collections/data/services/git_conflict_service.dart` — impl (NEW).
+- `lib/features/collections/domain/branch_service.dart` + `data/services/git_branch_service.dart` — add `fetch`.
+- `lib/features/collections/presentation/bloc/conflict_bloc.dart` / `_event.dart` / `_state.dart` (NEW).
+- `lib/features/collections/presentation/bloc/git_sync_event.dart` — add `FetchRemote`.
+- `lib/features/collections/presentation/bloc/git_sync_bloc.dart` — handle `FetchRemote`; pull returns outcome.
+- `lib/features/collections/presentation/widgets/conflict_resolution_dialog.dart` (NEW).
+- `lib/features/collections/presentation/widgets/branch_chip.dart` — FETCH menu item + auto-fetch timer + open resolver on conflicted pull.
+- `lib/core/di/injection_container.dart` + `lib/main.dart` — register `ConflictService` + `ConflictBloc`.
+
+---
+
+## Task 1: GitService — conflict + fetch primitives, `PullOutcome`
+
+**Files:**
+- Modify: `lib/core/git/git_service.dart`, `git_service_io.dart`, `git_service_stub.dart`
+- Test: `test/core/git/git_conflict_primitives_io_test.dart`
+
+**Interfaces produced (add to abstract `GitService`):**
+```dart
+/// The result of a rebase-pull: it either fast-forwarded/rebased cleanly, or it
+/// stopped on conflicts that are now sitting in the index for resolution.
+enum PullOutcome { clean, conflicted }
+
+Future<PullOutcome> pull(String root); // CHANGED from Future<void>
+Future<bool> isRebaseInProgress(String root);
+Future<List<String>> conflictedPaths(String root);
+/// Content of [path] at merge stage [stage] (1=base, 2=ours/incoming, 3=theirs/yours),
+/// or null when that stage is absent (e.g. add/add has no base).
+Future<String?> showStage(String root, String path, int stage);
+Future<void> writeWorkingFile(String root, String path, String content);
+Future<void> add(String root, String path);
+Future<void> rebaseContinue(String root);
+Future<void> rebaseAbort(String root);
+Future<void> fetch(String root);
+```
+
+- [ ] **Step 1: Write the failing io test** — `test/core/git/git_conflict_primitives_io_test.dart`, `@TestOn('vm')`. Skip when git is absent (mirror `gh_service_io_test.dart`). Script a real conflicting rebase in a temp repo and assert the primitives:
+```dart
+@TestOn('vm')
+library;
+
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/core/git/git_service.dart';
+
+void main() {
+  late GitService git;
+  late Directory tmp;
+
+  Future<bool> gitPresent() async => git.isAvailable();
+  Future<void> run(String dir, List<String> args) async {
+    final r = await Process.run('git', args, workingDirectory: dir);
+    if (r.exitCode != 0) throw Exception('git ${args.join(' ')}: ${r.stderr}');
+  }
+
+  setUp(() async {
+    git = createGitService();
+    tmp = await Directory.systemTemp.createTemp('getman_conflict');
+  });
+  tearDown(() async {
+    if (tmp.existsSync()) await tmp.delete(recursive: true);
+  });
+
+  test('a conflicting rebase exposes stages, resolves, and continues', () async {
+    if (!await gitPresent()) return; // skip when git is absent
+    final root = tmp.path;
+    await run(root, ['init', '-b', 'main']);
+    await run(root, ['config', 'user.email', 't@t.co']);
+    await run(root, ['config', 'user.name', 't']);
+    final f = File('$root/a.req.json')..writeAsStringSync('{"v":0}\n');
+    await run(root, ['add', '.']);
+    await run(root, ['commit', '-m', 'base']);
+    // upstream commit
+    f.writeAsStringSync('{"v":1}\n');
+    await run(root, ['commit', '-am', 'upstream']);
+    await run(root, ['branch', 'feature', 'HEAD~1']);
+    await run(root, ['switch', 'feature']);
+    f.writeAsStringSync('{"v":2}\n');
+    await run(root, ['commit', '-am', 'yours']);
+    // rebase feature onto main → conflict
+    final r = await Process.run('git', ['rebase', 'main'], workingDirectory: root);
+    expect(r.exitCode, isNot(0));
+
+    expect(await git.isRebaseInProgress(root), isTrue);
+    expect(await git.conflictedPaths(root), contains('a.req.json'));
+    expect(await git.showStage(root, 'a.req.json', 1), contains('"v":0'));
+    expect(await git.showStage(root, 'a.req.json', 2), contains('"v":1')); // incoming (main)
+    expect(await git.showStage(root, 'a.req.json', 3), contains('"v":2')); // yours
+
+    await git.writeWorkingFile(root, 'a.req.json', '{"v":9}\n');
+    await git.add(root, 'a.req.json');
+    await git.rebaseContinue(root);
+    expect(await git.isRebaseInProgress(root), isFalse);
+    expect(File('$root/a.req.json').readAsStringSync(), contains('"v":9'));
+  });
+
+  test('rebaseAbort restores the pre-rebase tree', () async {
+    if (!await gitPresent()) return;
+    // ... (same setup to the conflicted state) ...
+    // await git.rebaseAbort(root); expect isRebaseInProgress false.
+  });
+}
+```
+- [ ] **Step 2: Run, verify fail** — `fvm flutter test test/core/git/git_conflict_primitives_io_test.dart` → FAIL (methods undefined). (If git is absent the tests early-return; implement anyway.)
+- [ ] **Step 3: Implement in `git_service_io.dart`.** Add a stdin-closed, editor-disabled runner for rebase-continue:
+```dart
+@override
+Future<PullOutcome> pull(String root) async {
+  final r = await _run(root, ['pull', '--rebase'], allowFailure: true);
+  if (r.exitCode == 0) return PullOutcome.clean;
+  if (await isRebaseInProgress(root) && (await conflictedPaths(root)).isNotEmpty) {
+    return PullOutcome.conflicted; // leave paused for the resolver
+  }
+  // Not a resolvable conflict (auth/network/local changes) — restore + throw.
+  await _run(root, ['rebase', '--abort'], allowFailure: true);
+  final err = (r.stderr as String).trim();
+  throw GitException(err.isEmpty ? 'git pull failed' : err, exitCode: r.exitCode);
+}
+
+@override
+Future<bool> isRebaseInProgress(String root) async {
+  final r = await _run(root, ['rev-parse', '--git-path', 'rebase-merge'],
+      allowFailure: true);
+  final merge = (r.stdout as String).trim();
+  if (merge.isNotEmpty && Directory('$root/$merge').existsSync()) return true;
+  final r2 = await _run(root, ['rev-parse', '--git-path', 'rebase-apply'],
+      allowFailure: true);
+  final apply = (r2.stdout as String).trim();
+  return apply.isNotEmpty && Directory('$root/$apply').existsSync();
+}
+
+@override
+Future<List<String>> conflictedPaths(String root) async {
+  final r = await _run(root, ['diff', '--name-only', '--diff-filter=U']);
+  return (r.stdout as String).split('\n').map((l) => l.trim())
+      .where((l) => l.isNotEmpty).toList();
+}
+
+@override
+Future<String?> showStage(String root, String path, int stage) async {
+  final r = await _run(root, ['show', ':$stage:$path'], allowFailure: true);
+  return r.exitCode == 0 ? r.stdout as String : null;
+}
+
+@override
+Future<void> writeWorkingFile(String root, String path, String content) async {
+  final file = File('$root/$path');
+  await file.parent.create(recursive: true);
+  await file.writeAsString(content);
+}
+
+@override
+Future<void> add(String root, String path) => _run(root, ['add', path]);
+
+@override
+Future<void> rebaseContinue(String root) async {
+  // GIT_EDITOR=true so a commit-message step never blocks on an editor.
+  final r = await Process.run('git', ['rebase', '--continue'],
+      workingDirectory: root, stdoutEncoding: utf8, stderrEncoding: utf8,
+      environment: {'GIT_EDITOR': 'true'});
+  if (r.exitCode != 0) {
+    throw GitException((r.stderr as String).trim().isEmpty
+        ? 'git rebase --continue failed' : (r.stderr as String).trim(),
+        exitCode: r.exitCode);
+  }
+}
+
+@override
+Future<void> rebaseAbort(String root) => _run(root, ['rebase', '--abort']);
+
+@override
+Future<void> fetch(String root) => _run(root, ['fetch']);
+```
+- [ ] **Step 4: Stub in `git_service_stub.dart`** — `pull` → `PullOutcome.clean`; `isRebaseInProgress` → false; `conflictedPaths` → `const []`; `showStage` → null; `writeWorkingFile`/`add`/`rebaseContinue`/`rebaseAbort`/`fetch` → no-op `async {}`.
+- [ ] **Step 5: Run, verify green** — the io test passes (or skips when git absent). Also update any existing caller of `pull` for the new return type (Task 4 fixes `GitBranchService`).
+- [ ] **Step 6: Gate + commit** — analyze/custom_lint/format/test; `feat(git): GitService conflict + fetch primitives`.
+
+---
+
+## Task 2: `ThreeWayMerge` — the pure field-level merge engine
+
+**Files:**
+- Create: `lib/features/collections/domain/logic/three_way_merge.dart`
+- Test: `test/features/collections/domain/logic/three_way_merge_test.dart`
+
+**Interfaces produced:**
+```dart
+enum FieldConflictKind { scalar, mapEntry, opaque, list }
+
+class FieldConflict extends Equatable {           // one unresolved field
+  const FieldConflict({required this.field, required this.kind,
+    this.incoming, this.yours});
+  final String field;          // e.g. "url", "header 'X-Token'", "authentication"
+  final FieldConflictKind kind;
+  final String? incoming;      // null = opaque (auth/form) — no value shown
+  final String? yours;
+}
+
+class NodeMergeResult {
+  const NodeMergeResult({required this.merged, required this.conflicts});
+  final CollectionNodeEntity merged;    // auto-merged fields applied; conflicts left = incoming
+  final List<FieldConflict> conflicts;  // empty => fully auto-resolved
+}
+
+class ThreeWayMerge {
+  const ThreeWayMerge._();
+  /// [base]/[incoming]/[yours] are request leaves (isFolder=false). Any may be null.
+  static NodeMergeResult mergeRequest(CollectionNodeEntity? base,
+      CollectionNodeEntity? incoming, CollectionNodeEntity? yours);
+  /// Folder nodes; [childOrderX] are the persisted childOrder lists.
+  static NodeMergeResult mergeFolder(
+      CollectionNodeEntity? base, List<String> baseOrder,
+      CollectionNodeEntity? incoming, List<String> incomingOrder,
+      CollectionNodeEntity? yours, List<String> yoursOrder);
+}
+```
+
+**Per-field rule (private helpers):**
+- `_pick3(b, i, y)`: if `i == y` → value `i`, no conflict. If `i == b` → auto-merge `y`. If `y == b` → auto-merge `i`. Else → **conflict** (candidates `i`/`y`).
+- Scalars: `method, url, bodyType.wire, body, graphqlVariables, bodyFilePath` (config); `name, isFavorite` (leaf). Build the merged config from the auto-merged sides; unresolved scalars are left at `incoming` in `merged` and reported as `FieldConflict(kind: scalar)`.
+- Maps (`headers`, folder `variables`): per key over `{...base, ...incoming, ...yours}.keys` → `_pick3(base[k], incoming[k], yours[k])`; a conflicting key → `FieldConflict(field: "header '$k'", kind: mapEntry)`.
+- `auth`: opaque — if `!mapEq(incoming.auth, yours.auth)` and both differ from base → `FieldConflict(field: 'authentication', kind: opaque, incoming: null, yours: null)`; else auto-merge the side that changed.
+- `formFields`: list — same opaque/whole-field rule (`kind: list`, values null).
+- Folder `childOrder`: treat as a scalar over the joined string (`FieldConflict(field: 'child order', kind: scalar, incoming: order.join(', '), yours: ...)`).
+
+- [ ] **Step 1: Write the failing tests.** Cover:
+  - non-overlapping scalars auto-merge (incoming changed url, yours changed method → 0 conflicts, merged has both).
+  - true scalar overlap (both changed url differently → 1 conflict).
+  - map: different keys auto-merge; same key/diff value conflicts.
+  - auth opaque conflict has null values.
+  - add/add (base null) both-parseable → conflicts on differing fields, no crash.
+  - zero-true-conflict file → `conflicts.isEmpty` and `merged` carries both sides' changes.
+```dart
+test('non-overlapping scalar edits auto-merge with no conflict', () {
+  final base = _leaf(url: 'a', method: 'GET');
+  final incoming = _leaf(url: 'b', method: 'GET');   // changed url
+  final yours = _leaf(url: 'a', method: 'POST');     // changed method
+  final r = ThreeWayMerge.mergeRequest(base, incoming, yours);
+  expect(r.conflicts, isEmpty);
+  expect(r.merged.config!.url, 'b');
+  expect(r.merged.config!.method, 'POST');
+});
+test('a true url overlap is one conflict', () {
+  final r = ThreeWayMerge.mergeRequest(
+    _leaf(url: 'a'), _leaf(url: 'b'), _leaf(url: 'c'));
+  expect(r.conflicts.map((c) => c.field), ['url']);
+  expect(r.conflicts.single.incoming, 'b');
+  expect(r.conflicts.single.yours, 'c');
+});
+// ...map per-key, auth opaque, add/add, folder childOrder...
+```
+- [ ] **Step 2: Run, verify fail.** `fvm flutter test .../three_way_merge_test.dart` → FAIL (undefined).
+- [ ] **Step 3: Implement `three_way_merge.dart`** per the rules above. Pure Dart + equatable + collection (`MapEquality`/`ListEquality`) only — no Flutter/dio/hive imports (domain rule).
+- [ ] **Step 4: Run, verify green.**
+- [ ] **Step 5: Gate + commit** — `feat(collections): ThreeWayMerge field-level merge engine`.
+
+---
+
+## Task 3: Domain — `FileConflict` entities + `ConflictService` abstraction
+
+**Files:**
+- Create: `lib/features/collections/domain/entities/file_conflict.dart`, `lib/features/collections/domain/conflict_service.dart`
+- Test: `test/features/collections/domain/entities/file_conflict_test.dart`
+
+**Interfaces produced:**
+```dart
+// file_conflict.dart
+enum ConflictKind { request, folder, addAdd, deleteModify, structural }
+
+class FileConflict extends Equatable {
+  const FileConflict({required this.path, required this.kind, this.node});
+  final String path;
+  final ConflictKind kind;
+  final NodeMergeResult? node;   // present for request/folder (field-level); null for coarse
+  bool get isFieldLevel => node != null;
+  @override List<Object?> get props => [path, kind]; // node compared by identity is fine
+}
+
+/// One user decision. For field-level: a map of field-label → chosen value
+/// (an edited string, or the picked incoming/yours). For coarse: a whole-file side.
+enum FileSide { incoming, yours }
+class FileResolution extends Equatable {
+  const FileResolution({required this.path, this.fieldChoices = const {},
+    this.wholeFile});
+  final String path;
+  final Map<String, String> fieldChoices;   // field-label → resolved string value
+  final FileSide? wholeFile;                 // set for coarse/structural files
+  @override List<Object?> get props => [path, fieldChoices, wholeFile];
+}
+
+enum RebaseStep { done, moreConflicts }
+
+// conflict_service.dart
+abstract class ConflictService {
+  Future<PullOutcome> pullOrConflict(String root);   // rides GitService.pull
+  Future<List<FileConflict>> currentConflicts(String root);
+  Future<void> resolve(String root, List<FileResolution> resolutions);
+  Future<RebaseStep> continueRebase(String root);
+  Future<void> abort(String root);
+  Future<void> fetch(String root);
+}
+```
+- [ ] **Step 1: Write the failing test** — equality of `FileConflict`/`FileResolution` by value.
+- [ ] **Step 2/3/4:** run-fail → implement → run-green.
+- [ ] **Step 5: Gate + commit** — `feat(collections): FileConflict entities + ConflictService`.
+
+---
+
+## Task 4: Data — `GitConflictService` + `BranchService.fetch` + DI
+
+**Files:**
+- Create: `lib/features/collections/data/services/git_conflict_service.dart`
+- Modify: `lib/features/collections/domain/branch_service.dart` (+ `fetch`), `data/services/git_branch_service.dart`, `lib/core/di/injection_container.dart`
+- Test: `test/features/collections/data/services/git_conflict_service_test.dart`
+
+**Interfaces consumed:** `GitService` (Task 1), `ThreeWayMerge` (Task 2), `ConflictService`+entities (Task 3), `WorkspaceCollectionSerializer` (existing).
+
+Key logic:
+```dart
+class GitConflictService implements ConflictService {
+  GitConflictService(this._git);
+  final GitService _git;
+
+  @override
+  Future<PullOutcome> pullOrConflict(String root) => _git.pull(root);
+
+  @override
+  Future<RebaseStep> continueRebase(String root) async {
+    await _git.rebaseContinue(root);
+    return await _git.isRebaseInProgress(root)
+        ? RebaseStep.moreConflicts : RebaseStep.done;
+  }
+
+  @override
+  Future<void> abort(String root) => _git.rebaseAbort(root);
+  @override
+  Future<void> fetch(String root) => _git.fetch(root);
+
+  @override
+  Future<List<FileConflict>> currentConflicts(String root) async {
+    final paths = await _git.conflictedPaths(root);
+    return [for (final p in paths) await _classify(root, p)];
+  }
+
+  Future<FileConflict> _classify(String root, String path) async {
+    final s1 = await _git.showStage(root, path, 1);
+    final s2 = await _git.showStage(root, path, 2); // incoming
+    final s3 = await _git.showStage(root, path, 3); // yours
+    if (path.endsWith('.req.json')) {
+      // delete/modify: one side stage missing
+      if (s2 == null || s3 == null) {
+        return FileConflict(path: path, kind: ConflictKind.deleteModify);
+      }
+      final base = _leafOrNull(s1), inc = _leafOrNull(s2), you = _leafOrNull(s3);
+      if (inc == null || you == null) {
+        return FileConflict(path: path, kind: ConflictKind.structural); // unparseable
+      }
+      final node = ThreeWayMerge.mergeRequest(base, inc, you);
+      return FileConflict(path: path,
+        kind: s1 == null ? ConflictKind.addAdd : ConflictKind.request, node: node);
+    }
+    if (path.endsWith('.folder.json')) { /* symmetric with mergeFolder */ }
+    return FileConflict(path: path, kind: ConflictKind.structural); // workspace.json etc.
+  }
+
+  @override
+  Future<void> resolve(String root, List<FileResolution> resolutions) async {
+    for (final res in resolutions) {
+      final content = await _resolvedContent(root, res); // apply picks → JSON string
+      await _git.writeWorkingFile(root, res.path, content);
+      await _git.add(root, res.path);
+    }
+  }
+  // _resolvedContent: coarse → showStage(incoming|yours); field-level → rebuild the
+  // merged node applying res.fieldChoices, serialize via WorkspaceCollectionSerializer.
+}
+```
+`BranchService.fetch(String root)` → `GitBranchService`: **no** `_runOnTree` (fetch never touches the working tree), just `_git.fetch(root)`. Register `ConflictService` in DI: `sl.registerLazySingleton<ConflictService>(() => GitConflictService(sl()))`.
+
+- [ ] Steps: failing tests (mock `GitService`: classify req/folder/deleteModify/structural; resolve writes merged JSON + adds; continueRebase maps `isRebaseInProgress`) → run-fail → implement → green → gate → commit `feat(collections): GitConflictService + BranchService.fetch + DI`.
+
+---
+
+## Task 5: `ConflictBloc` (+ event/state) + DI
+
+**Files:**
+- Create: `lib/features/collections/presentation/bloc/conflict_bloc.dart` / `_event.dart` / `_state.dart`
+- Modify: `lib/core/di/injection_container.dart`
+- Test: `test/features/collections/presentation/bloc/conflict_bloc_test.dart`
+
+**Interfaces produced:**
+```dart
+// events: LoadConflicts(root) ; ResolveAndContinue(root, List<FileResolution>) ; AbortRebase(root)
+// state:
+enum ConflictStatus { initial, loading, resolving, done, error }
+class ConflictState extends Equatable {
+  const ConflictState({this.status = ConflictStatus.initial,
+    this.conflicts = const [], this.batch = 0, this.errorMessage});
+  final ConflictStatus status;
+  final List<FileConflict> conflicts;  // current batch
+  final int batch;                     // 0-based commit index, for "commit N"
+  final String? errorMessage;
+  bool get isBusy => status == ConflictStatus.loading || status == ConflictStatus.resolving;
+  // copyWith clears errorMessage unless status==error (mirror PullRequestsState).
+}
+```
+Behaviour (mirror `GitSyncBloc`/`PullRequestsBloc` conventions — droppable-while-busy, terminal on every path, `log` via `dart:developer`):
+- `LoadConflicts` → `currentConflicts(root)` → ready with the batch (or `done` if empty).
+- `ResolveAndContinue` → `resolve(root, res)` → `continueRebase(root)` → `moreConflicts` ? reload `currentConflicts` (bump `batch`) : `done`. Any throw → `error` (leave paused).
+- `AbortRebase` → `abort(root)` → `done`.
+
+- [ ] Steps: failing bloc tests (load populates; resolve→continue→done; resolve→continue→moreConflicts loads next batch, **Completer-gated non-vacuous** that the next `currentConflicts` runs only after `continueRebase`; abort→done; error surfaces) → run-fail → implement → green → gate + `feat(collections): ConflictBloc` (bloc_lint must pass).
+
+---
+
+## Task 6: `ConflictResolutionDialog` + pull-flow wiring + fetch UI
+
+**Files:**
+- Create: `lib/features/collections/presentation/widgets/conflict_resolution_dialog.dart`
+- Modify: `branch_chip.dart` (FETCH item + auto-fetch timer + open resolver on conflicted pull), `git_sync_event.dart` (`FetchRemote`), `git_sync_bloc.dart` (`FetchRemote` handler; pull now returns `PullOutcome` and, when conflicted, signals the widget to open the resolver), `lib/main.dart` (provide `ConflictBloc`)
+- Test: `test/features/collections/presentation/widgets/conflict_resolution_dialog_test.dart`
+
+**Dialog** (`ConflictResolutionDialog.show(context, {required String root})`), following `stash_list_dialog.dart` + `pull_requests_dialog.dart` patterns (`showResponsiveDialog` + `ResponsiveDialogScaffold`, blocs re-provided via `.value`, `context.appLayout/appTypography/appPalette` — no hardcoded sizes/colors):
+- `initState` dispatches `LoadConflicts(root)`.
+- Body: header "Resolving conflicts — commit ${batch+1}"; a list of `FileConflict` rows.
+  - Field-level file: expand to its `node.conflicts`; each row shows the field label, **Take Incoming** / **Keep Yours** segmented control (+ an **Edit** affordance for `scalar` kind opening a text field; `body` label → the JSON editor via `createJsonCodeController`). Opaque (`auth`/list) rows show only the two buttons, no values. Auto-merged files (empty `node.conflicts`) render a muted "auto-merged" row (no action).
+  - Coarse file (`addAdd`/`deleteModify`/`structural`): two choices — `deleteModify` labelled **"Keep your edited request" / "Accept the deletion"**; else **Take Incoming / Keep Yours**.
+- Footer: **CANCEL** → `AbortRebase` + close; **RESOLVE & CONTINUE** (enabled only when every conflict has a pick) → build `List<FileResolution>` + dispatch `ResolveAndContinue`.
+- `BlocListener`: `done` → close + snackbar "Conflicts resolved."; `error` → GIT ERROR dialog (leave open); when `moreConflicts` reloads, the list just rebuilds with the next batch.
+
+**Pull-flow wiring:** `GitSyncBloc._onPull` awaits `_service.pull` which now returns `PullOutcome`. On `conflicted`, emit a state flag (add `bool pullConflicted` or reuse a dedicated `GitSyncStatus`); `BranchChip`'s `BlocListener` on that flag opens `ConflictResolutionDialog.show(context, root:)`. (No bloc→bloc: the chip widget holds both blocs.) `BranchService.pull` return type changes to `Future<PullOutcome>`; `GitBranchService.pull` returns `_runOnTree`'s result — adjust `_runOnTree` to be generic `Future<T>` or add a `_runOnTreeValue`.
+
+**Fetch UI:** `FetchRemote(root)` event → `GitSyncBloc._onFetch` = `_run(root, emit, 'fetch', () => _service.fetch(root))` (no `changedDisk`). Branch-chip menu: add `PopupMenuItem(value: 'fetch', enabled: branch.hasRemote, child: Text(branch.hasRemote ? 'FETCH' : 'FETCH — NO REMOTE'))` and `case 'fetch': bloc.add(FetchRemote(root));`. Auto-fetch: in `_BranchChipState`, add a `Timer.periodic(const Duration(minutes: 5), ...)` started in `initState` (guarded by `!kIsWeb`) + one fetch on first workspace resolution; each tick reads root from `SettingsBloc` and, if a remote exists, dispatches `FetchRemote`; cancel the timer in `dispose`. Auto-fetch failures already land in `GitSyncState.errorMessage` — but to avoid a nagging dialog when offline, the chip's error listener should **not** pop a dialog for a fetch failure (gate the existing error listener so only user-initiated ops show the GIT ERROR dialog; simplest: a `bool _userAction` flag set on menu actions, or ignore errors whose op was a fetch by tracking the last dispatched op).
+
+- [ ] Steps: failing widget tests (field row renders Take Incoming/Keep Yours; coarse deleteModify labels; RESOLVE disabled until all picked; CANCEL dispatches AbortRebase; FETCH menu item dispatches FetchRemote; blocs built inside the test body with `brutalistTheme`) → run-fail → implement → green → **full done-bar** → commit `feat(git): conflict resolution dialog + fetch action`.
+
+---
+
+## Task 7: Full gate + wiki + final review
+
+- [ ] **Step 1:** Run the complete done-bar (all six gates) — fix anything.
+- [ ] **Step 2: Wiki** — on the `Version-Control.md` page (Getman.wiki, push over SSH): add a **Resolving conflicts** section (pull pauses on conflict → per-field Take Incoming/Keep Yours → RESOLVE & CONTINUE loops per commit → CANCEL aborts; only open PRs... n/a; describe auto-merge) and a **Fetch** note (auto-fetch keeps ahead/behind fresh; manual **FETCH** in the branch menu). Update "Requirements at a glance" if needed. Commit + push.
+- [ ] **Step 3: Final whole-branch adversarial review** over `git diff <spec-C-head>..HEAD` (exclude docs): the rebase ours/theirs swap, auto-merge correctness, resolve→continue loop can't wedge or lose data, cancel always aborts, non-interactive git (no editor block), auto-fetch swallows offline errors + never auto-pulls, web-safety, layering, test non-vacuity. Fix Critical/Important.
+- [ ] **Step 4:** Update the roadmap memory (Spec D done) + ledger.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** entry flow (T1 pull outcome + T6 wiring), field/file scope (T2 merge + T4 classify), 3-way auto-merge (T2), stage reads (T1), rebase-swap labelling (T2/T6, called out in Global Constraints), fetch auto+manual (T4/T6), structural (T4 classify + T6 coarse rows), error handling (T1 pull throw-on-non-conflict, T5 leave-paused, T6 fetch-error-silent), mirror suspension (reused via `_runOnTree` in T4/existing), testing (each task), wiki (T7). All covered.
+- **Type consistency:** `PullOutcome` (T1) used in T4/T6; `NodeMergeResult`/`FieldConflict` (T2) in T3/T4/T6; `FileConflict`/`FileResolution`/`RebaseStep` (T3) in T4/T5/T6; `ConflictService` methods consistent across T3/T4/T5.
+- **Placeholders:** the folder-classify and `_resolvedContent` bodies are described by rule (symmetric to the request path) rather than fully spelled — the implementer mirrors the request branch; acceptable given the request branch is fully shown.

--- a/docs/superpowers/specs/2026-07-14-git-pr-integration-design.md
+++ b/docs/superpowers/specs/2026-07-14-git-pr-integration-design.md
@@ -1,0 +1,120 @@
+# Spec C — Pull Request Integration (design)
+
+**Status:** approved 2026-07-14. Branch `feat/git-pr-integration` (off Spec B's
+`feat/git-branch-sync`). Third spec in the git-native-collaboration roadmap
+(A = review & commit / PR #50; B = branch & sync / PR #51).
+
+## Goal
+
+Create GitHub pull requests and see the repo's open PRs (state + checks) from
+inside Getman, layered on the git-friendly collections workspace — without the
+app ever storing a credential.
+
+## Decisions
+
+| Decision | Choice | Why |
+|---|---|---|
+| Scope (v1) | Create PRs **and** list open PRs with state + checks | The useful slice; reviewing/merging in-app is out of scope. |
+| Transport / auth | Shell out to the **`gh` CLI** | Rides on the user's existing `gh auth` exactly as we ride on git's credentials — **nothing stored**. Same shell-out + web-stub architecture as `GitService`. `gh --json` is machine-readable and handles enterprise/other hosts transparently. |
+| Unpushed branch | **Push (`-u`), then create** | One action opens a PR even on a never-pushed branch; reuses Spec B's flush-guarded push. |
+| `gh` missing | **Prompt to install** it (link to `cli.github.com`) | Explicit, actionable; no silent failure. |
+| `gh` present but unauthenticated | **Prompt to run `gh auth login`** | Distinct state from "not installed". |
+| Entry point | **PULL REQUESTS…** item in the branch-chip menu → `PullRequestsDialog` | No new header control (the header was just decluttered). |
+| List scope | **Open PRs only** | Focused v1; merged/closed can be a later toggle. |
+| Draft | **"Create as draft" toggle** in the create form (`gh pr create --draft`) | One flag, genuinely useful. |
+| Credentials | **None stored**, git config never edited | Same guarantee as Spec B; `gh` owns auth. |
+| Platform | **Desktop only** (web-stubbed + `kIsWeb`) | `gh` is a desktop binary. |
+
+## Architecture (three layers, mirroring Spec A/B)
+
+### Core — `lib/core/git/`
+`GhService` (abstract) + `gh_service_io.dart` (the only `dart:io` importer;
+shells out to `gh` via `Process.run`, no shell so no injection) +
+`gh_service_stub.dart` (web no-op). Surface:
+
+- `Future<bool> isAvailable()` — `gh --version` exit 0.
+- `Future<bool> isAuthenticated(String root)` — `gh auth status` exit 0.
+- `Future<PullRequestRef> createPr(String root, {required String base, required String title, required String body, required bool draft})` — `gh pr create --base <base> --title <title> --body <body> [--draft]`; parses the returned PR URL/number.
+- `Future<List<PullRequestInfo>> listPrs(String root)` — `gh pr list --state open --json number,title,state,url,isDraft,statusCheckRollup` (one call yields state **and** checks). `statusCheckRollup` is rolled into a simple `PrChecks` verdict: `none` (no checks) / `pending` / `passing` / `failing`.
+- `Future<String?> defaultBranch(String root)` — `gh repo view --json defaultBranchRef -q .defaultBranchRef.name`, for the create form's base default. Falls back to `null` (form then defaults base to the current branch's list).
+
+`PullRequestRef {number, url}` and `PullRequestInfo {number, title, state, url,
+isDraft, checks}` are plain core types (like `AheadBehind` / `StashEntry`).
+
+### Domain — `lib/features/collections/domain/`
+- `entities/pull_request.dart` — `PullRequestEntity {int number, String title, PrState state, String url, bool isDraft, PrChecks checks}` (Equatable); enums `PrState {open, merged, closed}` and `PrChecks {none, pending, passing, failing}`.
+- `pull_request_service.dart` — abstract `PullRequestService`: `availability()` → `GhAvailability {available, notInstalled, notAuthenticated}`, `list(root)`, `create(root, {...})`, `defaultBase(root)`.
+
+### Data — `lib/features/collections/data/services/`
+`GhPullRequestService implements PullRequestService`, composing `GhService` +
+the existing `BranchService`. `create(...)` does: if the branch has no upstream
+(`BranchService`/`GitService` already exposes this), call `BranchService`'s
+flush-guarded push with `setUpstream: true`, **then** `GhService.createPr`. This
+reuses Spec B's mirror-flush guarantee rather than duplicating it — no new race
+surface, because PR creation itself never touches the working tree.
+
+### Presentation — `lib/features/collections/presentation/`
+- `bloc/pull_requests_bloc.dart` (+ event/state) — depends **only** on the
+  `PullRequestService` abstraction (`bloc_depends_on_abstractions`). Events:
+  `LoadPullRequests(root)`, `CreatePullRequest(root, base, title, body, draft)`.
+  State: `{PrLoadStatus status, GhAvailability availability, List<PullRequestEntity> prs, String? errorMessage, PullRequestRef? lastCreated}`. Droppable while busy (like `GitSyncBloc`).
+- `widgets/pull_requests_dialog.dart` — reached via the branch-chip menu. Renders
+  one of: install prompt / auth prompt / the list + REFRESH + CREATE PULL
+  REQUEST…. The create form (base picker, title, body, draft toggle) is a nested
+  view or second dialog. A row opens its PR URL in the browser.
+
+## Flows
+
+**Open the dialog:** branch chip → PULL REQUESTS… → `LoadPullRequests` →
+`availability()` decides which of the three views renders; if ready, `list()`
+populates.
+
+**Create:** fill the form → `CreatePullRequest` → (push if no upstream) →
+`gh pr create` → on success, surface the PR number with an "open in browser"
+action and refresh the list. Any `gh` failure lands in `errorMessage` and a GIT
+ERROR-style dialog (consistent with the branch chip).
+
+**After a create that pushed:** the branch's ahead/behind changed, so the branch
+chip should refresh. The dialog and `GitSyncBloc` are both in scope under the
+collections header, so a widget-layer nudge (dispatch `LoadBranchStatus` on
+`GitSyncBloc`) refreshes the chip — no bloc→bloc coupling.
+
+## Error handling
+
+- `gh` non-zero exit → `GhException` (mirrors `GitException`), message surfaced.
+- Availability is checked before every dialog open, not cached, so installing /
+  authenticating `gh` and reopening the dialog just works.
+- Best-effort browser open: a failure to launch the browser shows a snackbar,
+  never throws.
+
+## Testing
+
+- `GhService` `_io`: parse `createPr` output and `listPrs --json` against
+  captured fixture strings (incl. the `statusCheckRollup` → `PrChecks` mapping
+  for none/pending/passing/failing, and a draft PR). `isAvailable` /
+  `isAuthenticated` gated on real `gh` presence (skip when absent), like the
+  `GitService` tests skip when `git` is absent.
+- `GhPullRequestService`: push-then-create ordering — a mock `BranchService`
+  push must run **before** `GhService.createPr`, and only when there is no
+  upstream (verify non-vacuously with a Completer gate, per the Spec B lesson
+  that a `thenAnswer((_) async {})` stub satisfies `verifyInOrder` vacuously).
+- `PullRequestsBloc`: each availability branch; load populates; create dispatches
+  through the service and refreshes; error surfaces; droppable-while-busy.
+- `PullRequestsDialog`: the three views render; a row opens the URL; CREATE opens
+  the form; blocs built **inside** the test body with a theme provided.
+- Full done-bar (analyze, custom_lint, bloc_lint, fixtures self-test, format,
+  100% tests).
+
+## Out of scope (v1)
+
+Reviewing/approving/merging PRs in-app; comment threads; non-GitHub hosts beyond
+whatever `gh` already supports; listing merged/closed PRs; CI log viewing.
+
+## Hazards / notes
+
+- **Non-interactive shell-out:** `gh` must never be run in a mode that prompts on
+  stdin (e.g. `gh pr create` on a branch with no upstream prompts interactively).
+  We push first precisely to avoid that; all `gh` calls run with stdin closed and
+  are treated as failed if they would block.
+- **Wiki:** the Version Control page (Spec B) gains a "Pull requests" section —
+  part of this spec's final task, per the keep-the-wiki-in-sync mandate.

--- a/docs/superpowers/specs/2026-07-15-git-conflict-resolution-design.md
+++ b/docs/superpowers/specs/2026-07-15-git-conflict-resolution-design.md
@@ -1,0 +1,208 @@
+# Spec D — Semantic Conflict Resolution (design)
+
+**Status:** approved 2026-07-15. Branch `feat/git-conflict-resolution` (off Spec
+C's `feat/git-pr-integration`). Fourth and final spec in the
+git-native-collaboration roadmap (A = review & commit / PR #50; B = branch &
+sync / PR #51; C = PR integration / PR #52).
+
+## Goal
+
+Resolve `git pull --rebase` merge conflicts **inside Getman**, field-by-field,
+on the diff-friendly collections workspace — turning git's whole-file conflict
+into a semantic, per-field merge where non-overlapping edits merge silently. Plus
+keep the remote view fresh with **auto-fetch** and a manual **FETCH** action.
+Built on Spec A's diff engine and Spec B's pull/mirror plumbing. Desktop-only,
+web-gated, **no credentials stored**.
+
+## Why
+
+Today `BranchService.pull` runs `git pull --rebase` and, on any conflict, runs
+`git rebase --abort` and throws — the user is bounced to their own git tool. But
+the workspace is a clean per-request/per-folder JSON tree, so most "conflicts"
+are edits to *different fields* of the same request and can merge automatically;
+only true field overlaps need a human. That semantic merge is the
+differentiator. Auto-fetch closes the loop: you can't decide to pull until you
+know you're behind, and git only learns that on a fetch.
+
+## Decisions
+
+| Decision | Choice | Why |
+|---|---|---|
+| Entry flow | **Pause & resolve inline** | `pull` stops aborting; on conflict it leaves the rebase paused, opens the resolver, and (on resolve) `git add` + `rebase --continue`, looping per commit. Cancel → `rebase --abort` (today's behavior). Most seamless. |
+| Conflict scope | **Field-level for req + folder; file-level for structural** | Both diff functions already exist; structural (add/add, delete/modify, manifest) get a coarse keep-mine/keep-theirs; unmodelable → abort with a clear message. |
+| Merge model | **3-way auto-merge, prompt only on true overlaps** | Read base/ours/theirs (`git show :1/:2/:3`); a field only one side changed auto-merges silently; only both-changed-to-different-values prompts. |
+| 3 versions | **`git show :N:path` per stage**, not conflict-marker parsing | JSON with `<<<<<<<` markers is unparseable; the index stages are clean JSON. |
+| Rebase ours/theirs | **Label by user's mental model** | In a rebase `:2` is upstream, `:3` is your replayed commit — the opposite of a merge. UI says **Incoming** (remote) vs **Yours** (local); never raw ours/theirs. |
+| Fetch | **Auto (timer + on-connect) + manual FETCH action** | Keeps ahead/behind accurate. `git fetch` only — never touches the working tree; collections change only on an explicit PULL. |
+| Credentials | **None stored**, git config never edited | Same guarantee as A/B/C. |
+| Platform | **Desktop only** (web-stubbed + `kIsWeb`) | git is a desktop binary. |
+
+## Architecture (three layers, mirroring A/B/C)
+
+### Core — `lib/core/git/`
+Extend `GitService` (the sole `dart:io` boundary; web-stubbed) with conflict +
+fetch primitives:
+
+- `Future<bool> isRebaseInProgress(String root)` — `.git/rebase-merge` /
+  `rebase-apply` present (via `git status` porcelain v2 / rev-parse).
+- `Future<List<String>> conflictedPaths(String root)` —
+  `git diff --name-only --diff-filter=U`.
+- `Future<String?> showStage(String root, String path, int stage)` —
+  `git show :<stage>:<path>`; null when the stage is absent (add/add has no `:1`).
+- `Future<void> add(String root, String path)` / `rebaseContinue` /
+  `rebaseAbort` — `git add <path>` / `git rebase --continue|--abort`.
+- `Future<void> fetch(String root)` — `git fetch`; updates remote-tracking refs
+  only.
+
+`pull` changes: on a non-zero `git pull --rebase`, if a rebase is in progress
+with conflicted paths, **return a "conflicted" result** instead of aborting +
+throwing; a non-zero pull with *no* conflicts still `rebase --abort`s and throws
+`GitException` (unchanged for auth/network/other failures).
+
+### Domain — `lib/features/collections/`
+- `logic/three_way_merge.dart` — **pure Dart** `ThreeWayMerge` engine. Input:
+  `base`/`incoming`/`yours` entities (any may be null). Output: the auto-merged
+  fields + a list of unresolved `FieldConflict`s (field label, kind, the two
+  candidate values, an `isOpaque` flag for auth). Reuses the field vocabulary of
+  Spec A's `RequestConfigDiff` / `FolderNodeDiff`.
+- `conflict_service.dart` — abstract `ConflictService`: `pullOrConflict(root)`,
+  `currentConflicts(root)` → `List<FileConflict>`, `resolve(root, resolutions)`
+  (write merged files + `git add`), `continueRebase(root)` →
+  `RebaseStep {done | moreConflicts}`, `abort(root)`, `fetch(root)`.
+- Entities: `FileConflict {path, ConflictKind kind, NodeConflict? fields}` where
+  `ConflictKind ∈ {request, folder, addAdd, deleteModify, structural}`;
+  `NodeConflict {List<FieldConflict>, autoMerged entity}`; a resolution is a map
+  of field → chosen side (or an edited value) plus, for structural, a whole-file
+  side.
+
+### Data — `lib/features/collections/data/services/`
+`GitConflictService implements ConflictService`, composing `GitService` (stage
+reads/writes, rebase control, fetch) + the existing `WorkspaceCollectionSerializer`
+(JSON ↔ entity). Classifies each conflicted path by extension + which stages
+exist; parses stages to entities; runs `ThreeWayMerge`; on `resolve`, applies the
+picks, serializes the merged node, writes it, and `git add`s it. A path whose any
+stage fails to parse degrades to a **structural** (file-level) choice — never a
+forced entity write.
+
+### Presentation — `lib/features/collections/presentation/`
+- `bloc/conflict_bloc.dart` (+ event/state) — on the `ConflictService`
+  abstraction only. Drives the resolve→`--continue`→(next batch | done) loop;
+  droppable-while-busy; a terminal state on every path. State carries the current
+  batch of `FileConflict`s, the user's in-progress resolutions, and a
+  commit-progress hint.
+- `widgets/conflict_resolution_dialog.dart` — one row per conflicted file
+  (tagged by kind). Field-level files expand to conflicting-field rows, each with
+  **Take Incoming / Keep Yours / Edit** (auth/form: the two coarse choices only;
+  `body`: the JSON code editor). Structural files show **Take Incoming / Keep
+  Yours**. A file with zero true conflicts shows as **auto-merged** (no action).
+  Header shows "commit N of M". **RESOLVE & CONTINUE** is enabled only when every
+  conflict has a pick; **CANCEL** aborts the rebase.
+
+## Field granularity (the merge engine)
+
+Per field, given `base`/`incoming`/`yours`:
+- `incoming == yours` → take it (agreement).
+- exactly one side differs from `base` → **auto-merge** that side, silently.
+- both differ from `base` to different values → **true conflict**, surfaced.
+
+- **Scalars** (`method`, `url`, `bodyType`, `body`, `bodyFilePath`,
+  `graphqlVariables`; folder `name`, `favorite`) — one row; Take Incoming / Keep
+  Yours / Edit (prefill from either side; `body` uses the JSON editor).
+- **Maps** (`headers`, folder `variables`) — resolved **per key**: different keys
+  auto-merge; same-key/different-value collides.
+- **Auth** — secret/opaque: whole-block Take Incoming / Keep Yours, no values, no
+  editor.
+- **Form fields** — list: whole-field Take Incoming / Keep Yours (no per-item
+  merge in v1 — YAGNI).
+
+A file with no surviving true conflict **auto-resolves and stages with no
+prompt** — the payoff: a git "conflict" that is really two non-overlapping edits
+merges silently.
+
+## Structural conflicts (file granularity)
+
+- **add/add** (both created the path, no `:1`) — Take Incoming / Keep Yours (may
+  still be shown field-level with base=empty since both stages parse).
+- **delete/modify** — framed plainly: **"Keep your edited request"** vs
+  **"Accept the deletion."**
+- **`workspace.json` manifest / any unparseable stage** — Take Incoming / Keep
+  Yours at file level.
+
+## Auto-fetch + manual fetch
+
+- `GitService.fetch` / `BranchService.fetch` / `GitSyncBloc.FetchRemote(root)` —
+  `git fetch` then reload branch status so the chip's ahead/behind refreshes.
+  Never changes the working tree.
+- **Auto**: a widget-layer coordinator in `BranchChip`'s State (alongside the
+  existing mirror listener) fetches on workspace-connect and on a periodic timer
+  (a small constant, ~5 min) while a workspace **with a remote** is connected.
+  Failures are logged, not shown (offline is normal). **No auto-pull.**
+- **Manual**: a **FETCH** item in the branch-chip menu (disabled as
+  **FETCH — NO REMOTE** without an upstream) → `FetchRemote`; manual failures
+  surface in a **GIT ERROR** dialog.
+- Interval is a constant, not a setting, in v1 (YAGNI).
+
+## Flows
+
+**Pull with conflicts:** PULL → `pullOrConflict` → conflicted → dialog with the
+first commit's `FileConflict`s → user picks → RESOLVE & CONTINUE → write + `add`
++ `rebase --continue` → more conflicts? loop : done → `BranchSyncListener`
+reloads Hive from disk. CANCEL → `rebase --abort` → pre-pull state.
+
+**Fetch:** timer/menu → `fetch` → reload status → chip ahead/behind refreshes.
+
+## Error handling
+
+- Non-zero pull with **no** conflicted paths → `GitException` (unchanged).
+- `rebase --continue` failing (empty commit, hook) → **GIT ERROR** dialog; leave
+  the repo paused (don't auto-abort the user's partial resolution).
+- Resolved files are written through `WorkspaceCollectionSerializer` (the mirror
+  writer), so a resolved file is byte-identical to a normal Getman write — no
+  formatting drift that re-conflicts.
+- The Spec B **mirror-suspension gate** is held across the whole
+  resolve→continue→reload sequence so a debounced Hive→disk mirror can't clobber
+  the resolution mid-flight.
+- No credentials stored; git config never edited; all git calls in `*_io.dart`;
+  web stub reports no rebase / no conflicts / fetch no-op.
+
+## Testing
+
+- **`ThreeWayMerge` (pure, the bulk):** non-overlapping fields auto-merge;
+  true-overlap detection; per-key map merge (different keys silent; same-key diff
+  collides); auth/form whole-field conflicts; base-absent (add/add); a
+  zero-true-conflict file → fully merged entity, no prompts; unparseable stage →
+  structural fallback.
+- **`GitConflictService`** with a mock `GitService`: stage reads → entities;
+  merged entity → serialize → `add`; classification (req/folder/structural).
+- **`ConflictBloc`:** resolve→continue loop incl. multi-batch; cancel→abort;
+  `--continue` failure surfacing; **non-vacuous** Completer-gated test that the
+  next batch loads only after `--continue` (per the Spec B lesson).
+- **`ConflictResolutionDialog`:** field rows (Take Incoming / Keep Yours / Edit);
+  structural rows; auto-merged rows; commit-progress; blocs built inside the test
+  body with a theme.
+- **Fetch:** `GitSyncBloc.FetchRemote` reloads status; manual failure → error;
+  auto-fetch timer coordinator (fake timer) fetches on connect + interval and
+  swallows offline failures.
+- **Real-git integration** (skips when `git` absent, like existing `GitService`
+  tests): script a genuine conflicting rebase in a temp repo; assert stage reads
+  and a full resolve→continue completes; a genuine fetch updates behind-count.
+- Full done-bar: analyze, custom_lint, bloc_lint, fixtures self-test, format,
+  100% tests.
+
+## Out of scope (v1)
+
+Per-item form-field merge; merge (non-rebase) conflict resolution; conflicts the
+user started in their own CLI outside a Getman pull (the resolver engages from
+Getman's pull flow); a configurable fetch interval; three-way merge of the
+`workspace.json` manifest beyond file-level; auto-pull.
+
+## Hazards / notes
+
+- **Rebase ours/theirs are swapped** vs a merge — the engine and UI must read
+  `:2` as Incoming and `:3` as Yours. This is the single most error-prone detail;
+  it gets its own focused tests.
+- **Non-interactive git**: all calls via `Process.run` with stdin closed (as in
+  A/B/C); a `rebase --continue` that would open an editor is prevented with
+  `GIT_EDITOR=true` / `--no-edit` semantics.
+- **Wiki:** the Version Control page gains a "Resolving conflicts" section and a
+  "Fetch" note — part of the final task.

--- a/lib/core/di/injection_container.dart
+++ b/lib/core/di/injection_container.dart
@@ -26,9 +26,11 @@ import 'package:getman/features/collections/data/models/saved_example_model.dart
 import 'package:getman/features/collections/data/repositories/collections_repository_impl.dart';
 import 'package:getman/features/collections/data/services/gh_pull_request_service.dart';
 import 'package:getman/features/collections/data/services/git_branch_service.dart';
+import 'package:getman/features/collections/data/services/git_conflict_service.dart';
 import 'package:getman/features/collections/data/services/workspace_review_service.dart';
 import 'package:getman/features/collections/data/services/workspace_sync_service.dart';
 import 'package:getman/features/collections/domain/branch_service.dart';
+import 'package:getman/features/collections/domain/conflict_service.dart';
 import 'package:getman/features/collections/domain/pull_request_service.dart';
 import 'package:getman/features/collections/domain/repositories/collections_repository.dart';
 import 'package:getman/features/collections/domain/review_service.dart';
@@ -198,6 +200,7 @@ Future<SettingsEntity> init({String? storageDirectoryOverride}) async {
     ..registerLazySingleton<GitService>(createGitService)
     ..registerLazySingleton<ReviewService>(() => WorkspaceReviewService(sl()))
     ..registerLazySingleton<BranchService>(() => GitBranchService(sl(), sl()))
+    ..registerLazySingleton<ConflictService>(() => GitConflictService(sl()))
     ..registerLazySingleton<GhService>(createGhService)
     ..registerLazySingleton<PullRequestService>(
       () => GhPullRequestService(sl(), sl()),

--- a/lib/core/di/injection_container.dart
+++ b/lib/core/di/injection_container.dart
@@ -1,4 +1,5 @@
 import 'package:get_it/get_it.dart';
+import 'package:getman/core/git/gh_service.dart';
 import 'package:getman/core/git/git_service.dart';
 import 'package:getman/core/navigation/app_router.dart';
 import 'package:getman/core/navigation/url_focus_registry.dart';
@@ -23,10 +24,12 @@ import 'package:getman/features/collections/data/datasources/workspace_data_sour
 import 'package:getman/features/collections/data/models/collection_node_model.dart';
 import 'package:getman/features/collections/data/models/saved_example_model.dart';
 import 'package:getman/features/collections/data/repositories/collections_repository_impl.dart';
+import 'package:getman/features/collections/data/services/gh_pull_request_service.dart';
 import 'package:getman/features/collections/data/services/git_branch_service.dart';
 import 'package:getman/features/collections/data/services/workspace_review_service.dart';
 import 'package:getman/features/collections/data/services/workspace_sync_service.dart';
 import 'package:getman/features/collections/domain/branch_service.dart';
+import 'package:getman/features/collections/domain/pull_request_service.dart';
 import 'package:getman/features/collections/domain/repositories/collections_repository.dart';
 import 'package:getman/features/collections/domain/review_service.dart';
 import 'package:getman/features/collections/domain/usecases/collections_usecases.dart';
@@ -194,6 +197,10 @@ Future<SettingsEntity> init({String? storageDirectoryOverride}) async {
     ..registerLazySingleton<GitService>(createGitService)
     ..registerLazySingleton<ReviewService>(() => WorkspaceReviewService(sl()))
     ..registerLazySingleton<BranchService>(() => GitBranchService(sl(), sl()))
+    ..registerLazySingleton<GhService>(createGhService)
+    ..registerLazySingleton<PullRequestService>(
+      () => GhPullRequestService(sl(), sl()),
+    )
     ..registerFactory(() => ReviewBloc(service: sl()))
     ..registerFactory(() => GitSyncBloc(service: sl()))
     // Features - Chaining (no-code extraction + assertions)

--- a/lib/core/di/injection_container.dart
+++ b/lib/core/di/injection_container.dart
@@ -36,6 +36,7 @@ import 'package:getman/features/collections/domain/repositories/collections_repo
 import 'package:getman/features/collections/domain/review_service.dart';
 import 'package:getman/features/collections/domain/usecases/collections_usecases.dart';
 import 'package:getman/features/collections/presentation/bloc/collections_bloc.dart';
+import 'package:getman/features/collections/presentation/bloc/conflict_bloc.dart';
 import 'package:getman/features/collections/presentation/bloc/git_sync_bloc.dart';
 import 'package:getman/features/collections/presentation/bloc/pull_requests_bloc.dart';
 import 'package:getman/features/collections/presentation/bloc/review_bloc.dart';
@@ -208,6 +209,7 @@ Future<SettingsEntity> init({String? storageDirectoryOverride}) async {
     ..registerFactory(() => ReviewBloc(service: sl()))
     ..registerFactory(() => GitSyncBloc(service: sl()))
     ..registerFactory(() => PullRequestsBloc(service: sl()))
+    ..registerFactory(() => ConflictBloc(service: sl()))
     // Features - Chaining (no-code extraction + assertions)
     ..registerLazySingleton(
       () => RulesBloc(

--- a/lib/core/di/injection_container.dart
+++ b/lib/core/di/injection_container.dart
@@ -35,6 +35,7 @@ import 'package:getman/features/collections/domain/review_service.dart';
 import 'package:getman/features/collections/domain/usecases/collections_usecases.dart';
 import 'package:getman/features/collections/presentation/bloc/collections_bloc.dart';
 import 'package:getman/features/collections/presentation/bloc/git_sync_bloc.dart';
+import 'package:getman/features/collections/presentation/bloc/pull_requests_bloc.dart';
 import 'package:getman/features/collections/presentation/bloc/review_bloc.dart';
 import 'package:getman/features/cookies/data/hive_cookie_persistence.dart';
 import 'package:getman/features/cookies/data/models/stored_cookie_model.dart';
@@ -203,6 +204,7 @@ Future<SettingsEntity> init({String? storageDirectoryOverride}) async {
     )
     ..registerFactory(() => ReviewBloc(service: sl()))
     ..registerFactory(() => GitSyncBloc(service: sl()))
+    ..registerFactory(() => PullRequestsBloc(service: sl()))
     // Features - Chaining (no-code extraction + assertions)
     ..registerLazySingleton(
       () => RulesBloc(

--- a/lib/core/di/injection_container.dart
+++ b/lib/core/di/injection_container.dart
@@ -201,7 +201,9 @@ Future<SettingsEntity> init({String? storageDirectoryOverride}) async {
     ..registerLazySingleton<GitService>(createGitService)
     ..registerLazySingleton<ReviewService>(() => WorkspaceReviewService(sl()))
     ..registerLazySingleton<BranchService>(() => GitBranchService(sl(), sl()))
-    ..registerLazySingleton<ConflictService>(() => GitConflictService(sl()))
+    ..registerLazySingleton<ConflictService>(
+      () => GitConflictService(sl(), sl()),
+    )
     ..registerLazySingleton<GhService>(createGhService)
     ..registerLazySingleton<PullRequestService>(
       () => GhPullRequestService(sl(), sl()),

--- a/lib/core/git/gh_output_parser.dart
+++ b/lib/core/git/gh_output_parser.dart
@@ -46,11 +46,13 @@ List<PullRequestInfo> parsePrList(String jsonText) {
     for (final raw in decoded)
       if (raw is Map)
         PullRequestInfo(
-          number: (raw['number'] as num?)?.toInt() ?? 0,
-          title: raw['title'] as String? ?? '',
-          state: raw['state'] as String? ?? 'OPEN',
-          url: raw['url'] as String? ?? '',
-          isDraft: raw['isDraft'] as bool? ?? false,
+          // Tolerate wrong-typed fields (a bad entry degrades, never aborts the
+          // whole parse) — `as num?` etc. would throw a CastError on a String.
+          number: raw['number'] is num ? (raw['number'] as num).toInt() : 0,
+          title: raw['title'] is String ? raw['title'] as String : '',
+          state: raw['state'] is String ? raw['state'] as String : 'OPEN',
+          url: raw['url'] is String ? raw['url'] as String : '',
+          isDraft: raw['isDraft'] == true,
           checks: rollupChecks(raw['statusCheckRollup']),
         ),
   ];

--- a/lib/core/git/gh_output_parser.dart
+++ b/lib/core/git/gh_output_parser.dart
@@ -1,0 +1,57 @@
+import 'dart:convert';
+
+import 'package:getman/core/git/gh_service.dart';
+
+/// Reduces a `statusCheckRollup` array to `none`/`pending`/`passing`/`failing`.
+/// A check is unfinished when a CheckRun's `status` != `COMPLETED` or a
+/// StatusContext's `state` is `PENDING`/`EXPECTED`. Pending wins over failing
+/// wins over passing.
+String rollupChecks(Object? statusCheckRollup) {
+  if (statusCheckRollup is! List || statusCheckRollup.isEmpty) return 'none';
+  var anyPending = false;
+  var anyFailing = false;
+  for (final raw in statusCheckRollup) {
+    if (raw is! Map) continue;
+    final type = raw['__typename'];
+    if (type == 'CheckRun') {
+      final status = raw['status'] as String?;
+      if (status != 'COMPLETED') {
+        anyPending = true;
+      } else {
+        final c = raw['conclusion'] as String?;
+        if (c != 'SUCCESS' && c != 'NEUTRAL' && c != 'SKIPPED') {
+          anyFailing = true;
+        }
+      }
+    } else {
+      // StatusContext
+      final state = raw['state'] as String?;
+      if (state == 'PENDING' || state == 'EXPECTED') {
+        anyPending = true;
+      } else if (state != 'SUCCESS') {
+        anyFailing = true;
+      }
+    }
+  }
+  if (anyPending) return 'pending';
+  if (anyFailing) return 'failing';
+  return 'passing';
+}
+
+/// Parses `gh pr list --json number,title,state,url,isDraft,statusCheckRollup`.
+List<PullRequestInfo> parsePrList(String jsonText) {
+  final decoded = jsonDecode(jsonText);
+  if (decoded is! List) return const [];
+  return [
+    for (final raw in decoded)
+      if (raw is Map)
+        PullRequestInfo(
+          number: (raw['number'] as num?)?.toInt() ?? 0,
+          title: raw['title'] as String? ?? '',
+          state: raw['state'] as String? ?? 'OPEN',
+          url: raw['url'] as String? ?? '',
+          isDraft: raw['isDraft'] as bool? ?? false,
+          checks: rollupChecks(raw['statusCheckRollup']),
+        ),
+  ];
+}

--- a/lib/core/git/gh_output_parser.dart
+++ b/lib/core/git/gh_output_parser.dart
@@ -55,3 +55,9 @@ List<PullRequestInfo> parsePrList(String jsonText) {
         ),
   ];
 }
+
+/// The last `https://…` token gh printed — that is the created PR's URL.
+String parsePrUrl(String stdout) {
+  final match = RegExp(r'https://\S+').allMatches(stdout).toList();
+  return match.isEmpty ? '' : match.last.group(0)!.trim();
+}

--- a/lib/core/git/gh_service.dart
+++ b/lib/core/git/gh_service.dart
@@ -1,0 +1,66 @@
+import 'package:getman/core/git/gh_service_stub.dart'
+    if (dart.library.io) 'package:getman/core/git/gh_service_io.dart';
+
+/// Talks to GitHub through the `gh` CLI. The single `dart:io` boundary for
+/// `gh` lives in `gh_service_io.dart`; web builds get the stub. Rides on the
+/// user's existing `gh auth` — Getman stores no credentials.
+abstract class GhService {
+  /// `gh --version` succeeds.
+  Future<bool> isAvailable();
+
+  /// `gh auth status` succeeds in [root] (a repo dir picks up its host).
+  Future<bool> isAuthenticated(String root);
+
+  /// Opens a PR for the current branch. Returns the PR URL printed by
+  /// `gh pr create`. Throws [GhException] on any failure (incl. gh trying to
+  /// prompt for a remote — we push first so it never should).
+  Future<String> createPr(
+    String root, {
+    required String base,
+    required String title,
+    required String body,
+    required bool draft,
+  });
+
+  /// Open PRs for the repo in [root], newest first as gh returns them.
+  Future<List<PullRequestInfo>> listPrs(String root);
+
+  /// The repo's default branch name (for the create form's base default), or
+  /// null if it can't be determined.
+  Future<String?> defaultBranch(String root);
+}
+
+GhService createGhService() => createGhServiceImpl();
+
+/// One open pull request as reported by `gh pr list --json`. Primitive/string
+/// fields only — the domain layer maps [state]/[checks] to its own enums.
+class PullRequestInfo {
+  const PullRequestInfo({
+    required this.number,
+    required this.title,
+    required this.state,
+    required this.url,
+    required this.isDraft,
+    required this.checks,
+  });
+
+  final int number;
+  final String title;
+
+  /// Raw gh state: `OPEN` / `MERGED` / `CLOSED`.
+  final String state;
+  final String url;
+  final bool isDraft;
+
+  /// Rolled-up check verdict: `none` / `pending` / `passing` / `failing`.
+  final String checks;
+}
+
+class GhException implements Exception {
+  GhException(this.message, {this.exitCode});
+  final String message;
+  final int? exitCode;
+
+  @override
+  String toString() => 'GhException($exitCode): $message';
+}

--- a/lib/core/git/gh_service_io.dart
+++ b/lib/core/git/gh_service_io.dart
@@ -7,6 +7,11 @@ import 'package:getman/core/git/gh_service.dart';
 GhService createGhServiceImpl() => _GhService();
 
 class _GhService implements GhService {
+  // NOTE: `Process.run` closes the child's stdin (it gets EOF), so `gh` runs
+  // non-interactively and errors instead of prompting — this is what upholds
+  // the "throws, never hangs" contract. Two things must stay true: (1) never
+  // switch to `Process.start` with an open stdin, and (2) there is no timeout,
+  // so any gh call that could block on something *other* than stdin would hang.
   Future<ProcessResult> _run(
     String root,
     List<String> args, {
@@ -97,10 +102,15 @@ class _GhService implements GhService {
       'defaultBranchRef',
     ], allowFailure: true);
     if (r.exitCode != 0) return null;
-    final decoded = jsonDecode(r.stdout as String);
-    if (decoded is! Map) return null;
-    final ref = decoded['defaultBranchRef'];
-    if (ref is! Map) return null;
-    return ref['name'] as String?;
+    // Best-effort: a non-JSON / empty stdout must yield null, not throw.
+    try {
+      final decoded = jsonDecode(r.stdout as String);
+      if (decoded is! Map) return null;
+      final ref = decoded['defaultBranchRef'];
+      if (ref is! Map) return null;
+      return ref['name'] as String?;
+    } on FormatException {
+      return null;
+    }
   }
 }

--- a/lib/core/git/gh_service_io.dart
+++ b/lib/core/git/gh_service_io.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:getman/core/git/gh_output_parser.dart';
 import 'package:getman/core/git/gh_service.dart';
 
 GhService createGhServiceImpl() => _GhService();
@@ -62,13 +63,30 @@ class _GhService implements GhService {
 
   @override
   Future<List<PullRequestInfo>> listPrs(String root) async {
-    // Filled in Task 2.
-    throw UnimplementedError();
+    final r = await _run(root, [
+      'pr',
+      'list',
+      '--state',
+      'open',
+      '--json',
+      'number,title,state,url,isDraft,statusCheckRollup',
+    ]);
+    return parsePrList(r.stdout as String);
   }
 
   @override
   Future<String?> defaultBranch(String root) async {
-    // Filled in Task 2.
-    throw UnimplementedError();
+    final r = await _run(root, [
+      'repo',
+      'view',
+      '--json',
+      'defaultBranchRef',
+    ], allowFailure: true);
+    if (r.exitCode != 0) return null;
+    final decoded = jsonDecode(r.stdout as String);
+    if (decoded is! Map) return null;
+    final ref = decoded['defaultBranchRef'];
+    if (ref is! Map) return null;
+    return ref['name'] as String?;
   }
 }

--- a/lib/core/git/gh_service_io.dart
+++ b/lib/core/git/gh_service_io.dart
@@ -57,8 +57,22 @@ class _GhService implements GhService {
     required String body,
     required bool draft,
   }) async {
-    // Filled in Task 3.
-    throw UnimplementedError();
+    final r = await _run(root, [
+      'pr',
+      'create',
+      '--base',
+      base,
+      '--title',
+      title,
+      '--body',
+      body,
+      if (draft) '--draft',
+    ]);
+    final url = parsePrUrl(r.stdout as String);
+    if (url.isEmpty) {
+      throw GhException('gh pr create did not return a PR url');
+    }
+    return url;
   }
 
   @override

--- a/lib/core/git/gh_service_io.dart
+++ b/lib/core/git/gh_service_io.dart
@@ -1,0 +1,74 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:getman/core/git/gh_service.dart';
+
+GhService createGhServiceImpl() => _GhService();
+
+class _GhService implements GhService {
+  Future<ProcessResult> _run(
+    String root,
+    List<String> args, {
+    bool allowFailure = false,
+  }) async {
+    final result = await Process.run(
+      'gh',
+      args,
+      workingDirectory: root,
+      stdoutEncoding: utf8,
+      stderrEncoding: utf8,
+    );
+    if (!allowFailure && result.exitCode != 0) {
+      final err = (result.stderr as String).trim();
+      throw GhException(
+        err.isEmpty ? 'gh ${args.first} failed' : err,
+        exitCode: result.exitCode,
+      );
+    }
+    return result;
+  }
+
+  @override
+  Future<bool> isAvailable() async {
+    try {
+      final r = await Process.run('gh', ['--version']);
+      return r.exitCode == 0;
+    } on Object {
+      return false;
+    }
+  }
+
+  @override
+  Future<bool> isAuthenticated(String root) async {
+    try {
+      final r = await _run(root, ['auth', 'status'], allowFailure: true);
+      return r.exitCode == 0;
+    } on Object {
+      return false;
+    }
+  }
+
+  @override
+  Future<String> createPr(
+    String root, {
+    required String base,
+    required String title,
+    required String body,
+    required bool draft,
+  }) async {
+    // Filled in Task 3.
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<List<PullRequestInfo>> listPrs(String root) async {
+    // Filled in Task 2.
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<String?> defaultBranch(String root) async {
+    // Filled in Task 2.
+    throw UnimplementedError();
+  }
+}

--- a/lib/core/git/gh_service_stub.dart
+++ b/lib/core/git/gh_service_stub.dart
@@ -1,0 +1,28 @@
+import 'package:getman/core/git/gh_service.dart';
+
+GhService createGhServiceImpl() => _StubGhService();
+
+/// Web build: `gh` is a desktop binary, so every call is a no-op that reports
+/// "not available".
+class _StubGhService implements GhService {
+  @override
+  Future<bool> isAvailable() async => false;
+
+  @override
+  Future<bool> isAuthenticated(String root) async => false;
+
+  @override
+  Future<String> createPr(
+    String root, {
+    required String base,
+    required String title,
+    required String body,
+    required bool draft,
+  }) async => throw GhException('gh is unavailable on web');
+
+  @override
+  Future<List<PullRequestInfo>> listPrs(String root) async => const [];
+
+  @override
+  Future<String?> defaultBranch(String root) async => null;
+}

--- a/lib/core/git/git_service.dart
+++ b/lib/core/git/git_service.dart
@@ -109,6 +109,10 @@ abstract class GitService {
   /// Whether the repo has at least one remote configured.
   Future<bool> hasRemote(String root);
 
+  /// Adds a remote (`git remote add <name> <url>`) — e.g. `origin` when the
+  /// user supplies a URL to enable pull/push/fetch on a repo with none yet.
+  Future<void> addRemote(String root, String name, String url);
+
   /// Ahead/behind counts vs the current branch's upstream.
   Future<AheadBehind> aheadBehind(String root);
 

--- a/lib/core/git/git_service.dart
+++ b/lib/core/git/git_service.dart
@@ -131,6 +131,9 @@ abstract class GitService {
   /// Stages [path] (`git add`) — marks a conflict as resolved.
   Future<void> add(String root, String path);
 
+  /// Removes [path] from the working tree and stages the deletion (git rm).
+  Future<void> removeFile(String root, String path);
+
   /// `git rebase --continue`, non-interactively (no editor prompt).
   Future<void> rebaseContinue(String root);
 

--- a/lib/core/git/git_service.dart
+++ b/lib/core/git/git_service.dart
@@ -119,12 +119,15 @@ abstract class GitService {
   /// Whether the current branch has an upstream configured.
   Future<bool> hasUpstream(String root);
 
-  /// `git pull --rebase`. On a true conflict, the rebase is left **paused**
-  /// (see [PullOutcome.conflicted]) so the caller can resolve it — see
-  /// [isRebaseInProgress] / [conflictedPaths] / [showStage] /
-  /// [writeWorkingFile] / [add] / [rebaseContinue] / [rebaseAbort]. Any other
-  /// failure (auth/network/local changes) aborts the rebase before throwing,
-  /// so a non-resolvable failed pull leaves the working tree exactly as it
+  /// `git pull --rebase --autostash`. Autostash because Getman mirrors in-app
+  /// edits to disk as uncommitted changes, so the tree is routinely dirty at
+  /// pull time; autostash stashes those edits, rebases, and reapplies them
+  /// instead of git refusing with "you have unstaged changes". On a true
+  /// conflict, the rebase is left **paused** (see [PullOutcome.conflicted]) so
+  /// the caller can resolve it — see [isRebaseInProgress] / [conflictedPaths] /
+  /// [showStage] / [writeWorkingFile] / [add] / [rebaseContinue] /
+  /// [rebaseAbort]. Any other failure (auth/network) aborts the rebase before
+  /// throwing, so a non-resolvable failed pull leaves the working tree as it
   /// was.
   /// [authorName]/[authorEmail] are passed inline to the rebase machinery the
   /// same way as [commit] — a rebase that needs to create a commit (e.g.

--- a/lib/core/git/git_service.dart
+++ b/lib/core/git/git_service.dart
@@ -48,6 +48,10 @@ class StashEntry {
   final String message;
 }
 
+/// The result of a rebase-pull: it either fast-forwarded/rebased cleanly, or
+/// it stopped on conflicts that are now sitting in the index for resolution.
+enum PullOutcome { clean, conflicted }
+
 /// Drives the system `git` CLI over a workspace directory. The `_io`
 /// implementation is the sole `dart:io` importer; web gets the no-op stub.
 abstract class GitService {
@@ -86,10 +90,14 @@ abstract class GitService {
   /// Whether the current branch has an upstream configured.
   Future<bool> hasUpstream(String root);
 
-  /// `git pull --rebase`. On conflict the rebase is **aborted** before
-  /// throwing, so a failed pull leaves the working tree exactly as it was —
-  /// Getman has no conflict-resolution UI yet (Spec D).
-  Future<void> pull(String root);
+  /// `git pull --rebase`. On a true conflict, the rebase is left **paused**
+  /// (see [PullOutcome.conflicted]) so the caller can resolve it — see
+  /// [isRebaseInProgress] / [conflictedPaths] / [showStage] /
+  /// [writeWorkingFile] / [add] / [rebaseContinue] / [rebaseAbort]. Any other
+  /// failure (auth/network/local changes) aborts the rebase before throwing,
+  /// so a non-resolvable failed pull leaves the working tree exactly as it
+  /// was.
+  Future<PullOutcome> pull(String root);
 
   /// Pushes the current branch. Pass [setUpstream] for a branch that has
   /// never been pushed (`git push -u origin <branch>`).
@@ -103,4 +111,33 @@ abstract class GitService {
 
   Future<void> stashPop(String root, int index);
   Future<void> stashDrop(String root, int index);
+
+  /// Whether a rebase is currently paused (mid-conflict) on [root].
+  Future<bool> isRebaseInProgress(String root);
+
+  /// Paths with unresolved merge conflicts (`git diff --name-only
+  /// --diff-filter=U`).
+  Future<List<String>> conflictedPaths(String root);
+
+  /// Content of [path] at merge stage [stage] (1=base, 2=ours/incoming,
+  /// 3=theirs/yours), or null when that stage is absent (e.g. add/add has no
+  /// base).
+  Future<String?> showStage(String root, String path, int stage);
+
+  /// Overwrites the working-tree copy of [path] with [content] (creating
+  /// parent directories as needed). Used to write a resolved conflict.
+  Future<void> writeWorkingFile(String root, String path, String content);
+
+  /// Stages [path] (`git add`) — marks a conflict as resolved.
+  Future<void> add(String root, String path);
+
+  /// `git rebase --continue`, non-interactively (no editor prompt).
+  Future<void> rebaseContinue(String root);
+
+  /// `git rebase --abort` — restores the pre-rebase tree.
+  Future<void> rebaseAbort(String root);
+
+  /// `git fetch` — updates remote-tracking refs without touching the working
+  /// tree.
+  Future<void> fetch(String root);
 }

--- a/lib/core/git/git_service.dart
+++ b/lib/core/git/git_service.dart
@@ -28,6 +28,18 @@ class GitException implements Exception {
   final int? exitCode;
   @override
   String toString() => 'GitException($message)';
+
+  /// Whether [message] is git's "no commit identity configured" failure —
+  /// the signal the review/pull/rebase blocs use to prompt for a Getman-owned
+  /// commit identity instead of surfacing a raw git error. Matches git's own
+  /// wording (`Author identity unknown` / `Please tell me who you are`) plus
+  /// the newer `unable to auto-detect email address` variant, case-insensitive.
+  static bool isMissingIdentity(String message) {
+    final m = message.toLowerCase();
+    return m.contains('author identity unknown') ||
+        m.contains('please tell me who you are') ||
+        m.contains('unable to auto-detect email');
+  }
 }
 
 /// Commits the current branch is ahead of / behind its upstream. Both are 0
@@ -69,7 +81,20 @@ abstract class GitService {
 
   Future<void> stage(String root, List<String> paths);
   Future<void> unstage(String root, List<String> paths);
-  Future<void> commit(String root, String message);
+
+  /// Commits staged changes. [authorName]/[authorEmail], when both non-empty,
+  /// are passed inline as `-c user.name=… -c user.email=…` so a commit
+  /// succeeds even when the OS git has no configured identity — Getman's own
+  /// identity (from Settings) is used for this commit only, never written to
+  /// the user's git config. When omitted, falls back to whatever git resolves
+  /// on its own (global config, or a failure the caller detects via
+  /// [GitException.isMissingIdentity]).
+  Future<void> commit(
+    String root,
+    String message, {
+    String? authorName,
+    String? authorEmail,
+  });
 
   /// Local branch names.
   Future<List<String>> branches(String root);
@@ -97,7 +122,14 @@ abstract class GitService {
   /// failure (auth/network/local changes) aborts the rebase before throwing,
   /// so a non-resolvable failed pull leaves the working tree exactly as it
   /// was.
-  Future<PullOutcome> pull(String root);
+  /// [authorName]/[authorEmail] are passed inline to the rebase machinery the
+  /// same way as [commit] — a rebase that needs to create a commit (e.g.
+  /// autostash replay) must not fail on a missing identity either.
+  Future<PullOutcome> pull(
+    String root, {
+    String? authorName,
+    String? authorEmail,
+  });
 
   /// Pushes the current branch. Pass [setUpstream] for a branch that has
   /// never been pushed (`git push -u origin <branch>`).
@@ -135,7 +167,13 @@ abstract class GitService {
   Future<void> removeFile(String root, String path);
 
   /// `git rebase --continue`, non-interactively (no editor prompt).
-  Future<void> rebaseContinue(String root);
+  /// [authorName]/[authorEmail] are passed inline like [commit] — continuing a
+  /// rebase re-creates a commit, so it hits the same missing-identity failure.
+  Future<void> rebaseContinue(
+    String root, {
+    String? authorName,
+    String? authorEmail,
+  });
 
   /// `git rebase --abort` — restores the pre-rebase tree.
   Future<void> rebaseAbort(String root);

--- a/lib/core/git/git_service_io.dart
+++ b/lib/core/git/git_service_io.dart
@@ -180,10 +180,14 @@ class _IoGitService implements GitService {
   }
 
   @override
-  Future<void> pull(String root) async {
+  Future<PullOutcome> pull(String root) async {
     final r = await _run(root, ['pull', '--rebase'], allowFailure: true);
-    if (r.exitCode == 0) return;
-    // Leave no half-rebased tree behind: undo it, then report the failure.
+    if (r.exitCode == 0) return PullOutcome.clean;
+    if (await isRebaseInProgress(root) &&
+        (await conflictedPaths(root)).isNotEmpty) {
+      return PullOutcome.conflicted; // leave paused for the resolver
+    }
+    // Not a resolvable conflict (auth/network/local changes) — restore + throw.
     await _run(root, ['rebase', '--abort'], allowFailure: true);
     final err = (r.stderr as String).trim();
     throw GitException(
@@ -231,6 +235,80 @@ class _IoGitService implements GitService {
   Future<void> stashDrop(String root, int index) async {
     await _run(root, ['stash', 'drop', 'stash@{$index}']);
   }
+
+  @override
+  Future<bool> isRebaseInProgress(String root) async {
+    final r = await _run(root, [
+      'rev-parse',
+      '--git-path',
+      'rebase-merge',
+    ], allowFailure: true);
+    final merge = (r.stdout as String).trim();
+    if (merge.isNotEmpty && Directory('$root/$merge').existsSync()) return true;
+    final r2 = await _run(root, [
+      'rev-parse',
+      '--git-path',
+      'rebase-apply',
+    ], allowFailure: true);
+    final apply = (r2.stdout as String).trim();
+    return apply.isNotEmpty && Directory('$root/$apply').existsSync();
+  }
+
+  @override
+  Future<List<String>> conflictedPaths(String root) async {
+    final r = await _run(root, ['diff', '--name-only', '--diff-filter=U']);
+    return (r.stdout as String)
+        .split('\n')
+        .map((l) => l.trim())
+        .where((l) => l.isNotEmpty)
+        .toList();
+  }
+
+  @override
+  Future<String?> showStage(String root, String path, int stage) async {
+    final r = await _run(root, ['show', ':$stage:$path'], allowFailure: true);
+    return r.exitCode == 0 ? r.stdout as String : null;
+  }
+
+  @override
+  Future<void> writeWorkingFile(
+    String root,
+    String path,
+    String content,
+  ) async {
+    final file = File('$root/$path');
+    await file.parent.create(recursive: true);
+    await file.writeAsString(content);
+  }
+
+  @override
+  Future<void> add(String root, String path) => _run(root, ['add', path]);
+
+  @override
+  Future<void> rebaseContinue(String root) async {
+    // GIT_EDITOR=true so a commit-message step never blocks on an editor.
+    final r = await Process.run(
+      'git',
+      ['rebase', '--continue'],
+      workingDirectory: root,
+      stdoutEncoding: utf8,
+      stderrEncoding: utf8,
+      environment: {'GIT_EDITOR': 'true'},
+    );
+    if (r.exitCode != 0) {
+      final err = (r.stderr as String).trim();
+      throw GitException(
+        err.isEmpty ? 'git rebase --continue failed' : err,
+        exitCode: r.exitCode,
+      );
+    }
+  }
+
+  @override
+  Future<void> rebaseAbort(String root) => _run(root, ['rebase', '--abort']);
+
+  @override
+  Future<void> fetch(String root) => _run(root, ['fetch']);
 
   /// Parses `git status --porcelain=v1 -z`. Records are NUL-terminated; a
   /// rename record (`R`/`C`) is followed by a second NUL-token holding the

--- a/lib/core/git/git_service_io.dart
+++ b/lib/core/git/git_service_io.dart
@@ -34,10 +34,16 @@ class _IoGitService implements GitService {
   /// config. Empty when either half is missing/blank so git falls back to
   /// its own resolution (and a genuinely missing identity still surfaces as
   /// [GitException.isMissingIdentity]).
+  ///
+  /// The stored name is suffixed with [_viaGetman] only at commit time (the
+  /// setting stays clean), so history reads `name via Getman` while GitHub —
+  /// which attributes by email — still credits the user normally.
   List<String> _identityArgs(String? name, String? email) =>
       (name != null && name.isNotEmpty && email != null && email.isNotEmpty)
-      ? ['-c', 'user.name=$name', '-c', 'user.email=$email']
+      ? ['-c', 'user.name=$name$_viaGetman', '-c', 'user.email=$email']
       : const [];
+
+  static const String _viaGetman = ' via Getman';
 
   @override
   Future<bool> isAvailable() async {

--- a/lib/core/git/git_service_io.dart
+++ b/lib/core/git/git_service_io.dart
@@ -29,6 +29,16 @@ class _IoGitService implements GitService {
     return result;
   }
 
+  /// `-c user.name=… -c user.email=…`, prepended to the git args of any
+  /// commit-creating command — never written to the user's global git
+  /// config. Empty when either half is missing/blank so git falls back to
+  /// its own resolution (and a genuinely missing identity still surfaces as
+  /// [GitException.isMissingIdentity]).
+  List<String> _identityArgs(String? name, String? email) =>
+      (name != null && name.isNotEmpty && email != null && email.isNotEmpty)
+      ? ['-c', 'user.name=$name', '-c', 'user.email=$email']
+      : const [];
+
   @override
   Future<bool> isAvailable() async {
     try {
@@ -116,8 +126,18 @@ class _IoGitService implements GitService {
   }
 
   @override
-  Future<void> commit(String root, String message) async {
-    await _run(root, ['commit', '-m', message]);
+  Future<void> commit(
+    String root,
+    String message, {
+    String? authorName,
+    String? authorEmail,
+  }) async {
+    await _run(root, [
+      ..._identityArgs(authorName, authorEmail),
+      'commit',
+      '-m',
+      message,
+    ]);
   }
 
   @override
@@ -180,8 +200,16 @@ class _IoGitService implements GitService {
   }
 
   @override
-  Future<PullOutcome> pull(String root) async {
-    final r = await _run(root, ['pull', '--rebase'], allowFailure: true);
+  Future<PullOutcome> pull(
+    String root, {
+    String? authorName,
+    String? authorEmail,
+  }) async {
+    final r = await _run(root, [
+      ..._identityArgs(authorName, authorEmail),
+      'pull',
+      '--rebase',
+    ], allowFailure: true);
     if (r.exitCode == 0) return PullOutcome.clean;
     if (await isRebaseInProgress(root) &&
         (await conflictedPaths(root)).isNotEmpty) {
@@ -289,11 +317,15 @@ class _IoGitService implements GitService {
       _run(root, ['rm', '--', path]);
 
   @override
-  Future<void> rebaseContinue(String root) async {
+  Future<void> rebaseContinue(
+    String root, {
+    String? authorName,
+    String? authorEmail,
+  }) async {
     // GIT_EDITOR=true so a commit-message step never blocks on an editor.
     final r = await Process.run(
       'git',
-      ['rebase', '--continue'],
+      [..._identityArgs(authorName, authorEmail), 'rebase', '--continue'],
       workingDirectory: root,
       stdoutEncoding: utf8,
       stderrEncoding: utf8,

--- a/lib/core/git/git_service_io.dart
+++ b/lib/core/git/git_service_io.dart
@@ -38,10 +38,22 @@ class _IoGitService implements GitService {
   /// The stored name is suffixed with [_viaGetman] only at commit time (the
   /// setting stays clean), so history reads `name via Getman` while GitHub —
   /// which attributes by email — still credits the user normally.
-  List<String> _identityArgs(String? name, String? email) =>
-      (name != null && name.isNotEmpty && email != null && email.isNotEmpty)
-      ? ['-c', 'user.name=$name$_viaGetman', '-c', 'user.email=$email']
-      : const [];
+  List<String> _identityArgs(String? name, String? email) {
+    final trimmedName = name?.trim();
+    final trimmedEmail = email?.trim();
+    if (trimmedName == null ||
+        trimmedName.isEmpty ||
+        trimmedEmail == null ||
+        trimmedEmail.isEmpty) {
+      return const [];
+    }
+    return [
+      '-c',
+      'user.name=$trimmedName$_viaGetman',
+      '-c',
+      'user.email=$trimmedEmail',
+    ];
+  }
 
   static const String _viaGetman = ' via Getman';
 

--- a/lib/core/git/git_service_io.dart
+++ b/lib/core/git/git_service_io.dart
@@ -189,7 +189,19 @@ class _IoGitService implements GitService {
 
   @override
   Future<void> addRemote(String root, String name, String url) async {
-    await _run(root, ['remote', 'add', name, url]);
+    // Idempotent: a retry after a failed paired push/pull/fetch (bad
+    // URL/auth/host) must not dead-end on `fatal: remote <name> already
+    // exists` — there is no remove-remote UI. `remote add` fails when the
+    // remote is already there; fall back to `remote set-url` so a retry
+    // with the same or corrected URL always re-points it and proceeds.
+    final added = await _run(root, [
+      'remote',
+      'add',
+      name,
+      url,
+    ], allowFailure: true);
+    if (added.exitCode == 0) return;
+    await _run(root, ['remote', 'set-url', name, url]);
   }
 
   @override

--- a/lib/core/git/git_service_io.dart
+++ b/lib/core/git/git_service_io.dart
@@ -244,6 +244,13 @@ class _IoGitService implements GitService {
       ..._identityArgs(authorName, authorEmail),
       'pull',
       '--rebase',
+      // Getman mirrors in-app edits to disk as uncommitted changes, so the
+      // tree is routinely dirty at pull time. --autostash stashes those edits,
+      // rebases, then reapplies them on top (the manual "stash, pull, pop"
+      // done for you) instead of git refusing with "you have unstaged
+      // changes". A rebase conflict still surfaces to the resolver as usual;
+      // the autostash pops when the rebase finishes (incl. via --continue).
+      '--autostash',
     ], allowFailure: true);
     if (r.exitCode == 0) return PullOutcome.clean;
     if (await isRebaseInProgress(root) &&

--- a/lib/core/git/git_service_io.dart
+++ b/lib/core/git/git_service_io.dart
@@ -285,6 +285,10 @@ class _IoGitService implements GitService {
   Future<void> add(String root, String path) => _run(root, ['add', path]);
 
   @override
+  Future<void> removeFile(String root, String path) =>
+      _run(root, ['rm', '--', path]);
+
+  @override
   Future<void> rebaseContinue(String root) async {
     // GIT_EDITOR=true so a commit-message step never blocks on an editor.
     final r = await Process.run(

--- a/lib/core/git/git_service_io.dart
+++ b/lib/core/git/git_service_io.dart
@@ -188,6 +188,11 @@ class _IoGitService implements GitService {
   }
 
   @override
+  Future<void> addRemote(String root, String name, String url) async {
+    await _run(root, ['remote', 'add', name, url]);
+  }
+
+  @override
   Future<AheadBehind> aheadBehind(String root) async {
     // `@{u}...HEAD` prints "<behind>\t<ahead>". Exits non-zero when the
     // branch has no upstream — that is a normal state, so report (0, 0).

--- a/lib/core/git/git_service_stub.dart
+++ b/lib/core/git/git_service_stub.dart
@@ -37,7 +37,7 @@ class _StubGitService implements GitService {
   @override
   Future<bool> hasUpstream(String root) async => false;
   @override
-  Future<void> pull(String root) async {}
+  Future<PullOutcome> pull(String root) async => PullOutcome.clean;
   @override
   Future<void> push(String root, {required bool setUpstream}) async {}
   @override
@@ -48,4 +48,24 @@ class _StubGitService implements GitService {
   Future<void> stashPop(String root, int index) async {}
   @override
   Future<void> stashDrop(String root, int index) async {}
+  @override
+  Future<bool> isRebaseInProgress(String root) async => false;
+  @override
+  Future<List<String>> conflictedPaths(String root) async => const [];
+  @override
+  Future<String?> showStage(String root, String path, int stage) async => null;
+  @override
+  Future<void> writeWorkingFile(
+    String root,
+    String path,
+    String content,
+  ) async {}
+  @override
+  Future<void> add(String root, String path) async {}
+  @override
+  Future<void> rebaseContinue(String root) async {}
+  @override
+  Future<void> rebaseAbort(String root) async {}
+  @override
+  Future<void> fetch(String root) async {}
 }

--- a/lib/core/git/git_service_stub.dart
+++ b/lib/core/git/git_service_stub.dart
@@ -63,6 +63,8 @@ class _StubGitService implements GitService {
   @override
   Future<void> add(String root, String path) async {}
   @override
+  Future<void> removeFile(String root, String path) async {}
+  @override
   Future<void> rebaseContinue(String root) async {}
   @override
   Future<void> rebaseAbort(String root) async {}

--- a/lib/core/git/git_service_stub.dart
+++ b/lib/core/git/git_service_stub.dart
@@ -23,7 +23,12 @@ class _StubGitService implements GitService {
   @override
   Future<void> unstage(String root, List<String> paths) async {}
   @override
-  Future<void> commit(String root, String message) async {}
+  Future<void> commit(
+    String root,
+    String message, {
+    String? authorName,
+    String? authorEmail,
+  }) async {}
   @override
   Future<List<String>> branches(String root) async => const [];
   @override
@@ -37,7 +42,11 @@ class _StubGitService implements GitService {
   @override
   Future<bool> hasUpstream(String root) async => false;
   @override
-  Future<PullOutcome> pull(String root) async => PullOutcome.clean;
+  Future<PullOutcome> pull(
+    String root, {
+    String? authorName,
+    String? authorEmail,
+  }) async => PullOutcome.clean;
   @override
   Future<void> push(String root, {required bool setUpstream}) async {}
   @override
@@ -65,7 +74,11 @@ class _StubGitService implements GitService {
   @override
   Future<void> removeFile(String root, String path) async {}
   @override
-  Future<void> rebaseContinue(String root) async {}
+  Future<void> rebaseContinue(
+    String root, {
+    String? authorName,
+    String? authorEmail,
+  }) async {}
   @override
   Future<void> rebaseAbort(String root) async {}
   @override

--- a/lib/core/git/git_service_stub.dart
+++ b/lib/core/git/git_service_stub.dart
@@ -38,6 +38,8 @@ class _StubGitService implements GitService {
   @override
   Future<bool> hasRemote(String root) async => false;
   @override
+  Future<void> addRemote(String root, String name, String url) async {}
+  @override
   Future<AheadBehind> aheadBehind(String root) async => AheadBehind.none;
   @override
   Future<bool> hasUpstream(String root) async => false;

--- a/lib/core/utils/open_url.dart
+++ b/lib/core/utils/open_url.dart
@@ -1,0 +1,13 @@
+import 'package:url_launcher/url_launcher.dart';
+
+/// Opens [url] in the system browser. Returns false (never throws) when the
+/// url is malformed or no handler is available — callers show a snackbar.
+Future<bool> openUrl(String url) async {
+  final uri = Uri.tryParse(url);
+  if (uri == null) return false;
+  try {
+    return await launchUrl(uri, mode: LaunchMode.externalApplication);
+  } on Object {
+    return false;
+  }
+}

--- a/lib/features/collections/data/services/gh_pull_request_service.dart
+++ b/lib/features/collections/data/services/gh_pull_request_service.dart
@@ -1,0 +1,82 @@
+import 'package:getman/core/git/gh_service.dart';
+import 'package:getman/features/collections/domain/branch_service.dart';
+import 'package:getman/features/collections/domain/entities/pull_request.dart';
+import 'package:getman/features/collections/domain/pull_request_service.dart';
+
+/// `gh`-backed [PullRequestService]. Composes [GhService] with the Spec B
+/// [BranchService] so the pre-create push reuses the flush-guarded push (no
+/// duplicated mirror-race handling — PR creation itself never touches the
+/// working tree).
+class GhPullRequestService implements PullRequestService {
+  GhPullRequestService(this._gh, this._branch);
+
+  final GhService _gh;
+  final BranchService _branch;
+
+  @override
+  Future<GhAvailability> availability(String root) async {
+    if (!await _gh.isAvailable()) return GhAvailability.notInstalled;
+    if (!await _gh.isAuthenticated(root)) {
+      return GhAvailability.notAuthenticated;
+    }
+    return GhAvailability.available;
+  }
+
+  @override
+  Future<List<PullRequestEntity>> list(String root) async {
+    final raw = await _gh.listPrs(root);
+    return [for (final p in raw) _toEntity(p)];
+  }
+
+  @override
+  Future<PullRequestRef> create(
+    String root, {
+    required String base,
+    required String title,
+    required String body,
+    required bool draft,
+  }) async {
+    // Ensure the branch (and its latest commits) are on the remote first —
+    // gh pr create would otherwise prompt for a remote on stdin, which a
+    // non-interactive Process.run cannot answer. push sets upstream on the
+    // first push.
+    await _branch.push(root);
+    final url = await _gh.createPr(
+      root,
+      base: base,
+      title: title,
+      body: body,
+      draft: draft,
+    );
+    return PullRequestRef(number: _numberFromUrl(url), url: url);
+  }
+
+  @override
+  Future<String?> defaultBase(String root) => _gh.defaultBranch(root);
+
+  PullRequestEntity _toEntity(PullRequestInfo p) => PullRequestEntity(
+    number: p.number,
+    title: p.title,
+    state: switch (p.state) {
+      'MERGED' => PrState.merged,
+      'CLOSED' => PrState.closed,
+      _ => PrState.open,
+    },
+    url: p.url,
+    isDraft: p.isDraft,
+    checks: switch (p.checks) {
+      'pending' => PrChecks.pending,
+      'passing' => PrChecks.passing,
+      'failing' => PrChecks.failing,
+      _ => PrChecks.none,
+    },
+  );
+
+  int _numberFromUrl(String url) {
+    // Drop any ?query / #fragment before taking the trailing path segment so a
+    // `.../pull/77?foo=bar` URL still yields 77.
+    final path = url.split(RegExp('[?#]')).first;
+    final last = path.split('/').where((s) => s.isNotEmpty).lastOrNull;
+    return int.tryParse(last ?? '') ?? 0;
+  }
+}

--- a/lib/features/collections/data/services/git_branch_service.dart
+++ b/lib/features/collections/data/services/git_branch_service.dart
@@ -84,6 +84,13 @@ class GitBranchService implements BranchService {
     await _git.createBranch(root, branch);
   }
 
+  // No flush/suspension here, deliberately: adding a remote only writes to
+  // `.git/config` — it never touches the working tree — so it cannot race a
+  // pending mirror write (same rationale as `dropStash`/`fetch`).
+  @override
+  Future<void> addRemote(String root, String name, String url) =>
+      _git.addRemote(root, name, url);
+
   @override
   Future<PullOutcome> pull(
     String root, {

--- a/lib/features/collections/data/services/git_branch_service.dart
+++ b/lib/features/collections/data/services/git_branch_service.dart
@@ -83,8 +83,14 @@ class GitBranchService implements BranchService {
     await _git.createBranch(root, branch);
   }
 
+  // `GitService.pull` now returns a `PullOutcome`; `BranchService.pull` is
+  // still `Future<void>` here — a later task (Spec D T4/T6) rewires callers
+  // to consume the outcome for conflict handling. Discard it for now so the
+  // tree keeps compiling.
   @override
-  Future<void> pull(String root) => _runOnTree(() => _git.pull(root));
+  Future<void> pull(String root) => _runOnTree(() async {
+    await _git.pull(root);
+  });
 
   // No suspension here: `git push` reads the working tree, it never rewrites
   // it — an edit made mid-push belongs on disk and must still be mirrored.

--- a/lib/features/collections/data/services/git_branch_service.dart
+++ b/lib/features/collections/data/services/git_branch_service.dart
@@ -55,10 +55,11 @@ class GitBranchService implements BranchService {
   /// aborts), and the suspension drops any edit made *during* it — whose
   /// debounce would otherwise fire after the checkout and mirror the old
   /// branch's tree onto the new one. The suspension is lifted even if git
-  /// throws.
-  Future<void> _runOnTree(Future<void> Function() action) async {
+  /// throws. Generic so callers that need the action's result (e.g. `pull`'s
+  /// [PullOutcome]) don't need a second helper.
+  Future<T> _runOnTree<T>(Future<T> Function() action) async {
     await _flushOrThrow();
-    await _sync.withMirroringSuspended(action);
+    return _sync.withMirroringSuspended(action);
   }
 
   @override
@@ -83,14 +84,8 @@ class GitBranchService implements BranchService {
     await _git.createBranch(root, branch);
   }
 
-  // `GitService.pull` now returns a `PullOutcome`; `BranchService.pull` is
-  // still `Future<void>` here — a later task (Spec D T4/T6) rewires callers
-  // to consume the outcome for conflict handling. Discard it for now so the
-  // tree keeps compiling.
   @override
-  Future<void> pull(String root) => _runOnTree(() async {
-    await _git.pull(root);
-  });
+  Future<PullOutcome> pull(String root) => _runOnTree(() => _git.pull(root));
 
   // No suspension here: `git push` reads the working tree, it never rewrites
   // it — an edit made mid-push belongs on disk and must still be mirrored.

--- a/lib/features/collections/data/services/git_branch_service.dart
+++ b/lib/features/collections/data/services/git_branch_service.dart
@@ -113,4 +113,10 @@ class GitBranchService implements BranchService {
   // it. This omission is intentional; do not "fix" it by adding a flush.
   @override
   Future<void> dropStash(String root, int index) => _git.stashDrop(root, index);
+
+  // No flush/suspension here, deliberately: `git fetch` only updates
+  // remote-tracking refs — it never touches the working tree — so it cannot
+  // race a pending mirror write.
+  @override
+  Future<void> fetch(String root) => _git.fetch(root);
 }

--- a/lib/features/collections/data/services/git_branch_service.dart
+++ b/lib/features/collections/data/services/git_branch_service.dart
@@ -85,7 +85,13 @@ class GitBranchService implements BranchService {
   }
 
   @override
-  Future<PullOutcome> pull(String root) => _runOnTree(() => _git.pull(root));
+  Future<PullOutcome> pull(
+    String root, {
+    String? authorName,
+    String? authorEmail,
+  }) => _runOnTree(
+    () => _git.pull(root, authorName: authorName, authorEmail: authorEmail),
+  );
 
   // No suspension here: `git push` reads the working tree, it never rewrites
   // it — an edit made mid-push belongs on disk and must still be mirrored.

--- a/lib/features/collections/data/services/git_conflict_service.dart
+++ b/lib/features/collections/data/services/git_conflict_service.dart
@@ -100,20 +100,36 @@ class GitConflictService implements ConflictService {
   @override
   Future<void> resolve(String root, List<FileResolution> resolutions) async {
     for (final res in resolutions) {
+      if (res.wholeFile != null) {
+        await _resolveWholeFile(root, res);
+        continue;
+      }
       final content = await _resolvedContent(root, res); // apply picks → JSON
       await _git.writeWorkingFile(root, res.path, content);
       await _git.add(root, res.path);
     }
   }
 
-  /// Coarse resolutions pick a whole merge-stage side verbatim. Field-level
-  /// resolutions re-derive the same 3-way merge [_classify] would produce,
-  /// then apply [FileResolution.fieldChoices] on top before serializing.
-  Future<String> _resolvedContent(String root, FileResolution res) async {
-    if (res.wholeFile != null) {
-      final stage = res.wholeFile == FileSide.incoming ? 2 : 3;
-      return await _git.showStage(root, res.path, stage) ?? '';
+  /// Coarse resolutions pick a whole merge-stage side verbatim. When the
+  /// chosen side is the deleting side of a delete/modify conflict, its stage
+  /// content is absent (`showStage` returns null) — keeping that side means
+  /// removing the file (`git rm`), never writing empty content (that would
+  /// resurrect it as unparseable JSON).
+  Future<void> _resolveWholeFile(String root, FileResolution res) async {
+    final stage = res.wholeFile == FileSide.incoming ? 2 : 3;
+    final content = await _git.showStage(root, res.path, stage);
+    if (content == null) {
+      await _git.removeFile(root, res.path);
+      return;
     }
+    await _git.writeWorkingFile(root, res.path, content);
+    await _git.add(root, res.path);
+  }
+
+  /// Field-level resolutions re-derive the same 3-way merge [_classify]
+  /// would produce, then apply [FileResolution.fieldChoices] on top before
+  /// serializing.
+  Future<String> _resolvedContent(String root, FileResolution res) async {
     return res.path.endsWith('.folder.json')
         ? _resolvedFolderContent(root, res)
         : _resolvedRequestContent(root, res);

--- a/lib/features/collections/data/services/git_conflict_service.dart
+++ b/lib/features/collections/data/services/git_conflict_service.dart
@@ -1,0 +1,309 @@
+import 'dart:convert';
+
+import 'package:getman/core/domain/entities/body_type.dart';
+import 'package:getman/core/domain/entities/request_config_entity.dart';
+import 'package:getman/core/git/git_service.dart';
+import 'package:getman/core/utils/workspace/workspace_collection_serializer.dart';
+import 'package:getman/features/collections/domain/conflict_service.dart';
+import 'package:getman/features/collections/domain/entities/collection_node_entity.dart';
+import 'package:getman/features/collections/domain/entities/file_conflict.dart';
+import 'package:getman/features/collections/domain/logic/three_way_merge.dart';
+
+/// Drives semantic conflict resolution over a paused `git pull --rebase`:
+/// classifies each conflicted path ([currentConflicts]), field-level 3-way
+/// merges request/folder JSON via [ThreeWayMerge], and writes the user's
+/// picks back to the working tree ([resolve]). Pure orchestration over
+/// [GitService] — no `dart:io` here.
+class GitConflictService implements ConflictService {
+  GitConflictService(this._git);
+  final GitService _git;
+
+  static const JsonEncoder _enc = JsonEncoder.withIndent('  ');
+
+  @override
+  Future<PullOutcome> pullOrConflict(String root) => _git.pull(root);
+
+  @override
+  Future<RebaseStep> continueRebase(String root) async {
+    await _git.rebaseContinue(root);
+    return await _git.isRebaseInProgress(root)
+        ? RebaseStep.moreConflicts
+        : RebaseStep.done;
+  }
+
+  @override
+  Future<void> abort(String root) => _git.rebaseAbort(root);
+
+  // Fetch never touches the working tree — it only updates remote-tracking
+  // refs — so unlike pull/resolve there is nothing here to flush or suspend.
+  @override
+  Future<void> fetch(String root) => _git.fetch(root);
+
+  @override
+  Future<List<FileConflict>> currentConflicts(String root) async {
+    final paths = await _git.conflictedPaths(root);
+    return [for (final p in paths) await _classify(root, p)];
+  }
+
+  Future<FileConflict> _classify(String root, String path) async {
+    if (path.endsWith('.req.json')) {
+      final s1 = await _git.showStage(root, path, 1);
+      final s2 = await _git.showStage(root, path, 2); // incoming
+      final s3 = await _git.showStage(root, path, 3); // yours
+      // delete/modify: one side stage missing.
+      if (s2 == null || s3 == null) {
+        return FileConflict(path: path, kind: ConflictKind.deleteModify);
+      }
+      final base = _leafOrNull(s1);
+      final inc = _leafOrNull(s2);
+      final you = _leafOrNull(s3);
+      if (inc == null || you == null) {
+        return FileConflict(path: path, kind: ConflictKind.structural);
+      }
+      final node = ThreeWayMerge.mergeRequest(base, inc, you);
+      return FileConflict(
+        path: path,
+        kind: s1 == null ? ConflictKind.addAdd : ConflictKind.request,
+        node: node,
+      );
+    }
+    if (path.endsWith('.folder.json')) {
+      final s1 = await _git.showStage(root, path, 1);
+      final s2 = await _git.showStage(root, path, 2); // incoming
+      final s3 = await _git.showStage(root, path, 3); // yours
+      if (s2 == null || s3 == null) {
+        return FileConflict(path: path, kind: ConflictKind.deleteModify);
+      }
+      final base = _folderOrNull(s1);
+      final inc = _folderOrNull(s2);
+      final you = _folderOrNull(s3);
+      if (inc == null || you == null) {
+        return FileConflict(path: path, kind: ConflictKind.structural);
+      }
+      final node = ThreeWayMerge.mergeFolder(
+        base,
+        _folderOrderOrEmpty(s1),
+        inc,
+        _folderOrderOrEmpty(s2),
+        you,
+        _folderOrderOrEmpty(s3),
+      );
+      return FileConflict(
+        path: path,
+        kind: s1 == null ? ConflictKind.addAdd : ConflictKind.folder,
+        node: node,
+      );
+    }
+    return FileConflict(path: path, kind: ConflictKind.structural);
+  }
+
+  @override
+  Future<void> resolve(String root, List<FileResolution> resolutions) async {
+    for (final res in resolutions) {
+      final content = await _resolvedContent(root, res); // apply picks → JSON
+      await _git.writeWorkingFile(root, res.path, content);
+      await _git.add(root, res.path);
+    }
+  }
+
+  /// Coarse resolutions pick a whole merge-stage side verbatim. Field-level
+  /// resolutions re-derive the same 3-way merge [_classify] would produce,
+  /// then apply [FileResolution.fieldChoices] on top before serializing.
+  Future<String> _resolvedContent(String root, FileResolution res) async {
+    if (res.wholeFile != null) {
+      final stage = res.wholeFile == FileSide.incoming ? 2 : 3;
+      return await _git.showStage(root, res.path, stage) ?? '';
+    }
+    return res.path.endsWith('.folder.json')
+        ? _resolvedFolderContent(root, res)
+        : _resolvedRequestContent(root, res);
+  }
+
+  Future<String> _resolvedRequestContent(
+    String root,
+    FileResolution res,
+  ) async {
+    final s1 = await _git.showStage(root, res.path, 1);
+    final s2 = await _git.showStage(root, res.path, 2);
+    final s3 = await _git.showStage(root, res.path, 3);
+    final base = _leafOrNull(s1);
+    final inc = _leafOrNull(s2);
+    final you = _leafOrNull(s3);
+    final node = ThreeWayMerge.mergeRequest(base, inc, you);
+    final resolved = _applyRequestChoices(
+      node.merged,
+      res.fieldChoices,
+      inc,
+      you,
+    );
+    return _enc.convert(WorkspaceCollectionSerializer.requestToJson(resolved));
+  }
+
+  Future<String> _resolvedFolderContent(
+    String root,
+    FileResolution res,
+  ) async {
+    final s1 = await _git.showStage(root, res.path, 1);
+    final s2 = await _git.showStage(root, res.path, 2);
+    final s3 = await _git.showStage(root, res.path, 3);
+    final base = _folderOrNull(s1);
+    final inc = _folderOrNull(s2);
+    final you = _folderOrNull(s3);
+    final incOrder = _folderOrderOrEmpty(s2);
+    final node = ThreeWayMerge.mergeFolder(
+      base,
+      _folderOrderOrEmpty(s1),
+      inc,
+      incOrder,
+      you,
+      _folderOrderOrEmpty(s3),
+    );
+    final resolved = _applyFolderChoices(
+      node.merged,
+      res.fieldChoices,
+      inc,
+      you,
+    );
+    // `childOrder` is structural (see ThreeWayMerge.mergeFolder), so it isn't
+    // reconstructed from an entity field: `_pick` renders it as a
+    // comma-joined string for display, and if the user's choice round-trips
+    // that same joining, split it back; otherwise keep the incoming order.
+    final orderChoice = res.fieldChoices['child order'];
+    final order = orderChoice != null && orderChoice.isNotEmpty
+        ? orderChoice.split(', ')
+        : incOrder;
+    return _enc.convert(
+      WorkspaceCollectionSerializer.folderToJson(resolved, order),
+    );
+  }
+
+  /// Applies request-leaf field picks onto the merged skeleton. Scalar/map
+  /// fields apply the chosen string directly; opaque/list fields
+  /// (`authentication`, `form fields`) aren't representable as a single
+  /// string, so their chosen value must be the literal side marker
+  /// `'incoming'` or `'yours'`, and the whole field is taken from that side's
+  /// parsed entity.
+  CollectionNodeEntity _applyRequestChoices(
+    CollectionNodeEntity merged,
+    Map<String, String> choices,
+    CollectionNodeEntity? incoming,
+    CollectionNodeEntity? yours,
+  ) {
+    var node = merged;
+    var config = merged.config;
+    for (final entry in choices.entries) {
+      final field = entry.key;
+      final value = entry.value;
+      final headerKey = _bracketedKey(field, "header '");
+      if (field == 'name') {
+        node = node.copyWith(name: value);
+      } else if (field == 'favorite') {
+        node = node.copyWith(isFavorite: value == 'true');
+      } else if (field == 'method') {
+        config = config?.copyWith(method: value);
+      } else if (field == 'url') {
+        config = config?.copyWith(url: value);
+      } else if (field == 'body type') {
+        config = config?.copyWith(bodyType: BodyType.fromWire(value));
+      } else if (field == 'body') {
+        config = config?.copyWith(body: value);
+      } else if (field == 'GraphQL variables') {
+        config = config?.copyWith(graphqlVariables: value);
+      } else if (field == 'binary file') {
+        config = config?.copyWith(bodyFilePath: value.isEmpty ? null : value);
+      } else if (field == 'authentication') {
+        config = config?.copyWith(
+          auth: _sideConfig(value, incoming, yours)?.auth ?? const {},
+        );
+      } else if (field == 'form fields') {
+        config = config?.copyWith(
+          formFields:
+              _sideConfig(value, incoming, yours)?.formFields ?? const [],
+        );
+      } else if (headerKey != null) {
+        final headers = Map<String, String>.from(config?.headers ?? const {});
+        headers[headerKey] = value;
+        config = config?.copyWith(headers: headers);
+      }
+    }
+    return config == null ? node : node.copyWith(config: config);
+  }
+
+  /// Applies folder field picks onto the merged skeleton. `secret keys` is a
+  /// list field (same `'incoming'`/`'yours'` side-marker convention as
+  /// request-leaf opaque/list fields). `child order` is handled by the
+  /// caller — it isn't part of the entity.
+  CollectionNodeEntity _applyFolderChoices(
+    CollectionNodeEntity merged,
+    Map<String, String> choices,
+    CollectionNodeEntity? incoming,
+    CollectionNodeEntity? yours,
+  ) {
+    var node = merged;
+    final variables = Map<String, String>.from(merged.variables);
+    var secretKeys = merged.secretKeys;
+    for (final entry in choices.entries) {
+      final field = entry.key;
+      final value = entry.value;
+      final variableKey = _bracketedKey(field, "variable '");
+      if (field == 'name') {
+        node = node.copyWith(name: value);
+      } else if (field == 'favorite') {
+        node = node.copyWith(isFavorite: value == 'true');
+      } else if (field == 'secret keys') {
+        secretKeys =
+            (value == 'yours' ? yours : incoming)?.secretKeys ?? const {};
+      } else if (variableKey != null) {
+        variables[variableKey] = value;
+      }
+    }
+    return node.copyWith(variables: variables, secretKeys: secretKeys);
+  }
+
+  static String? _bracketedKey(String field, String prefix) {
+    if (!field.startsWith(prefix) || !field.endsWith("'")) return null;
+    return field.substring(prefix.length, field.length - 1);
+  }
+
+  static HttpRequestConfigEntity? _sideConfig(
+    String value,
+    CollectionNodeEntity? incoming,
+    CollectionNodeEntity? yours,
+  ) => (value == 'yours' ? yours : incoming)?.config;
+
+  static CollectionNodeEntity? _leafOrNull(String? json) {
+    if (json == null) return null;
+    try {
+      return WorkspaceCollectionSerializer.requestFromJson(
+        jsonDecode(json) as Map<String, dynamic>,
+      );
+    } on Object catch (_) {
+      // Unparseable stage content (malformed JSON or shape mismatch) is
+      // reported as a structural conflict by the caller, not a crash.
+      return null;
+    }
+  }
+
+  static CollectionNodeEntity? _folderOrNull(String? json) {
+    if (json == null) return null;
+    try {
+      return WorkspaceCollectionSerializer.folderFromJson(
+        jsonDecode(json) as Map<String, dynamic>,
+        const [],
+      );
+    } on Object catch (_) {
+      return null;
+    }
+  }
+
+  static List<String> _folderOrderOrEmpty(String? json) {
+    if (json == null) return const [];
+    try {
+      return WorkspaceCollectionSerializer.childOrder(
+        jsonDecode(json) as Map<String, dynamic>,
+      );
+    } on Object catch (_) {
+      return const [];
+    }
+  }
+}

--- a/lib/features/collections/data/services/git_conflict_service.dart
+++ b/lib/features/collections/data/services/git_conflict_service.dart
@@ -26,13 +26,20 @@ class GitConflictService implements ConflictService {
   Future<PullOutcome> pullOrConflict(String root) => _git.pull(root);
 
   @override
-  Future<RebaseStep> continueRebase(String root) =>
-      _sync.withMirroringSuspended(() async {
-        await _git.rebaseContinue(root);
-        return await _git.isRebaseInProgress(root)
-            ? RebaseStep.moreConflicts
-            : RebaseStep.done;
-      });
+  Future<RebaseStep> continueRebase(
+    String root, {
+    String? authorName,
+    String? authorEmail,
+  }) => _sync.withMirroringSuspended(() async {
+    await _git.rebaseContinue(
+      root,
+      authorName: authorName,
+      authorEmail: authorEmail,
+    );
+    return await _git.isRebaseInProgress(root)
+        ? RebaseStep.moreConflicts
+        : RebaseStep.done;
+  });
 
   @override
   Future<void> abort(String root) => _git.rebaseAbort(root);

--- a/lib/features/collections/data/services/git_conflict_service.dart
+++ b/lib/features/collections/data/services/git_conflict_service.dart
@@ -4,6 +4,7 @@ import 'package:getman/core/domain/entities/body_type.dart';
 import 'package:getman/core/domain/entities/request_config_entity.dart';
 import 'package:getman/core/git/git_service.dart';
 import 'package:getman/core/utils/workspace/workspace_collection_serializer.dart';
+import 'package:getman/features/collections/data/services/workspace_sync_service.dart';
 import 'package:getman/features/collections/domain/conflict_service.dart';
 import 'package:getman/features/collections/domain/entities/collection_node_entity.dart';
 import 'package:getman/features/collections/domain/entities/file_conflict.dart';
@@ -15,8 +16,9 @@ import 'package:getman/features/collections/domain/logic/three_way_merge.dart';
 /// picks back to the working tree ([resolve]). Pure orchestration over
 /// [GitService] — no `dart:io` here.
 class GitConflictService implements ConflictService {
-  GitConflictService(this._git);
+  GitConflictService(this._git, this._sync);
   final GitService _git;
+  final WorkspaceSyncService _sync;
 
   static const JsonEncoder _enc = JsonEncoder.withIndent('  ');
 
@@ -24,12 +26,13 @@ class GitConflictService implements ConflictService {
   Future<PullOutcome> pullOrConflict(String root) => _git.pull(root);
 
   @override
-  Future<RebaseStep> continueRebase(String root) async {
-    await _git.rebaseContinue(root);
-    return await _git.isRebaseInProgress(root)
-        ? RebaseStep.moreConflicts
-        : RebaseStep.done;
-  }
+  Future<RebaseStep> continueRebase(String root) =>
+      _sync.withMirroringSuspended(() async {
+        await _git.rebaseContinue(root);
+        return await _git.isRebaseInProgress(root)
+            ? RebaseStep.moreConflicts
+            : RebaseStep.done;
+      });
 
   @override
   Future<void> abort(String root) => _git.rebaseAbort(root);
@@ -50,9 +53,14 @@ class GitConflictService implements ConflictService {
       final s1 = await _git.showStage(root, path, 1);
       final s2 = await _git.showStage(root, path, 2); // incoming
       final s3 = await _git.showStage(root, path, 3); // yours
-      // delete/modify: one side stage missing.
+      // delete/modify: one side stage missing. The side whose stage is
+      // ABSENT is the one that deleted the file.
       if (s2 == null || s3 == null) {
-        return FileConflict(path: path, kind: ConflictKind.deleteModify);
+        return FileConflict(
+          path: path,
+          kind: ConflictKind.deleteModify,
+          deletedSide: s2 == null ? FileSide.incoming : FileSide.yours,
+        );
       }
       final base = _leafOrNull(s1);
       final inc = _leafOrNull(s2);
@@ -72,7 +80,11 @@ class GitConflictService implements ConflictService {
       final s2 = await _git.showStage(root, path, 2); // incoming
       final s3 = await _git.showStage(root, path, 3); // yours
       if (s2 == null || s3 == null) {
-        return FileConflict(path: path, kind: ConflictKind.deleteModify);
+        return FileConflict(
+          path: path,
+          kind: ConflictKind.deleteModify,
+          deletedSide: s2 == null ? FileSide.incoming : FileSide.yours,
+        );
       }
       final base = _folderOrNull(s1);
       final inc = _folderOrNull(s2);
@@ -98,17 +110,19 @@ class GitConflictService implements ConflictService {
   }
 
   @override
-  Future<void> resolve(String root, List<FileResolution> resolutions) async {
-    for (final res in resolutions) {
-      if (res.wholeFile != null) {
-        await _resolveWholeFile(root, res);
-        continue;
-      }
-      final content = await _resolvedContent(root, res); // apply picks → JSON
-      await _git.writeWorkingFile(root, res.path, content);
-      await _git.add(root, res.path);
-    }
-  }
+  Future<void> resolve(String root, List<FileResolution> resolutions) =>
+      _sync.withMirroringSuspended(() async {
+        for (final res in resolutions) {
+          if (res.wholeFile != null) {
+            await _resolveWholeFile(root, res);
+            continue;
+          }
+          // apply picks → JSON
+          final content = await _resolvedContent(root, res);
+          await _git.writeWorkingFile(root, res.path, content);
+          await _git.add(root, res.path);
+        }
+      });
 
   /// Coarse resolutions pick a whole merge-stage side verbatim. When the
   /// chosen side is the deleting side of a delete/modify conflict, its stage

--- a/lib/features/collections/data/services/workspace_review_service.dart
+++ b/lib/features/collections/data/services/workspace_review_service.dart
@@ -54,8 +54,17 @@ class WorkspaceReviewService implements ReviewService {
   Future<void> unstage(String root, List<String> paths) =>
       _git.unstage(root, paths);
   @override
-  Future<void> commit(String root, String message) =>
-      _git.commit(root, message);
+  Future<void> commit(
+    String root,
+    String message, {
+    String? authorName,
+    String? authorEmail,
+  }) => _git.commit(
+    root,
+    message,
+    authorName: authorName,
+    authorEmail: authorEmail,
+  );
 
   Future<ReviewEntry?> _entryFor(String root, GitStatusEntry s) async {
     final path = s.path;

--- a/lib/features/collections/domain/branch_service.dart
+++ b/lib/features/collections/domain/branch_service.dart
@@ -13,6 +13,11 @@ abstract class BranchService {
   Future<void> switchTo(String root, String branch);
   Future<void> create(String root, String branch);
 
+  /// Adds a remote (`git remote add <name> <url>`) — used when the user
+  /// supplies a URL from the add-remote prompt to enable pull/push/fetch on a
+  /// repo that has none yet.
+  Future<void> addRemote(String root, String name, String url);
+
   /// `git pull --rebase`. Returns [PullOutcome.conflicted] when the rebase
   /// halted on a true conflict — the working tree is left mid-rebase for the
   /// conflict-resolution flow, not rolled back. [authorName]/[authorEmail]

--- a/lib/features/collections/domain/branch_service.dart
+++ b/lib/features/collections/domain/branch_service.dart
@@ -15,8 +15,15 @@ abstract class BranchService {
 
   /// `git pull --rebase`. Returns [PullOutcome.conflicted] when the rebase
   /// halted on a true conflict — the working tree is left mid-rebase for the
-  /// conflict-resolution flow, not rolled back.
-  Future<PullOutcome> pull(String root);
+  /// conflict-resolution flow, not rolled back. [authorName]/[authorEmail]
+  /// are the Getman-owned commit identity from Settings (see
+  /// `GitService.commit`) — threaded through so a rebase that needs to
+  /// create a commit still succeeds without a configured OS git identity.
+  Future<PullOutcome> pull(
+    String root, {
+    String? authorName,
+    String? authorEmail,
+  });
   Future<void> push(String root);
   Future<void> stash(String root, String message);
   Future<void> popStash(String root, int index);

--- a/lib/features/collections/domain/branch_service.dart
+++ b/lib/features/collections/domain/branch_service.dart
@@ -16,4 +16,8 @@ abstract class BranchService {
   Future<void> stash(String root, String message);
   Future<void> popStash(String root, int index);
   Future<void> dropStash(String root, int index);
+
+  /// `git fetch` — updates remote-tracking refs without touching the working
+  /// tree (manual FETCH action + the auto-fetch background loop).
+  Future<void> fetch(String root);
 }

--- a/lib/features/collections/domain/branch_service.dart
+++ b/lib/features/collections/domain/branch_service.dart
@@ -1,3 +1,4 @@
+import 'package:getman/core/git/git_service.dart' show PullOutcome;
 import 'package:getman/features/collections/domain/entities/branch_status.dart';
 
 /// Branch + sync operations over the git workspace. The bloc depends on this
@@ -11,7 +12,11 @@ abstract class BranchService {
 
   Future<void> switchTo(String root, String branch);
   Future<void> create(String root, String branch);
-  Future<void> pull(String root);
+
+  /// `git pull --rebase`. Returns [PullOutcome.conflicted] when the rebase
+  /// halted on a true conflict — the working tree is left mid-rebase for the
+  /// conflict-resolution flow, not rolled back.
+  Future<PullOutcome> pull(String root);
   Future<void> push(String root);
   Future<void> stash(String root, String message);
   Future<void> popStash(String root, int index);

--- a/lib/features/collections/domain/conflict_service.dart
+++ b/lib/features/collections/domain/conflict_service.dart
@@ -18,7 +18,15 @@ abstract class ConflictService {
   Future<void> resolve(String root, List<FileResolution> resolutions);
 
   /// Continues an in-progress rebase after conflicts are staged.
-  Future<RebaseStep> continueRebase(String root);
+  /// [authorName]/[authorEmail] are the Getman-owned commit identity from
+  /// Settings (see `GitService.commit`) — threaded through so the commit
+  /// `rebase --continue` creates still succeeds without a configured OS git
+  /// identity.
+  Future<RebaseStep> continueRebase(
+    String root, {
+    String? authorName,
+    String? authorEmail,
+  });
 
   /// Aborts an in-progress rebase, restoring the pre-pull state.
   Future<void> abort(String root);

--- a/lib/features/collections/domain/conflict_service.dart
+++ b/lib/features/collections/domain/conflict_service.dart
@@ -1,0 +1,29 @@
+import 'package:getman/core/git/git_service.dart';
+import 'package:getman/features/collections/domain/entities/file_conflict.dart';
+
+/// Orchestrates `git pull --rebase` conflict resolution: field-level 3-way
+/// merge where possible, whole-file resolution otherwise. Implementations
+/// live in the data layer (they shell out to git via [GitService]); this
+/// abstraction is what `ConflictBloc` depends on.
+abstract class ConflictService {
+  /// Runs `git pull --rebase` and reports whether it landed clean or halted
+  /// with conflicts to resolve.
+  Future<PullOutcome> pullOrConflict(String root);
+
+  /// The conflicted files of an in-progress rebase, classified and — where
+  /// possible — pre-merged field-by-field.
+  Future<List<FileConflict>> currentConflicts(String root);
+
+  /// Applies the user's [resolutions] to the working tree and stages them.
+  Future<void> resolve(String root, List<FileResolution> resolutions);
+
+  /// Continues an in-progress rebase after conflicts are staged.
+  Future<RebaseStep> continueRebase(String root);
+
+  /// Aborts an in-progress rebase, restoring the pre-pull state.
+  Future<void> abort(String root);
+
+  /// Fetches from the remote without merging (manual FETCH action + the
+  /// auto-fetch background loop).
+  Future<void> fetch(String root);
+}

--- a/lib/features/collections/domain/entities/file_conflict.dart
+++ b/lib/features/collections/domain/entities/file_conflict.dart
@@ -1,0 +1,57 @@
+import 'package:equatable/equatable.dart';
+import 'package:getman/features/collections/domain/logic/three_way_merge.dart';
+
+/// What kind of conflict a workspace file is in, as classified by the
+/// conflict service after a rebase halts. `request`/`folder` are
+/// field-level (resolved via [ThreeWayMerge]); `addAdd`/`deleteModify`/
+/// `structural` are coarse — resolved by picking a whole-file side.
+enum ConflictKind { request, folder, addAdd, deleteModify, structural }
+
+/// One conflicted file surfaced by `ConflictService.currentConflicts`.
+/// `node` is deliberately excluded from props — it's compared by identity,
+/// not value; only path + kind determine conflict identity/equality.
+// ignore: equatable_props_complete
+class FileConflict extends Equatable {
+  const FileConflict({required this.path, required this.kind, this.node});
+
+  final String path;
+  final ConflictKind kind;
+
+  /// Present for [ConflictKind.request]/[ConflictKind.folder] (field-level);
+  /// null for coarse kinds.
+  final NodeMergeResult? node;
+
+  bool get isFieldLevel => node != null;
+
+  @override
+  // node compared by identity is fine.
+  List<Object?> get props => [path, kind];
+}
+
+/// The side of a whole-file (coarse) conflict the user picked.
+enum FileSide { incoming, yours }
+
+/// One user decision for a conflicted file. For field-level conflicts:
+/// a map of field-label → chosen value (an edited string, or the picked
+/// incoming/yours value). For coarse conflicts: a whole-file side.
+class FileResolution extends Equatable {
+  const FileResolution({
+    required this.path,
+    this.fieldChoices = const {},
+    this.wholeFile,
+  });
+
+  final String path;
+
+  /// field-label → resolved string value.
+  final Map<String, String> fieldChoices;
+
+  /// Set for coarse/structural files.
+  final FileSide? wholeFile;
+
+  @override
+  List<Object?> get props => [path, fieldChoices, wholeFile];
+}
+
+/// Outcome of asking the conflict service to continue an in-progress rebase.
+enum RebaseStep { done, moreConflicts }

--- a/lib/features/collections/domain/entities/file_conflict.dart
+++ b/lib/features/collections/domain/entities/file_conflict.dart
@@ -12,7 +12,12 @@ enum ConflictKind { request, folder, addAdd, deleteModify, structural }
 /// not value; only path + kind determine conflict identity/equality.
 // ignore: equatable_props_complete
 class FileConflict extends Equatable {
-  const FileConflict({required this.path, required this.kind, this.node});
+  const FileConflict({
+    required this.path,
+    required this.kind,
+    this.node,
+    this.deletedSide,
+  });
 
   final String path;
   final ConflictKind kind;
@@ -21,11 +26,17 @@ class FileConflict extends Equatable {
   /// null for coarse kinds.
   final NodeMergeResult? node;
 
+  /// For [ConflictKind.deleteModify] only: which side deleted the file (the
+  /// side whose merge stage is absent). Null for every other [kind]. Drives
+  /// the coarse tile's button orientation — "Accept the deletion" always maps
+  /// to this side, never hardcoded to incoming/yours.
+  final FileSide? deletedSide;
+
   bool get isFieldLevel => node != null;
 
   @override
   // node compared by identity is fine.
-  List<Object?> get props => [path, kind];
+  List<Object?> get props => [path, kind, deletedSide];
 }
 
 /// The side of a whole-file (coarse) conflict the user picked.

--- a/lib/features/collections/domain/entities/pull_request.dart
+++ b/lib/features/collections/domain/entities/pull_request.dart
@@ -1,0 +1,43 @@
+import 'package:equatable/equatable.dart';
+
+/// A PR's lifecycle state (only `open` is listed in v1, but the mapping is
+/// total so a created PR and future scopes are covered).
+enum PrState { open, merged, closed }
+
+/// Rolled-up CI verdict for a PR's head commit.
+enum PrChecks { none, pending, passing, failing }
+
+/// Whether the `gh` CLI can be used right now.
+enum GhAvailability { available, notInstalled, notAuthenticated }
+
+class PullRequestEntity extends Equatable {
+  const PullRequestEntity({
+    required this.number,
+    required this.title,
+    required this.state,
+    required this.url,
+    required this.isDraft,
+    required this.checks,
+  });
+
+  final int number;
+  final String title;
+  final PrState state;
+  final String url;
+  final bool isDraft;
+  final PrChecks checks;
+
+  @override
+  List<Object?> get props => [number, title, state, url, isDraft, checks];
+}
+
+/// The just-created PR — its number (parsed from the url) and url.
+class PullRequestRef extends Equatable {
+  const PullRequestRef({required this.number, required this.url});
+
+  final int number;
+  final String url;
+
+  @override
+  List<Object?> get props => [number, url];
+}

--- a/lib/features/collections/domain/logic/three_way_merge.dart
+++ b/lib/features/collections/domain/logic/three_way_merge.dart
@@ -1,0 +1,383 @@
+import 'package:collection/collection.dart';
+import 'package:equatable/equatable.dart';
+import 'package:getman/core/domain/entities/body_type.dart';
+import 'package:getman/core/domain/entities/multipart_field_entity.dart';
+import 'package:getman/core/domain/entities/request_config_entity.dart';
+import 'package:getman/features/collections/domain/entities/collection_node_entity.dart';
+
+/// What kind of value a [FieldConflict] carries. `scalar`/`mapEntry` show the
+/// raw incoming/yours strings; `opaque`/`list` are whole-field (auth,
+/// formFields) where the raw values aren't surfaced.
+enum FieldConflictKind { scalar, mapEntry, opaque, list }
+
+/// One field of a request/folder node that [ThreeWayMerge] could not
+/// auto-resolve because both `incoming` and `yours` changed it differently
+/// from `base`. Field labels mirror the vocabulary used by
+/// `lib/features/collections/domain/logic/semantic_diff.dart` (e.g. "url",
+/// "header 'X'", "authentication", "variable 'Y'", "child order") so the
+/// resolver UI and the diff viewer read the same names.
+class FieldConflict extends Equatable {
+  const FieldConflict({
+    required this.field,
+    required this.kind,
+    this.incoming,
+    this.yours,
+  });
+
+  final String field;
+  final FieldConflictKind kind;
+
+  /// Null for opaque/list conflicts (auth, formFields) where the raw value
+  /// isn't shown.
+  final String? incoming;
+  final String? yours;
+
+  @override
+  List<Object?> get props => [field, kind, incoming, yours];
+}
+
+/// Result of a field-level 3-way merge: a best-effort [merged] node with
+/// every auto-resolvable field applied (unresolved fields left at the
+/// `incoming` value) plus the [conflicts] that still need a user decision.
+/// An empty [conflicts] list means the node fully auto-merged.
+class NodeMergeResult {
+  const NodeMergeResult({required this.merged, required this.conflicts});
+
+  final CollectionNodeEntity merged;
+  final List<FieldConflict> conflicts;
+}
+
+const _mapEq = MapEquality<String, String>();
+const _formFieldsEq = ListEquality<MultipartFieldEntity>();
+const _secretKeysEq = SetEquality<String>();
+
+/// Pure field-level 3-way merge for collection nodes, driven by a rebase
+/// conflict's base (stage 1) / incoming (stage 2, upstream) / yours (stage 3,
+/// your replayed commit) versions. No IO, no Flutter — pure Dart +
+/// equatable + collection only (`domain_no_infrastructure_imports`).
+class ThreeWayMerge {
+  const ThreeWayMerge._();
+
+  /// Merges a request leaf. [base]/[incoming]/[yours] may each be null (e.g.
+  /// [base] is null for an add/add conflict).
+  static NodeMergeResult mergeRequest(
+    CollectionNodeEntity? base,
+    CollectionNodeEntity? incoming,
+    CollectionNodeEntity? yours,
+  ) {
+    final skeleton = incoming ?? yours ?? base;
+    if (skeleton == null) {
+      throw ArgumentError(
+        'mergeRequest requires at least one of base/incoming/yours',
+      );
+    }
+    final conflicts = <FieldConflict>[];
+
+    final name = _pick(
+      conflicts,
+      'name',
+      base?.name,
+      incoming?.name,
+      yours?.name,
+      (v) => v ?? '',
+    );
+    final isFavorite = _pick(
+      conflicts,
+      'favorite',
+      base?.isFavorite,
+      incoming?.isFavorite,
+      yours?.isFavorite,
+      (v) => '${v ?? false}',
+    );
+    final mergedConfig = _mergeConfig(
+      conflicts,
+      base?.config,
+      incoming?.config,
+      yours?.config,
+    );
+
+    final merged = skeleton.copyWith(
+      name: name,
+      isFavorite: isFavorite,
+      config: mergedConfig,
+    );
+    return NodeMergeResult(merged: merged, conflicts: conflicts);
+  }
+
+  /// Merges a folder node's own fields (name, favorite, variables,
+  /// secretKeys) and reports a "child order" conflict when the persisted
+  /// [baseOrder]/[incomingOrder]/[yoursOrder] child-name lists diverge on all
+  /// three sides. Does not reconcile the actual `children` list — that's a
+  /// structural concern handled above this pure engine.
+  static NodeMergeResult mergeFolder(
+    CollectionNodeEntity? base,
+    List<String> baseOrder,
+    CollectionNodeEntity? incoming,
+    List<String> incomingOrder,
+    CollectionNodeEntity? yours,
+    List<String> yoursOrder,
+  ) {
+    final skeleton = incoming ?? yours ?? base;
+    if (skeleton == null) {
+      throw ArgumentError(
+        'mergeFolder requires at least one of base/incoming/yours',
+      );
+    }
+    final conflicts = <FieldConflict>[];
+
+    final name = _pick(
+      conflicts,
+      'name',
+      base?.name,
+      incoming?.name,
+      yours?.name,
+      (v) => v ?? '',
+    );
+    final isFavorite = _pick(
+      conflicts,
+      'favorite',
+      base?.isFavorite,
+      incoming?.isFavorite,
+      yours?.isFavorite,
+      (v) => '${v ?? false}',
+    );
+    final variables = _mergeMap(
+      conflicts,
+      'variable',
+      base?.variables ?? const {},
+      incoming?.variables ?? const {},
+      yours?.variables ?? const {},
+    );
+    final secretKeys = _mergeSecretKeys(
+      conflicts,
+      base?.secretKeys ?? const {},
+      incoming?.secretKeys ?? const {},
+      yours?.secretKeys ?? const {},
+    );
+
+    // childOrder is a scalar over the joined string — reported only, not
+    // reconstructed into `children` (structural, handled elsewhere).
+    _pick(
+      conflicts,
+      'child order',
+      baseOrder.join(', '),
+      incomingOrder.join(', '),
+      yoursOrder.join(', '),
+      (v) => v,
+    );
+
+    final merged = skeleton.copyWith(
+      name: name,
+      isFavorite: isFavorite,
+      variables: variables,
+      secretKeys: secretKeys,
+    );
+    return NodeMergeResult(merged: merged, conflicts: conflicts);
+  }
+
+  static HttpRequestConfigEntity? _mergeConfig(
+    List<FieldConflict> conflicts,
+    HttpRequestConfigEntity? base,
+    HttpRequestConfigEntity? incoming,
+    HttpRequestConfigEntity? yours,
+  ) {
+    final skeleton = incoming ?? yours ?? base;
+    if (skeleton == null) return null;
+
+    final method = _pick(
+      conflicts,
+      'method',
+      base?.method,
+      incoming?.method,
+      yours?.method,
+      (v) => v ?? '',
+    );
+    final url = _pick(
+      conflicts,
+      'url',
+      base?.url,
+      incoming?.url,
+      yours?.url,
+      (v) => v ?? '',
+    );
+    final bodyTypeWire = _pick(
+      conflicts,
+      'body type',
+      base?.bodyType.wire,
+      incoming?.bodyType.wire,
+      yours?.bodyType.wire,
+      (v) => v ?? '',
+    );
+    final body = _pick(
+      conflicts,
+      'body',
+      base?.body,
+      incoming?.body,
+      yours?.body,
+      (v) => v ?? '',
+    );
+    final graphqlVariables = _pick(
+      conflicts,
+      'GraphQL variables',
+      base?.graphqlVariables,
+      incoming?.graphqlVariables,
+      yours?.graphqlVariables,
+      (v) => v ?? '',
+    );
+    final bodyFilePath = _pick(
+      conflicts,
+      'binary file',
+      base?.bodyFilePath,
+      incoming?.bodyFilePath,
+      yours?.bodyFilePath,
+      (v) => v ?? '',
+    );
+    final headers = _mergeMap(
+      conflicts,
+      'header',
+      base?.headers ?? const {},
+      incoming?.headers ?? const {},
+      yours?.headers ?? const {},
+    );
+    final auth = _mergeAuth(
+      conflicts,
+      base?.auth ?? const {},
+      incoming?.auth ?? const {},
+      yours?.auth ?? const {},
+    );
+    final formFields = _mergeFormFields(
+      conflicts,
+      base?.formFields ?? const [],
+      incoming?.formFields ?? const [],
+      yours?.formFields ?? const [],
+    );
+
+    return skeleton.copyWith(
+      method: method,
+      url: url,
+      headers: headers,
+      body: body,
+      auth: auth,
+      bodyType: BodyType.fromWire(bodyTypeWire),
+      formFields: formFields,
+      bodyFilePath: bodyFilePath,
+      graphqlVariables: graphqlVariables,
+    );
+  }
+
+  /// Core per-field rule: `incoming == yours` -> agree; `incoming == base` ->
+  /// auto-merge `yours`; `yours == base` -> auto-merge `incoming`; else -> a
+  /// true conflict (value left at `incoming`, both candidates recorded).
+  static T _pick<T>(
+    List<FieldConflict> conflicts,
+    String field,
+    T base,
+    T incoming,
+    T yours,
+    String Function(T value) show, {
+    FieldConflictKind kind = FieldConflictKind.scalar,
+  }) {
+    if (incoming == yours) return incoming;
+    if (incoming == base) return yours;
+    if (yours == base) return incoming;
+    conflicts.add(
+      FieldConflict(
+        field: field,
+        kind: kind,
+        incoming: show(incoming),
+        yours: show(yours),
+      ),
+    );
+    return incoming;
+  }
+
+  /// Maps (headers, folder variables) are merged per key over the union of
+  /// keys from all three sides, applying [_pick]'s rule to each key.
+  static Map<String, String> _mergeMap(
+    List<FieldConflict> conflicts,
+    String label,
+    Map<String, String> base,
+    Map<String, String> incoming,
+    Map<String, String> yours,
+  ) {
+    final result = <String, String>{};
+    for (final key in {...base.keys, ...incoming.keys, ...yours.keys}) {
+      final b = base[key];
+      final i = incoming[key];
+      final y = yours[key];
+      String? resolved;
+      if (i == y) {
+        resolved = i;
+      } else if (i == b) {
+        resolved = y;
+      } else if (y == b) {
+        resolved = i;
+      } else {
+        conflicts.add(
+          FieldConflict(
+            field: "$label '$key'",
+            kind: FieldConflictKind.mapEntry,
+            incoming: i,
+            yours: y,
+          ),
+        );
+        resolved = i;
+      }
+      if (resolved != null) result[key] = resolved;
+    }
+    return result;
+  }
+
+  static Set<String> _mergeSecretKeys(
+    List<FieldConflict> conflicts,
+    Set<String> base,
+    Set<String> incoming,
+    Set<String> yours,
+  ) {
+    if (_secretKeysEq.equals(incoming, yours)) return incoming;
+    if (_secretKeysEq.equals(incoming, base)) return yours;
+    if (_secretKeysEq.equals(yours, base)) return incoming;
+    conflicts.add(
+      FieldConflict(
+        field: 'secret keys',
+        kind: FieldConflictKind.list,
+        incoming: (incoming.toList()..sort()).join(', '),
+        yours: (yours.toList()..sort()).join(', '),
+      ),
+    );
+    return incoming;
+  }
+
+  static Map<String, String> _mergeAuth(
+    List<FieldConflict> conflicts,
+    Map<String, String> base,
+    Map<String, String> incoming,
+    Map<String, String> yours,
+  ) {
+    if (_mapEq.equals(incoming, yours)) return incoming;
+    if (_mapEq.equals(incoming, base)) return yours;
+    if (_mapEq.equals(yours, base)) return incoming;
+    conflicts.add(
+      const FieldConflict(
+        field: 'authentication',
+        kind: FieldConflictKind.opaque,
+      ),
+    );
+    return incoming;
+  }
+
+  static List<MultipartFieldEntity> _mergeFormFields(
+    List<FieldConflict> conflicts,
+    List<MultipartFieldEntity> base,
+    List<MultipartFieldEntity> incoming,
+    List<MultipartFieldEntity> yours,
+  ) {
+    if (_formFieldsEq.equals(incoming, yours)) return incoming;
+    if (_formFieldsEq.equals(incoming, base)) return yours;
+    if (_formFieldsEq.equals(yours, base)) return incoming;
+    conflicts.add(
+      const FieldConflict(field: 'form fields', kind: FieldConflictKind.list),
+    );
+    return incoming;
+  }
+}

--- a/lib/features/collections/domain/logic/three_way_merge.dart
+++ b/lib/features/collections/domain/logic/three_way_merge.dart
@@ -338,12 +338,7 @@ class ThreeWayMerge {
     if (_secretKeysEq.equals(incoming, base)) return yours;
     if (_secretKeysEq.equals(yours, base)) return incoming;
     conflicts.add(
-      FieldConflict(
-        field: 'secret keys',
-        kind: FieldConflictKind.list,
-        incoming: (incoming.toList()..sort()).join(', '),
-        yours: (yours.toList()..sort()).join(', '),
-      ),
+      const FieldConflict(field: 'secret keys', kind: FieldConflictKind.list),
     );
     return incoming;
   }

--- a/lib/features/collections/domain/pull_request_service.dart
+++ b/lib/features/collections/domain/pull_request_service.dart
@@ -1,0 +1,23 @@
+import 'package:getman/features/collections/domain/entities/pull_request.dart';
+
+/// Domain gateway for GitHub pull-request operations. The data layer backs this
+/// with the `gh` CLI; the bloc depends only on this abstraction.
+abstract class PullRequestService {
+  /// Whether `gh` is installed and authenticated for [root].
+  Future<GhAvailability> availability(String root);
+
+  /// Open PRs for the repo in [root].
+  Future<List<PullRequestEntity>> list(String root);
+
+  /// Pushes the current branch (setting upstream on first push) and opens a PR.
+  Future<PullRequestRef> create(
+    String root, {
+    required String base,
+    required String title,
+    required String body,
+    required bool draft,
+  });
+
+  /// The default base branch to preselect in the create form, or null.
+  Future<String?> defaultBase(String root);
+}

--- a/lib/features/collections/domain/review_service.dart
+++ b/lib/features/collections/domain/review_service.dart
@@ -9,6 +9,15 @@ abstract class ReviewService {
   /// than one subprocess per entry.
   Future<void> stage(String root, List<String> paths);
   Future<void> unstage(String root, List<String> paths);
-  Future<void> commit(String root, String message);
+
+  /// [authorName]/[authorEmail] are the Getman-owned commit identity from
+  /// Settings (see `GitService.commit`) — passed through so a commit
+  /// succeeds even without a configured OS git identity.
+  Future<void> commit(
+    String root,
+    String message, {
+    String? authorName,
+    String? authorEmail,
+  });
   Future<void> init(String root);
 }

--- a/lib/features/collections/presentation/bloc/conflict_bloc.dart
+++ b/lib/features/collections/presentation/bloc/conflict_bloc.dart
@@ -1,10 +1,19 @@
 import 'dart:developer';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:getman/core/git/git_service.dart' show GitException;
 import 'package:getman/features/collections/domain/conflict_service.dart';
 import 'package:getman/features/collections/domain/entities/file_conflict.dart';
 import 'package:getman/features/collections/presentation/bloc/conflict_event.dart';
 import 'package:getman/features/collections/presentation/bloc/conflict_state.dart';
+
+/// Friendly, actionable replacement for the raw git stderr surfaced when
+/// rebase-continue hits a missing commit identity — the raw message tells
+/// the user to run `git config --global …`, which contradicts Getman's
+/// no-config-file approach (identity is stored in Getman only).
+const _missingIdentityMessage =
+    'Set your commit identity (your name and email) in Settings → '
+    'Workspace, then try again.';
 
 /// Drives the resolve → continue loop over an in-progress rebase, one commit
 /// (batch) of conflicts at a time. Errors are surfaced in state and the
@@ -64,7 +73,19 @@ class ConflictBloc extends Bloc<ConflictEvent, ConflictState> {
     } on Object catch (e) {
       // Leave the repo paused mid-rebase — do NOT abort on a resolve failure,
       // the user's picks (and the in-progress rebase) must survive a retry.
-      _fail(e, emit, 'resolve');
+      log('resolve failed: $e', name: 'ConflictBloc');
+      if (e is GitException && GitException.isMissingIdentity(e.message)) {
+        emit(
+          state.copyWith(
+            status: ConflictStatus.error,
+            errorMessage: _missingIdentityMessage,
+          ),
+        );
+      } else {
+        emit(
+          state.copyWith(status: ConflictStatus.error, errorMessage: '$e'),
+        );
+      }
     }
   }
 

--- a/lib/features/collections/presentation/bloc/conflict_bloc.dart
+++ b/lib/features/collections/presentation/bloc/conflict_bloc.dart
@@ -50,7 +50,11 @@ class ConflictBloc extends Bloc<ConflictEvent, ConflictState> {
     emit(state.copyWith(status: ConflictStatus.resolving));
     try {
       await _service.resolve(event.root, event.resolutions);
-      final step = await _service.continueRebase(event.root);
+      final step = await _service.continueRebase(
+        event.root,
+        authorName: event.authorName,
+        authorEmail: event.authorEmail,
+      );
       if (step == RebaseStep.done) {
         emit(state.copyWith(status: ConflictStatus.done));
         return;

--- a/lib/features/collections/presentation/bloc/conflict_bloc.dart
+++ b/lib/features/collections/presentation/bloc/conflict_bloc.dart
@@ -1,0 +1,104 @@
+import 'dart:developer';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:getman/features/collections/domain/conflict_service.dart';
+import 'package:getman/features/collections/domain/entities/file_conflict.dart';
+import 'package:getman/features/collections/presentation/bloc/conflict_event.dart';
+import 'package:getman/features/collections/presentation/bloc/conflict_state.dart';
+
+/// Drives the resolve → continue loop over an in-progress rebase, one commit
+/// (batch) of conflicts at a time. Errors are surfaced in state and the
+/// rebase is left paused — never auto-aborted — so the user never loses
+/// work to a swallowed failure.
+class ConflictBloc extends Bloc<ConflictEvent, ConflictState> {
+  ConflictBloc({required this._service}) : super(const ConflictState()) {
+    on<LoadConflicts>(_onLoad);
+    on<ResolveAndContinue>(_onResolveAndContinue);
+    on<AbortRebase>(_onAbort);
+  }
+
+  final ConflictService _service;
+
+  /// Drops an event while another op is in flight — the bloc is effectively
+  /// droppable. Every handler always emits a terminal (ready/done/error)
+  /// state in a try/catch, so [ConflictState.isBusy] is always exited and
+  /// this cannot deadlock.
+  bool _dropWhileBusy(String op) {
+    if (state.isBusy) {
+      log('$op ignored: another operation is in flight', name: 'ConflictBloc');
+      return true;
+    }
+    return false;
+  }
+
+  Future<void> _onLoad(LoadConflicts event, Emitter<ConflictState> emit) async {
+    if (_dropWhileBusy('load')) return;
+    emit(state.copyWith(status: ConflictStatus.loading));
+    try {
+      final conflicts = await _service.currentConflicts(event.root);
+      _emitBatch(emit, conflicts, state.batch);
+    } on Object catch (e) {
+      _fail(e, emit, 'load');
+    }
+  }
+
+  Future<void> _onResolveAndContinue(
+    ResolveAndContinue event,
+    Emitter<ConflictState> emit,
+  ) async {
+    if (_dropWhileBusy('resolve')) return;
+    emit(state.copyWith(status: ConflictStatus.resolving));
+    try {
+      await _service.resolve(event.root, event.resolutions);
+      final step = await _service.continueRebase(event.root);
+      if (step == RebaseStep.done) {
+        emit(state.copyWith(status: ConflictStatus.done));
+        return;
+      }
+      final conflicts = await _service.currentConflicts(event.root);
+      _emitBatch(emit, conflicts, state.batch + 1);
+    } on Object catch (e) {
+      // Leave the repo paused mid-rebase — do NOT abort on a resolve failure,
+      // the user's picks (and the in-progress rebase) must survive a retry.
+      _fail(e, emit, 'resolve');
+    }
+  }
+
+  Future<void> _onAbort(AbortRebase event, Emitter<ConflictState> emit) async {
+    if (_dropWhileBusy('abort')) return;
+    emit(state.copyWith(status: ConflictStatus.resolving));
+    try {
+      await _service.abort(event.root);
+      emit(state.copyWith(status: ConflictStatus.done));
+    } on Object catch (e) {
+      _fail(e, emit, 'abort');
+    }
+  }
+
+  /// Emits `done` when [conflicts] is empty (nothing left to resolve),
+  /// otherwise `ready` with the batch populated.
+  void _emitBatch(
+    Emitter<ConflictState> emit,
+    List<FileConflict> conflicts,
+    int batch,
+  ) {
+    if (conflicts.isEmpty) {
+      emit(state.copyWith(status: ConflictStatus.done));
+      return;
+    }
+    emit(
+      state.copyWith(
+        status: ConflictStatus.ready,
+        conflicts: conflicts,
+        batch: batch,
+      ),
+    );
+  }
+
+  void _fail(Object e, Emitter<ConflictState> emit, String op) {
+    log('$op failed: $e', name: 'ConflictBloc');
+    emit(
+      state.copyWith(status: ConflictStatus.error, errorMessage: e.toString()),
+    );
+  }
+}

--- a/lib/features/collections/presentation/bloc/conflict_event.dart
+++ b/lib/features/collections/presentation/bloc/conflict_event.dart
@@ -1,0 +1,37 @@
+import 'package:equatable/equatable.dart';
+import 'package:getman/features/collections/domain/entities/file_conflict.dart';
+
+abstract class ConflictEvent extends Equatable {
+  const ConflictEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+/// Loads the current batch of conflicted files for an in-progress rebase.
+class LoadConflicts extends ConflictEvent {
+  const LoadConflicts(this.root);
+  final String root;
+
+  @override
+  List<Object?> get props => [root];
+}
+
+/// Applies [resolutions], stages them, and continues the rebase.
+class ResolveAndContinue extends ConflictEvent {
+  const ResolveAndContinue(this.root, this.resolutions);
+  final String root;
+  final List<FileResolution> resolutions;
+
+  @override
+  List<Object?> get props => [root, resolutions];
+}
+
+/// Aborts the in-progress rebase, restoring the pre-pull state.
+class AbortRebase extends ConflictEvent {
+  const AbortRebase(this.root);
+  final String root;
+
+  @override
+  List<Object?> get props => [root];
+}

--- a/lib/features/collections/presentation/bloc/conflict_event.dart
+++ b/lib/features/collections/presentation/bloc/conflict_event.dart
@@ -19,12 +19,24 @@ class LoadConflicts extends ConflictEvent {
 
 /// Applies [resolutions], stages them, and continues the rebase.
 class ResolveAndContinue extends ConflictEvent {
-  const ResolveAndContinue(this.root, this.resolutions);
+  const ResolveAndContinue(
+    this.root,
+    this.resolutions, {
+    this.authorName,
+    this.authorEmail,
+  });
   final String root;
   final List<FileResolution> resolutions;
 
+  /// Getman-owned commit identity from Settings (see
+  /// `GitService.commit`) — threaded through so the commit
+  /// `rebase --continue` creates still succeeds without a configured OS git
+  /// identity.
+  final String? authorName;
+  final String? authorEmail;
+
   @override
-  List<Object?> get props => [root, resolutions];
+  List<Object?> get props => [root, resolutions, authorName, authorEmail];
 }
 
 /// Aborts the in-progress rebase, restoring the pre-pull state.

--- a/lib/features/collections/presentation/bloc/conflict_state.dart
+++ b/lib/features/collections/presentation/bloc/conflict_state.dart
@@ -1,0 +1,50 @@
+import 'package:equatable/equatable.dart';
+import 'package:getman/features/collections/domain/entities/file_conflict.dart';
+
+/// `ready` is the only non-busy, non-terminal status: the dialog shows the
+/// current batch of conflicts and waits for the user to resolve them.
+enum ConflictStatus { initial, loading, ready, resolving, done, error }
+
+class ConflictState extends Equatable {
+  const ConflictState({
+    this.status = ConflictStatus.initial,
+    this.conflicts = const [],
+    this.batch = 0,
+    this.errorMessage,
+  });
+
+  final ConflictStatus status;
+
+  /// The current batch of conflicted files (one rebase-halt's worth).
+  final List<FileConflict> conflicts;
+
+  /// 0-based commit index — bumped each time a resolve+continue surfaces
+  /// another commit's conflicts, for the dialog's "commit N" header.
+  final int batch;
+
+  final String? errorMessage;
+
+  bool get isBusy =>
+      status == ConflictStatus.loading || status == ConflictStatus.resolving;
+
+  ConflictState copyWith({
+    ConflictStatus? status,
+    List<FileConflict>? conflicts,
+    int? batch,
+    String? errorMessage,
+  }) {
+    final next = status ?? this.status;
+    return ConflictState(
+      status: next,
+      conflicts: conflicts ?? this.conflicts,
+      batch: batch ?? this.batch,
+      // Only an error state keeps a message; anything else clears it.
+      errorMessage: next == ConflictStatus.error
+          ? (errorMessage ?? this.errorMessage)
+          : null,
+    );
+  }
+
+  @override
+  List<Object?> get props => [status, conflicts, batch, errorMessage];
+}

--- a/lib/features/collections/presentation/bloc/git_sync_bloc.dart
+++ b/lib/features/collections/presentation/bloc/git_sync_bloc.dart
@@ -1,10 +1,19 @@
 import 'dart:developer';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:getman/core/git/git_service.dart' show PullOutcome;
+import 'package:getman/core/git/git_service.dart'
+    show GitException, PullOutcome;
 import 'package:getman/features/collections/domain/branch_service.dart';
 import 'package:getman/features/collections/presentation/bloc/git_sync_event.dart';
 import 'package:getman/features/collections/presentation/bloc/git_sync_state.dart';
+
+/// Friendly, actionable replacement for the raw git stderr surfaced when a
+/// pull/rebase hits a missing commit identity — the raw message tells the
+/// user to run `git config --global …`, which contradicts Getman's
+/// no-config-file approach (identity is stored in Getman only).
+const _missingIdentityMessage =
+    'Set your commit identity (your name and email) in Settings → '
+    'Workspace, then try again.';
 
 /// Drives branch + sync over [BranchService]. Errors are surfaced in state
 /// (never only logged) — a silent failure here looks like a no-op to the user.
@@ -158,7 +167,19 @@ class GitSyncBloc extends Bloc<GitSyncEvent, GitSyncState> {
         authorEmail: event.authorEmail,
       );
     } on Object catch (e) {
-      _fail(e, emit, 'pull');
+      log('pull failed: $e', name: 'GitSyncBloc');
+      if (e is GitException && GitException.isMissingIdentity(e.message)) {
+        emit(
+          state.copyWith(
+            status: GitSyncStatus.error,
+            errorMessage: _missingIdentityMessage,
+          ),
+        );
+      } else {
+        emit(
+          state.copyWith(status: GitSyncStatus.error, errorMessage: '$e'),
+        );
+      }
       return;
     }
     emit(

--- a/lib/features/collections/presentation/bloc/git_sync_bloc.dart
+++ b/lib/features/collections/presentation/bloc/git_sync_bloc.dart
@@ -152,7 +152,11 @@ class GitSyncBloc extends Bloc<GitSyncEvent, GitSyncState> {
     emit(state.copyWith(status: GitSyncStatus.busy));
     final PullOutcome outcome;
     try {
-      outcome = await _service.pull(event.root);
+      outcome = await _service.pull(
+        event.root,
+        authorName: event.authorName,
+        authorEmail: event.authorEmail,
+      );
     } on Object catch (e) {
       _fail(e, emit, 'pull');
       return;

--- a/lib/features/collections/presentation/bloc/git_sync_bloc.dart
+++ b/lib/features/collections/presentation/bloc/git_sync_bloc.dart
@@ -68,6 +68,17 @@ class GitSyncBloc extends Bloc<GitSyncEvent, GitSyncState> {
     }
   }
 
+  /// Adds [url] as the `origin` remote when non-null/non-blank — set from the
+  /// add-remote prompt when a pull/push/fetch was invoked on a repo with no
+  /// remote configured yet. Runs before the action it is paired with, inside
+  /// the same try/catch, so a failure here surfaces as the normal error state
+  /// instead of a distinct code path.
+  Future<void> _maybeAddRemote(String root, String? url) async {
+    final trimmed = url?.trim();
+    if (trimmed == null || trimmed.isEmpty) return;
+    await _service.addRemote(root, 'origin', trimmed);
+  }
+
   void _fail(Object e, Emitter<GitSyncState> emit, String op) {
     log('$op failed: $e', name: 'GitSyncBloc');
     emit(
@@ -161,6 +172,7 @@ class GitSyncBloc extends Bloc<GitSyncEvent, GitSyncState> {
     emit(state.copyWith(status: GitSyncStatus.busy));
     final PullOutcome outcome;
     try {
+      await _maybeAddRemote(event.root, event.addRemoteUrl);
       outcome = await _service.pull(
         event.root,
         authorName: event.authorName,
@@ -200,6 +212,7 @@ class GitSyncBloc extends Bloc<GitSyncEvent, GitSyncState> {
     if (_dropWhileBusy('fetch')) return;
     emit(state.copyWith(status: GitSyncStatus.busy));
     try {
+      await _maybeAddRemote(event.root, event.addRemoteUrl);
       await _service.fetch(event.root);
     } on Object catch (e) {
       if (event.silent) {
@@ -230,7 +243,10 @@ class GitSyncBloc extends Bloc<GitSyncEvent, GitSyncState> {
 
   Future<void> _onPush(PushChanges event, Emitter<GitSyncState> emit) async {
     if (_dropWhileBusy('push')) return;
-    await _run(event.root, emit, 'push', () => _service.push(event.root));
+    await _run(event.root, emit, 'push', () async {
+      await _maybeAddRemote(event.root, event.addRemoteUrl);
+      await _service.push(event.root);
+    });
   }
 
   Future<void> _onStash(StashChanges event, Emitter<GitSyncState> emit) async {

--- a/lib/features/collections/presentation/bloc/git_sync_bloc.dart
+++ b/lib/features/collections/presentation/bloc/git_sync_bloc.dart
@@ -23,6 +23,7 @@ class GitSyncBloc extends Bloc<GitSyncEvent, GitSyncState> {
     on<PopStash>(_onPop);
     on<DropStash>(_onDrop);
     on<FetchRemote>(_onFetch);
+    on<ConflictsResolved>(_onResolved);
   }
 
   final BranchService _service;
@@ -187,6 +188,19 @@ class GitSyncBloc extends Bloc<GitSyncEvent, GitSyncState> {
       }
     }
     await _refresh(event.root, emit);
+  }
+
+  /// The conflict resolver finished a rebase (RESOLVE & CONTINUE reached
+  /// `RebaseStep.done`). Nothing here touches git directly — the resolved
+  /// files are already on disk — this only needs to bump `reloadToken` so
+  /// `BranchSyncListener` reloads the merged tree, using the same
+  /// `changedDisk: true` pattern as every other disk-changing op.
+  Future<void> _onResolved(
+    ConflictsResolved event,
+    Emitter<GitSyncState> emit,
+  ) async {
+    if (_dropWhileBusy('resolved')) return;
+    await _run(event.root, emit, 'resolved', () async {}, changedDisk: true);
   }
 
   Future<void> _onPush(PushChanges event, Emitter<GitSyncState> emit) async {

--- a/lib/features/collections/presentation/bloc/git_sync_bloc.dart
+++ b/lib/features/collections/presentation/bloc/git_sync_bloc.dart
@@ -1,6 +1,7 @@
 import 'dart:developer';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:getman/core/git/git_service.dart' show PullOutcome;
 import 'package:getman/features/collections/domain/branch_service.dart';
 import 'package:getman/features/collections/presentation/bloc/git_sync_event.dart';
 import 'package:getman/features/collections/presentation/bloc/git_sync_state.dart';
@@ -21,6 +22,7 @@ class GitSyncBloc extends Bloc<GitSyncEvent, GitSyncState> {
     on<StashChanges>(_onStash);
     on<PopStash>(_onPop);
     on<DropStash>(_onDrop);
+    on<FetchRemote>(_onFetch);
   }
 
   final BranchService _service;
@@ -136,15 +138,55 @@ class GitSyncBloc extends Bloc<GitSyncEvent, GitSyncState> {
     );
   }
 
+  /// Unlike the other mutating ops, `pull` doesn't go through the uniform
+  /// [_run] helper: it needs the [PullOutcome] to decide *which* token to
+  /// bump. A clean pull behaves like every other disk-changing op
+  /// (`reloadToken`); a conflicted pull leaves the tree mid-rebase — it must
+  /// NOT bump `reloadToken` (nothing to reload yet, the rebase is paused) and
+  /// instead bumps `conflictToken` so the widget layer opens the resolver.
+  /// Either way a terminal `ready` state is always emitted so the bloc is
+  /// never left stuck on `busy`.
   Future<void> _onPull(PullChanges event, Emitter<GitSyncState> emit) async {
     if (_dropWhileBusy('pull')) return;
-    await _run(
-      event.root,
-      emit,
-      'pull',
-      () => _service.pull(event.root),
-      changedDisk: true,
+    emit(state.copyWith(status: GitSyncStatus.busy));
+    final PullOutcome outcome;
+    try {
+      outcome = await _service.pull(event.root);
+    } on Object catch (e) {
+      _fail(e, emit, 'pull');
+      return;
+    }
+    emit(
+      state.copyWith(
+        status: GitSyncStatus.busy,
+        reloadToken: outcome == PullOutcome.clean
+            ? state.reloadToken + 1
+            : null,
+        conflictToken: outcome == PullOutcome.conflicted
+            ? state.conflictToken + 1
+            : null,
+      ),
     );
+    await _refresh(event.root, emit);
+  }
+
+  Future<void> _onFetch(FetchRemote event, Emitter<GitSyncState> emit) async {
+    if (_dropWhileBusy('fetch')) return;
+    emit(state.copyWith(status: GitSyncStatus.busy));
+    try {
+      await _service.fetch(event.root);
+    } on Object catch (e) {
+      if (event.silent) {
+        // Auto-fetch runs unattended every few minutes — being offline is
+        // normal, not an error. Log only and fall through to the refresh so
+        // the bloc still lands on a terminal `ready` state.
+        log('fetch (silent) failed: $e', name: 'GitSyncBloc');
+      } else {
+        _fail(e, emit, 'fetch');
+        return;
+      }
+    }
+    await _refresh(event.root, emit);
   }
 
   Future<void> _onPush(PushChanges event, Emitter<GitSyncState> emit) async {

--- a/lib/features/collections/presentation/bloc/git_sync_event.dart
+++ b/lib/features/collections/presentation/bloc/git_sync_event.dart
@@ -30,7 +30,12 @@ class CreateBranch extends GitSyncEvent {
 }
 
 class PullChanges extends GitSyncEvent {
-  const PullChanges(this.root, {this.authorName, this.authorEmail});
+  const PullChanges(
+    this.root, {
+    this.authorName,
+    this.authorEmail,
+    this.addRemoteUrl,
+  });
   final String root;
 
   /// Getman-owned commit identity from Settings (see
@@ -38,15 +43,25 @@ class PullChanges extends GitSyncEvent {
   /// create a commit still succeeds without a configured OS git identity.
   final String? authorName;
   final String? authorEmail;
+
+  /// When non-null (and non-blank), the bloc adds this URL as the `origin`
+  /// remote before pulling — set from the add-remote prompt when the repo
+  /// had no remote configured yet.
+  final String? addRemoteUrl;
   @override
-  List<Object?> get props => [root, authorName, authorEmail];
+  List<Object?> get props => [root, authorName, authorEmail, addRemoteUrl];
 }
 
 class PushChanges extends GitSyncEvent {
-  const PushChanges(this.root);
+  const PushChanges(this.root, {this.addRemoteUrl});
   final String root;
+
+  /// When non-null (and non-blank), the bloc adds this URL as the `origin`
+  /// remote before pushing — set from the add-remote prompt when the repo
+  /// had no remote configured yet.
+  final String? addRemoteUrl;
   @override
-  List<Object?> get props => [root];
+  List<Object?> get props => [root, addRemoteUrl];
 }
 
 class StashChanges extends GitSyncEvent {
@@ -80,11 +95,16 @@ class DropStash extends GitSyncEvent {
 /// manual FETCH menu selection leaves it `false` so a real failure (e.g. auth)
 /// still shows the GIT ERROR dialog.
 class FetchRemote extends GitSyncEvent {
-  const FetchRemote(this.root, {this.silent = false});
+  const FetchRemote(this.root, {this.silent = false, this.addRemoteUrl});
   final String root;
   final bool silent;
+
+  /// When non-null (and non-blank), the bloc adds this URL as the `origin`
+  /// remote before fetching — set from the add-remote prompt when the repo
+  /// had no remote configured yet.
+  final String? addRemoteUrl;
   @override
-  List<Object?> get props => [root, silent];
+  List<Object?> get props => [root, silent, addRemoteUrl];
 }
 
 /// Dispatched by the conflict resolver after it finishes a rebase

--- a/lib/features/collections/presentation/bloc/git_sync_event.dart
+++ b/lib/features/collections/presentation/bloc/git_sync_event.dart
@@ -30,10 +30,16 @@ class CreateBranch extends GitSyncEvent {
 }
 
 class PullChanges extends GitSyncEvent {
-  const PullChanges(this.root);
+  const PullChanges(this.root, {this.authorName, this.authorEmail});
   final String root;
+
+  /// Getman-owned commit identity from Settings (see
+  /// `GitService.commit`) — threaded through so a rebase that needs to
+  /// create a commit still succeeds without a configured OS git identity.
+  final String? authorName;
+  final String? authorEmail;
   @override
-  List<Object?> get props => [root];
+  List<Object?> get props => [root, authorName, authorEmail];
 }
 
 class PushChanges extends GitSyncEvent {

--- a/lib/features/collections/presentation/bloc/git_sync_event.dart
+++ b/lib/features/collections/presentation/bloc/git_sync_event.dart
@@ -80,3 +80,15 @@ class FetchRemote extends GitSyncEvent {
   @override
   List<Object?> get props => [root, silent];
 }
+
+/// Dispatched by the conflict resolver after it finishes a rebase
+/// (RESOLVE & CONTINUE reaches `RebaseStep.done`). Bumps `reloadToken` so
+/// `BranchSyncListener` reloads the merged tree from disk — without this the
+/// resolved files sit on disk while the app's Hive tree stays pre-pull, and
+/// the next edit's debounced mirror silently reverts the merge.
+class ConflictsResolved extends GitSyncEvent {
+  const ConflictsResolved(this.root);
+  final String root;
+  @override
+  List<Object?> get props => [root];
+}

--- a/lib/features/collections/presentation/bloc/git_sync_event.dart
+++ b/lib/features/collections/presentation/bloc/git_sync_event.dart
@@ -66,3 +66,17 @@ class DropStash extends GitSyncEvent {
   @override
   List<Object?> get props => [root, index];
 }
+
+/// `git fetch` — updates remote-tracking refs without touching the working
+/// tree. [silent] marks a background auto-fetch tick: a failure (e.g. offline)
+/// is logged and swallowed rather than surfaced as an error status, so the
+/// branch chip never nags the user for a routine connectivity hiccup. A
+/// manual FETCH menu selection leaves it `false` so a real failure (e.g. auth)
+/// still shows the GIT ERROR dialog.
+class FetchRemote extends GitSyncEvent {
+  const FetchRemote(this.root, {this.silent = false});
+  final String root;
+  final bool silent;
+  @override
+  List<Object?> get props => [root, silent];
+}

--- a/lib/features/collections/presentation/bloc/git_sync_state.dart
+++ b/lib/features/collections/presentation/bloc/git_sync_state.dart
@@ -9,6 +9,7 @@ class GitSyncState extends Equatable {
     this.branch = BranchStatus.none,
     this.errorMessage,
     this.reloadToken = 0,
+    this.conflictToken = 0,
   });
 
   final GitSyncStatus status;
@@ -20,6 +21,13 @@ class GitSyncState extends Equatable {
   /// tree when it changes — blocs never talk to each other directly.
   final int reloadToken;
 
+  /// Bumped when a pull halts on conflicts (rebase left paused). The
+  /// widget-layer BranchChip opens `ConflictResolutionDialog` when it changes
+  /// — blocs never talk to each other directly. Deliberately separate from
+  /// [reloadToken]: a conflicted pull does not reload the tree (the working
+  /// tree is mid-rebase; the reload happens once the conflicts are resolved).
+  final int conflictToken;
+
   bool get isBusy => status == GitSyncStatus.busy;
 
   GitSyncState copyWith({
@@ -27,6 +35,7 @@ class GitSyncState extends Equatable {
     BranchStatus? branch,
     String? errorMessage,
     int? reloadToken,
+    int? conflictToken,
   }) {
     final next = status ?? this.status;
     return GitSyncState(
@@ -40,9 +49,16 @@ class GitSyncState extends Equatable {
           ? (errorMessage ?? this.errorMessage)
           : null,
       reloadToken: reloadToken ?? this.reloadToken,
+      conflictToken: conflictToken ?? this.conflictToken,
     );
   }
 
   @override
-  List<Object?> get props => [status, branch, errorMessage, reloadToken];
+  List<Object?> get props => [
+    status,
+    branch,
+    errorMessage,
+    reloadToken,
+    conflictToken,
+  ];
 }

--- a/lib/features/collections/presentation/bloc/pull_requests_bloc.dart
+++ b/lib/features/collections/presentation/bloc/pull_requests_bloc.dart
@@ -1,0 +1,93 @@
+import 'dart:developer';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:getman/features/collections/domain/entities/pull_request.dart';
+import 'package:getman/features/collections/domain/pull_request_service.dart';
+import 'package:getman/features/collections/presentation/bloc/pull_requests_event.dart';
+import 'package:getman/features/collections/presentation/bloc/pull_requests_state.dart';
+
+class PullRequestsBloc extends Bloc<PullRequestsEvent, PullRequestsState> {
+  PullRequestsBloc({required this._service})
+    : super(const PullRequestsState()) {
+    on<LoadPullRequests>(_onLoad);
+    on<CreatePullRequest>(_onCreate);
+  }
+
+  final PullRequestService _service;
+
+  Future<void> _onLoad(
+    LoadPullRequests event,
+    Emitter<PullRequestsState> emit,
+  ) async {
+    if (_dropWhileBusy('LoadPullRequests')) return;
+    emit(state.copyWith(status: PrStatus.loading));
+    try {
+      final availability = await _service.availability(event.root);
+      if (availability != GhAvailability.available) {
+        emit(
+          state.copyWith(
+            status: PrStatus.ready,
+            availability: availability,
+            prs: const [],
+          ),
+        );
+        return;
+      }
+      final prs = await _service.list(event.root);
+      emit(
+        state.copyWith(
+          status: PrStatus.ready,
+          availability: availability,
+          prs: prs,
+        ),
+      );
+    } on Object catch (e) {
+      _fail(emit, e);
+    }
+  }
+
+  Future<void> _onCreate(
+    CreatePullRequest event,
+    Emitter<PullRequestsState> emit,
+  ) async {
+    if (_dropWhileBusy('CreatePullRequest')) return;
+    emit(state.copyWith(status: PrStatus.creating));
+    try {
+      final ref = await _service.create(
+        event.root,
+        base: event.base,
+        title: event.title,
+        body: event.body,
+        draft: event.draft,
+      );
+      final prs = await _service.list(event.root);
+      emit(
+        state.copyWith(
+          status: PrStatus.ready,
+          prs: prs,
+          lastCreated: ref,
+        ),
+      );
+    } on Object catch (e) {
+      _fail(emit, e);
+    }
+  }
+
+  /// Drops a second op while one is running: a concurrent gh call could race
+  /// the push/create. Every handler always emits a terminal state, so busy is
+  /// always exited — this cannot deadlock.
+  bool _dropWhileBusy(String event) {
+    if (state.isBusy) {
+      log('dropping $event while busy', name: 'PullRequestsBloc');
+      return true;
+    }
+    return false;
+  }
+
+  void _fail(Emitter<PullRequestsState> emit, Object error) {
+    log('pull-request op failed: $error', name: 'PullRequestsBloc');
+    emit(
+      state.copyWith(status: PrStatus.error, errorMessage: error.toString()),
+    );
+  }
+}

--- a/lib/features/collections/presentation/bloc/pull_requests_bloc.dart
+++ b/lib/features/collections/presentation/bloc/pull_requests_bloc.dart
@@ -34,11 +34,14 @@ class PullRequestsBloc extends Bloc<PullRequestsEvent, PullRequestsState> {
         return;
       }
       final prs = await _service.list(event.root);
+      // Resolve the default base once (for the create form) — best-effort.
+      final base = state.defaultBase ?? await _service.defaultBase(event.root);
       emit(
         state.copyWith(
           status: PrStatus.ready,
           availability: availability,
           prs: prs,
+          defaultBase: base,
         ),
       );
     } on Object catch (e) {
@@ -52,25 +55,30 @@ class PullRequestsBloc extends Bloc<PullRequestsEvent, PullRequestsState> {
   ) async {
     if (_dropWhileBusy('CreatePullRequest')) return;
     emit(state.copyWith(status: PrStatus.creating));
+    final PullRequestRef ref;
     try {
-      final ref = await _service.create(
+      ref = await _service.create(
         event.root,
         base: event.base,
         title: event.title,
         body: event.body,
         draft: event.draft,
       );
-      final prs = await _service.list(event.root);
-      emit(
-        state.copyWith(
-          status: PrStatus.ready,
-          prs: prs,
-          lastCreated: ref,
-        ),
-      );
     } on Object catch (e) {
       _fail(emit, e);
+      return;
     }
+    // The PR now exists — surface it (lastCreated) even if the follow-up list
+    // refresh fails, so a transient list error can't hide a real PR behind a
+    // misleading GIT ERROR.
+    List<PullRequestEntity> prs;
+    try {
+      prs = await _service.list(event.root);
+    } on Object catch (e) {
+      log('created PR but list refresh failed: $e', name: 'PullRequestsBloc');
+      prs = state.prs;
+    }
+    emit(state.copyWith(status: PrStatus.ready, prs: prs, lastCreated: ref));
   }
 
   /// Drops a second op while one is running: a concurrent gh call could race

--- a/lib/features/collections/presentation/bloc/pull_requests_event.dart
+++ b/lib/features/collections/presentation/bloc/pull_requests_event.dart
@@ -1,0 +1,36 @@
+import 'package:equatable/equatable.dart';
+
+abstract class PullRequestsEvent extends Equatable {
+  const PullRequestsEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+/// Check availability, then (if ready) load open PRs for [root].
+class LoadPullRequests extends PullRequestsEvent {
+  const LoadPullRequests(this.root);
+  final String root;
+
+  @override
+  List<Object?> get props => [root];
+}
+
+class CreatePullRequest extends PullRequestsEvent {
+  const CreatePullRequest(
+    this.root, {
+    required this.base,
+    required this.title,
+    required this.body,
+    required this.draft,
+  });
+
+  final String root;
+  final String base;
+  final String title;
+  final String body;
+  final bool draft;
+
+  @override
+  List<Object?> get props => [root, base, title, body, draft];
+}

--- a/lib/features/collections/presentation/bloc/pull_requests_state.dart
+++ b/lib/features/collections/presentation/bloc/pull_requests_state.dart
@@ -1,0 +1,53 @@
+import 'package:equatable/equatable.dart';
+import 'package:getman/features/collections/domain/entities/pull_request.dart';
+
+enum PrStatus { initial, loading, ready, creating, error }
+
+class PullRequestsState extends Equatable {
+  const PullRequestsState({
+    // `initial`, not `loading`: the load/create guard drops events while
+    // `isBusy`, and a `loading` default would make it drop the very first load.
+    this.status = PrStatus.initial,
+    this.availability = GhAvailability.available,
+    this.prs = const [],
+    this.errorMessage,
+    this.lastCreated,
+  });
+
+  final PrStatus status;
+  final GhAvailability availability;
+  final List<PullRequestEntity> prs;
+  final String? errorMessage;
+  final PullRequestRef? lastCreated;
+
+  bool get isBusy => status == PrStatus.loading || status == PrStatus.creating;
+
+  PullRequestsState copyWith({
+    PrStatus? status,
+    GhAvailability? availability,
+    List<PullRequestEntity>? prs,
+    String? errorMessage,
+    PullRequestRef? lastCreated,
+  }) {
+    final next = status ?? this.status;
+    return PullRequestsState(
+      status: next,
+      availability: availability ?? this.availability,
+      prs: prs ?? this.prs,
+      // Only an error state keeps a message; anything else clears it.
+      errorMessage: next == PrStatus.error
+          ? (errorMessage ?? this.errorMessage)
+          : null,
+      lastCreated: lastCreated ?? this.lastCreated,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+    status,
+    availability,
+    prs,
+    errorMessage,
+    lastCreated,
+  ];
+}

--- a/lib/features/collections/presentation/bloc/pull_requests_state.dart
+++ b/lib/features/collections/presentation/bloc/pull_requests_state.dart
@@ -12,6 +12,7 @@ class PullRequestsState extends Equatable {
     this.prs = const [],
     this.errorMessage,
     this.lastCreated,
+    this.defaultBase,
   });
 
   final PrStatus status;
@@ -19,6 +20,10 @@ class PullRequestsState extends Equatable {
   final List<PullRequestEntity> prs;
   final String? errorMessage;
   final PullRequestRef? lastCreated;
+
+  /// The repo's default branch (`gh repo view`), for the create form's base
+  /// prefill. Null until resolved / when it can't be determined.
+  final String? defaultBase;
 
   bool get isBusy => status == PrStatus.loading || status == PrStatus.creating;
 
@@ -28,6 +33,7 @@ class PullRequestsState extends Equatable {
     List<PullRequestEntity>? prs,
     String? errorMessage,
     PullRequestRef? lastCreated,
+    String? defaultBase,
   }) {
     final next = status ?? this.status;
     return PullRequestsState(
@@ -39,6 +45,7 @@ class PullRequestsState extends Equatable {
           ? (errorMessage ?? this.errorMessage)
           : null,
       lastCreated: lastCreated ?? this.lastCreated,
+      defaultBase: defaultBase ?? this.defaultBase,
     );
   }
 
@@ -49,5 +56,6 @@ class PullRequestsState extends Equatable {
     prs,
     errorMessage,
     lastCreated,
+    defaultBase,
   ];
 }

--- a/lib/features/collections/presentation/bloc/review_bloc.dart
+++ b/lib/features/collections/presentation/bloc/review_bloc.dart
@@ -1,6 +1,7 @@
 import 'dart:developer';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:getman/core/git/git_service.dart' show GitException;
 import 'package:getman/features/collections/domain/review_service.dart';
 import 'package:getman/features/collections/presentation/bloc/review_event.dart';
 import 'package:getman/features/collections/presentation/bloc/review_state.dart';
@@ -104,12 +105,24 @@ class ReviewBloc extends Bloc<ReviewEvent, ReviewState> {
   Future<void> _onCommit(Commit event, Emitter<ReviewState> emit) async {
     emit(state.copyWith(status: ReviewStatus.committing));
     try {
-      await _service.commit(event.root, event.message);
+      await _service.commit(
+        event.root,
+        event.message,
+        authorName: event.authorName,
+        authorEmail: event.authorEmail,
+      );
     } on Object catch (e) {
       log('commit failed: $e', name: 'ReviewBloc');
-      emit(
-        state.copyWith(status: ReviewStatus.error, errorMessage: e.toString()),
-      );
+      if (e is GitException && GitException.isMissingIdentity(e.message)) {
+        emit(state.copyWith(status: ReviewStatus.needsIdentity));
+      } else {
+        emit(
+          state.copyWith(
+            status: ReviewStatus.error,
+            errorMessage: e.toString(),
+          ),
+        );
+      }
       return;
     }
     add(LoadReview(event.root));

--- a/lib/features/collections/presentation/bloc/review_event.dart
+++ b/lib/features/collections/presentation/bloc/review_event.dart
@@ -53,11 +53,17 @@ class SelectEntry extends ReviewEvent {
 }
 
 class Commit extends ReviewEvent {
-  const Commit(this.root, this.message);
+  const Commit(this.root, this.message, {this.authorName, this.authorEmail});
   final String root;
   final String message;
+
+  /// Getman-owned commit identity from Settings (see
+  /// `GitService.commit`) — threaded through so a commit succeeds even
+  /// without a configured OS git identity.
+  final String? authorName;
+  final String? authorEmail;
   @override
-  List<Object?> get props => [root, message];
+  List<Object?> get props => [root, message, authorName, authorEmail];
 }
 
 class InitRepo extends ReviewEvent {

--- a/lib/features/collections/presentation/bloc/review_state.dart
+++ b/lib/features/collections/presentation/bloc/review_state.dart
@@ -1,7 +1,18 @@
 import 'package:equatable/equatable.dart';
 import 'package:getman/features/collections/domain/entities/review_entry.dart';
 
-enum ReviewStatus { initial, loading, ready, committing, error }
+enum ReviewStatus {
+  initial,
+  loading,
+  ready,
+  committing,
+  error,
+
+  /// A commit failed because neither Getman's stored identity nor the OS
+  /// git config has a commit author — the widget layer prompts for a
+  /// name/email, saves it to Settings, and re-dispatches `Commit`.
+  needsIdentity,
+}
 
 class ReviewState extends Equatable {
   const ReviewState({

--- a/lib/features/collections/presentation/widgets/branch_chip.dart
+++ b/lib/features/collections/presentation/widgets/branch_chip.dart
@@ -9,11 +9,19 @@ import 'package:getman/features/collections/data/services/workspace_sync_service
 import 'package:getman/features/collections/presentation/bloc/git_sync_bloc.dart';
 import 'package:getman/features/collections/presentation/bloc/git_sync_event.dart';
 import 'package:getman/features/collections/presentation/bloc/git_sync_state.dart';
+import 'package:getman/features/collections/presentation/widgets/conflict_resolution_dialog.dart';
 import 'package:getman/features/collections/presentation/widgets/pull_requests_dialog.dart';
 import 'package:getman/features/collections/presentation/widgets/review_changes_dialog.dart';
 import 'package:getman/features/collections/presentation/widgets/stash_list_dialog.dart';
 import 'package:getman/features/settings/presentation/bloc/settings_bloc.dart';
 import 'package:getman/features/settings/presentation/bloc/settings_state.dart';
+
+/// How often the chip auto-fetches remote-tracking refs in the background, so
+/// ahead/behind counts stay fresh without the user remembering to pull.
+/// `@visibleForTesting` so a test can assert the interval without waiting for
+/// it to elapse for real.
+@visibleForTesting
+const Duration kAutoFetchInterval = Duration(minutes: 5);
 
 /// Collections-header chip: current branch + ahead/behind, opening the branch
 /// and sync menu. Hidden on web, without a workspace, or when the workspace is
@@ -31,6 +39,16 @@ class BranchChip extends StatefulWidget {
 
 class _BranchChipState extends State<BranchChip> {
   StreamSubscription<String>? _mirrorSub;
+  Timer? _fetchTimer;
+
+  // Tracked locally (not derived from `previous` inside the listener, which
+  // BlocConsumer doesn't expose) so the resolver opens exactly once per bump.
+  // Seeded from `state.conflictToken` on the first BlocConsumer build (not
+  // read from GitSyncBloc directly in initState — the workspace may not have
+  // a git repo yet, or GitSyncBloc may not even be provided above this chip
+  // in a screen that never renders it) so a BranchChip remount after an
+  // earlier, already-resolved conflict doesn't replay a stale open.
+  int? _lastConflictToken;
 
   @override
   void initState() {
@@ -42,19 +60,35 @@ class _BranchChipState extends State<BranchChip> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       final root = context.read<SettingsBloc>().state.settings.workspacePath;
-      if (root != null && root.isNotEmpty) _refresh(root);
+      if (root != null && root.isNotEmpty) {
+        _refresh(root);
+        _fetchSilently(root);
+      }
+    });
+    // Keeps ahead/behind counts fresh without the user remembering to pull.
+    // Silent: a routine offline tick must never surface a GIT ERROR dialog.
+    _fetchTimer = Timer.periodic(kAutoFetchInterval, (_) {
+      if (!mounted) return;
+      final root = context.read<SettingsBloc>().state.settings.workspacePath;
+      if (root != null && root.isNotEmpty) _fetchSilently(root);
     });
   }
 
   @override
   void dispose() {
     unawaited(_mirrorSub?.cancel());
+    _fetchTimer?.cancel();
     super.dispose();
   }
 
   void _refresh(String root) {
     if (!mounted) return;
     context.read<GitSyncBloc>().add(LoadBranchStatus(root));
+  }
+
+  void _fetchSilently(String root) {
+    if (!mounted) return;
+    context.read<GitSyncBloc>().add(FetchRemote(root, silent: true));
   }
 
   @override
@@ -69,8 +103,20 @@ class _BranchChipState extends State<BranchChip> {
 
         return BlocConsumer<GitSyncBloc, GitSyncState>(
           listenWhen: (p, n) =>
-              p.errorMessage != n.errorMessage && n.errorMessage != null,
+              (p.errorMessage != n.errorMessage && n.errorMessage != null) ||
+              p.conflictToken != n.conflictToken,
           listener: (context, state) {
+            // A pull halted on conflicts — open the resolver. Checked first
+            // and separately from the error path below: a conflicted pull is
+            // NOT an error state (see GitSyncBloc._onPull), so this is the
+            // only signal for it. `_lastConflictToken` is always seeded by
+            // the builder below before the first stream event can arrive, so
+            // it is never null here.
+            if (state.conflictToken != _lastConflictToken) {
+              _lastConflictToken = state.conflictToken;
+              unawaited(ConflictResolutionDialog.show(context, root: root));
+              return;
+            }
             final message = state.errorMessage;
             if (message == null) return;
             if (message.contains('uncommitted changes')) {
@@ -80,6 +126,10 @@ class _BranchChipState extends State<BranchChip> {
             }
           },
           builder: (context, state) {
+            // Seed on the first build from `bloc.state` (not a separate
+            // `.read()` — this callback already has it) so a later real bump
+            // is the only thing that can ever pop the dialog.
+            _lastConflictToken ??= state.conflictToken;
             final branch = state.branch;
             if (!branch.isRepo || branch.current == null) {
               return const SizedBox.shrink();
@@ -142,6 +192,12 @@ class _BranchChipState extends State<BranchChip> {
         const PopupMenuItem<String>(
           value: 'prs',
           child: Text('PULL REQUESTS…'),
+        ),
+        PopupMenuItem<String>(
+          key: const ValueKey('branch_menu_fetch'),
+          value: 'fetch',
+          enabled: branch.hasRemote,
+          child: Text(branch.hasRemote ? 'FETCH' : 'FETCH — NO REMOTE'),
         ),
       ],
       child: Padding(
@@ -214,6 +270,8 @@ class _BranchChipState extends State<BranchChip> {
         unawaited(StashListDialog.show(context, root: root));
       case 'prs':
         unawaited(PullRequestsDialog.show(context, root: root));
+      case 'fetch':
+        bloc.add(FetchRemote(root));
     }
   }
 

--- a/lib/features/collections/presentation/widgets/branch_chip.dart
+++ b/lib/features/collections/presentation/widgets/branch_chip.dart
@@ -263,7 +263,14 @@ class _BranchChipState extends State<BranchChip> {
           ),
         );
       case 'pull':
-        bloc.add(PullChanges(root));
+        final identity = context.read<SettingsBloc>().state.settings;
+        bloc.add(
+          PullChanges(
+            root,
+            authorName: identity.gitUserName,
+            authorEmail: identity.gitUserEmail,
+          ),
+        );
       case 'push':
         bloc.add(PushChanges(root));
       case 'stashes':

--- a/lib/features/collections/presentation/widgets/branch_chip.dart
+++ b/lib/features/collections/presentation/widgets/branch_chip.dart
@@ -6,6 +6,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:getman/core/theme/app_theme.dart';
 import 'package:getman/core/ui/widgets/name_prompt_dialog.dart';
 import 'package:getman/features/collections/data/services/workspace_sync_service.dart';
+import 'package:getman/features/collections/domain/entities/branch_status.dart';
 import 'package:getman/features/collections/presentation/bloc/git_sync_bloc.dart';
 import 'package:getman/features/collections/presentation/bloc/git_sync_event.dart';
 import 'package:getman/features/collections/presentation/bloc/git_sync_state.dart';
@@ -150,7 +151,7 @@ class _BranchChipState extends State<BranchChip> {
       key: const ValueKey('branch_chip'),
       tooltip: 'Branch & sync',
       enabled: !state.isBusy,
-      onSelected: (value) => _onSelected(context, root, value),
+      onSelected: (value) => _onSelected(context, root, branch, value),
       itemBuilder: (context) => [
         for (final b in branch.branches)
           PopupMenuItem<String>(
@@ -171,19 +172,15 @@ class _BranchChipState extends State<BranchChip> {
           value: 'new',
           child: Text('NEW BRANCH…'),
         ),
-        PopupMenuItem<String>(
-          key: const ValueKey('branch_menu_pull'),
+        const PopupMenuItem<String>(
+          key: ValueKey('branch_menu_pull'),
           value: 'pull',
-          enabled: branch.hasRemote,
-          child: Text(
-            branch.hasRemote ? 'PULL (REBASE)' : 'PULL — NO REMOTE',
-          ),
+          child: Text('PULL (REBASE)'),
         ),
-        PopupMenuItem<String>(
-          key: const ValueKey('branch_menu_push'),
+        const PopupMenuItem<String>(
+          key: ValueKey('branch_menu_push'),
           value: 'push',
-          enabled: branch.hasRemote,
-          child: Text(branch.hasRemote ? 'PUSH' : 'PUSH — NO REMOTE'),
+          child: Text('PUSH'),
         ),
         PopupMenuItem<String>(
           value: 'stashes',
@@ -193,11 +190,10 @@ class _BranchChipState extends State<BranchChip> {
           value: 'prs',
           child: Text('PULL REQUESTS…'),
         ),
-        PopupMenuItem<String>(
-          key: const ValueKey('branch_menu_fetch'),
+        const PopupMenuItem<String>(
+          key: ValueKey('branch_menu_fetch'),
           value: 'fetch',
-          enabled: branch.hasRemote,
-          child: Text(branch.hasRemote ? 'FETCH' : 'FETCH — NO REMOTE'),
+          child: Text('FETCH'),
         ),
       ],
       child: Padding(
@@ -245,7 +241,12 @@ class _BranchChipState extends State<BranchChip> {
     );
   }
 
-  void _onSelected(BuildContext context, String root, String value) {
+  void _onSelected(
+    BuildContext context,
+    String root,
+    BranchStatus branch,
+    String value,
+  ) {
     final bloc = context.read<GitSyncBloc>();
     if (value.startsWith('switch:')) {
       bloc.add(SwitchBranch(root, value.substring('switch:'.length)));
@@ -264,22 +265,80 @@ class _BranchChipState extends State<BranchChip> {
         );
       case 'pull':
         final identity = context.read<SettingsBloc>().state.settings;
-        bloc.add(
-          PullChanges(
-            root,
-            authorName: identity.gitUserName,
-            authorEmail: identity.gitUserEmail,
-          ),
-        );
+        if (branch.hasRemote) {
+          bloc.add(
+            PullChanges(
+              root,
+              authorName: identity.gitUserName,
+              authorEmail: identity.gitUserEmail,
+            ),
+          );
+        } else {
+          unawaited(
+            _promptAddRemote(
+              context,
+              root,
+              onUrl: (url) => bloc.add(
+                PullChanges(
+                  root,
+                  authorName: identity.gitUserName,
+                  authorEmail: identity.gitUserEmail,
+                  addRemoteUrl: url,
+                ),
+              ),
+            ),
+          );
+        }
       case 'push':
-        bloc.add(PushChanges(root));
+        if (branch.hasRemote) {
+          bloc.add(PushChanges(root));
+        } else {
+          unawaited(
+            _promptAddRemote(
+              context,
+              root,
+              onUrl: (url) => bloc.add(PushChanges(root, addRemoteUrl: url)),
+            ),
+          );
+        }
       case 'stashes':
         unawaited(StashListDialog.show(context, root: root));
       case 'prs':
         unawaited(PullRequestsDialog.show(context, root: root));
       case 'fetch':
-        bloc.add(FetchRemote(root));
+        if (branch.hasRemote) {
+          bloc.add(FetchRemote(root));
+        } else {
+          unawaited(
+            _promptAddRemote(
+              context,
+              root,
+              onUrl: (url) => bloc.add(FetchRemote(root, addRemoteUrl: url)),
+            ),
+          );
+        }
     }
+  }
+
+  /// Prompts for a remote URL (used when the repo has none yet) and, on
+  /// confirm, invokes [onUrl] with the trimmed value — the caller dispatches
+  /// the actual pull/push/fetch event carrying `addRemoteUrl` so the bloc
+  /// adds `origin` before performing the action.
+  Future<void> _promptAddRemote(
+    BuildContext context,
+    String root, {
+    required void Function(String url) onUrl,
+  }) {
+    return NamePromptDialog.show(
+      context,
+      title: 'ADD REMOTE',
+      hintText: 'https://github.com/you/repo.git',
+      confirmLabel: 'ADD REMOTE',
+      onConfirm: (url) {
+        if (url.trim().isEmpty) return;
+        onUrl(url.trim());
+      },
+    );
   }
 
   /// A switch was refused because the tree is dirty: offer the two ways out.

--- a/lib/features/collections/presentation/widgets/branch_chip.dart
+++ b/lib/features/collections/presentation/widgets/branch_chip.dart
@@ -9,6 +9,7 @@ import 'package:getman/features/collections/data/services/workspace_sync_service
 import 'package:getman/features/collections/presentation/bloc/git_sync_bloc.dart';
 import 'package:getman/features/collections/presentation/bloc/git_sync_event.dart';
 import 'package:getman/features/collections/presentation/bloc/git_sync_state.dart';
+import 'package:getman/features/collections/presentation/widgets/pull_requests_dialog.dart';
 import 'package:getman/features/collections/presentation/widgets/review_changes_dialog.dart';
 import 'package:getman/features/collections/presentation/widgets/stash_list_dialog.dart';
 import 'package:getman/features/settings/presentation/bloc/settings_bloc.dart';
@@ -138,6 +139,10 @@ class _BranchChipState extends State<BranchChip> {
           value: 'stashes',
           child: Text('STASHES (${branch.stashCount})'),
         ),
+        const PopupMenuItem<String>(
+          value: 'prs',
+          child: Text('PULL REQUESTS…'),
+        ),
       ],
       child: Padding(
         padding: EdgeInsets.symmetric(horizontal: layout.tabSpacing),
@@ -207,6 +212,8 @@ class _BranchChipState extends State<BranchChip> {
         bloc.add(PushChanges(root));
       case 'stashes':
         unawaited(StashListDialog.show(context, root: root));
+      case 'prs':
+        unawaited(PullRequestsDialog.show(context, root: root));
     }
   }
 

--- a/lib/features/collections/presentation/widgets/branch_sync_listener.dart
+++ b/lib/features/collections/presentation/widgets/branch_sync_listener.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:getman/core/domain/entities/request_config_entity.dart';
 import 'package:getman/features/collections/data/services/workspace_sync_service.dart';
 import 'package:getman/features/collections/domain/entities/collection_node_entity.dart';
 import 'package:getman/features/collections/presentation/bloc/collections_bloc.dart';
@@ -8,13 +9,18 @@ import 'package:getman/features/collections/presentation/bloc/git_sync_bloc.dart
 import 'package:getman/features/collections/presentation/bloc/git_sync_state.dart';
 import 'package:getman/features/collections/presentation/widgets/workspace_sync_listener.dart';
 import 'package:getman/features/settings/presentation/bloc/settings_bloc.dart';
+import 'package:getman/features/tabs/domain/entities/panel_entity.dart';
+import 'package:getman/features/tabs/domain/entities/request_tab_entity.dart';
+import 'package:getman/features/tabs/presentation/bloc/tabs_bloc.dart';
+import 'package:getman/features/tabs/presentation/bloc/tabs_event.dart';
 
 /// Reloads the collections tree from disk after a git operation changed the
-/// files under the app (branch switch, pull, stash, pop).
+/// files under the app (branch switch, pull, stash, pop), and brings untouched
+/// open tabs along so a pulled request shows its new version.
 ///
 /// This is a widget-layer coordinator by design: GitSyncBloc must not depend on
-/// CollectionsBloc (no bloc→bloc coupling), so the widget that holds both does
-/// the wiring — same shape as [WorkspaceSyncListener].
+/// CollectionsBloc/TabsBloc (no bloc→bloc coupling), so the widget that holds
+/// them does the wiring — same shape as [WorkspaceSyncListener].
 class BranchSyncListener extends StatelessWidget {
   const BranchSyncListener({required this.child, super.key});
   final Widget child;
@@ -28,6 +34,11 @@ class BranchSyncListener extends StatelessWidget {
         if (path == null || path.isEmpty) return;
         final sync = context.read<WorkspaceSyncService>();
         final collections = context.read<CollectionsBloc>();
+        final tabs = context.read<TabsBloc>();
+        // Snapshot the saved configs *before* the reload so we can tell open
+        // tabs that were untouched (safe to refresh) from those the user has
+        // edited (must not be clobbered).
+        final beforeIndex = collections.state.configById;
         // The disk read runs *inside* the suspension, not before it.
         // GitBranchService resumes mirroring the moment git returns, so the
         // window this listener opens starts there: while `read` walks the
@@ -61,8 +72,54 @@ class BranchSyncListener extends StatelessWidget {
           // deliberately.)
           await Future<void>.delayed(Duration.zero);
         });
+        // The tree is now the pulled/switched version. Bring untouched open
+        // tabs along so "pull → my open request updates" holds; tabs with
+        // unsaved edits are deliberately left as-is (never clobbered). Outside
+        // the suspension: UpdateTab touches the tabs box, not the collections
+        // mirror, so it can't feed the reload→mirror loop above.
+        for (final refreshed in tabsToRefreshAfterReload(
+          tabs.state.panels,
+          beforeIndex,
+          collections.state.configById,
+        )) {
+          tabs.add(UpdateTab(refreshed));
+        }
       },
       child: child,
     );
   }
+}
+
+/// Pure reconciliation: given every open tab (across [panels]) and the saved
+/// request configs keyed by collection-node id *before* and *after* a git
+/// reload, returns the tab entities whose linked request changed upstream and
+/// that had **no local edits** — updated to the new config. Tabs that were
+/// edited, unlinked, or whose node was deleted upstream are left out.
+///
+/// "Untouched" mirrors `TabDirtyChecker`: a clean tab's config equals what was
+/// saved before the pull. `HttpRequestConfigEntity` equality excludes `id`, so
+/// the comparison is on the request signature; the pulled config keeps the
+/// same persisted `id`, so linkage (e.g. chaining rules) survives the refresh.
+@visibleForTesting
+List<HttpRequestTabEntity> tabsToRefreshAfterReload(
+  List<PanelEntity> panels,
+  Map<String, HttpRequestConfigEntity> before,
+  Map<String, HttpRequestConfigEntity> after,
+) {
+  final out = <HttpRequestTabEntity>[];
+  for (final panel in panels) {
+    for (final tab in panel.tabs) {
+      final nodeId = tab.collectionNodeId;
+      if (nodeId == null) continue; // unlinked tab — nothing to track
+      final saved = after[nodeId];
+      if (saved == null) continue; // node deleted upstream — leave the tab
+      final previouslySaved = before[nodeId];
+      final untouched =
+          previouslySaved != null && tab.config == previouslySaved;
+      if (untouched && tab.config != saved) {
+        out.add(tab.copyWith(config: saved));
+      }
+    }
+  }
+  return out;
 }

--- a/lib/features/collections/presentation/widgets/conflict_resolution_dialog.dart
+++ b/lib/features/collections/presentation/widgets/conflict_resolution_dialog.dart
@@ -60,6 +60,11 @@ class _ConflictResolutionBodyState extends State<ConflictResolutionBody> {
   // path -> whole-file side. Coarse conflicts only.
   final Map<String, FileSide> _wholeFilePicks = {};
   int _picksForBatch = -1;
+  // Set by _cancel before dispatching AbortRebase: the abort also resolves
+  // to ConflictStatus.done, but _cancel already popped and the done-listener
+  // must not pop again or show the resolve-flow's "Conflicts resolved."
+  // snackbar.
+  bool _aborting = false;
 
   @override
   void initState() {
@@ -122,6 +127,7 @@ class _ConflictResolutionBodyState extends State<ConflictResolutionBody> {
   }
 
   void _cancel(BuildContext context) {
+    _aborting = true;
     context.read<ConflictBloc>().add(AbortRebase(widget.root));
     unawaited(Navigator.of(context).maybePop());
   }
@@ -156,6 +162,12 @@ class _ConflictResolutionBodyState extends State<ConflictResolutionBody> {
           (c.status == ConflictStatus.done && p.status != ConflictStatus.done),
       listener: (context, state) {
         if (state.status == ConflictStatus.done) {
+          if (_aborting) {
+            // _cancel already popped the dialog; the abort itself resolves
+            // to `done` too, but it must not also show the resolve-flow's
+            // snackbar or pop a second time.
+            return;
+          }
           // Capture before popping: the dialog's own context is about to be
           // deactivated, so the snackbar goes through the captured messenger.
           final messenger = ScaffoldMessenger.of(context);
@@ -221,6 +233,7 @@ class _ConflictResolutionBodyState extends State<ConflictResolutionBody> {
   Widget _fileTile(BuildContext context, FileConflict fc) {
     if (fc.node != null) {
       return _FieldLevelTile(
+        key: ValueKey(fc.path),
         conflict: fc,
         picks: _fieldPicks[fc.path] ?? const {},
         onPick: (field, pick) => _onFieldPick(fc.path, field, pick),
@@ -248,6 +261,7 @@ class _FieldLevelTile extends StatelessWidget {
     required this.conflict,
     required this.picks,
     required this.onPick,
+    super.key,
   });
   final FileConflict conflict;
   final Map<String, FieldPick> picks;
@@ -285,6 +299,7 @@ class _FieldLevelTile extends StatelessWidget {
               Padding(
                 padding: EdgeInsets.only(top: layout.tabSpacing),
                 child: _FieldConflictRow(
+                  key: ValueKey('${conflict.path}_${fieldConflict.field}'),
                   path: conflict.path,
                   fieldConflict: fieldConflict,
                   pick: picks[fieldConflict.field],
@@ -303,6 +318,7 @@ class _FieldConflictRow extends StatefulWidget {
     required this.fieldConflict,
     required this.pick,
     required this.onPick,
+    super.key,
   });
   final String path;
   final FieldConflict fieldConflict;

--- a/lib/features/collections/presentation/widgets/conflict_resolution_dialog.dart
+++ b/lib/features/collections/presentation/widgets/conflict_resolution_dialog.dart
@@ -60,10 +60,13 @@ class _ConflictResolutionBodyState extends State<ConflictResolutionBody> {
   // path -> whole-file side. Coarse conflicts only.
   final Map<String, FileSide> _wholeFilePicks = {};
   int _picksForBatch = -1;
-  // Set by _cancel before dispatching AbortRebase: the abort also resolves
-  // to ConflictStatus.done, but _cancel already popped and the done-listener
-  // must not pop again or show the resolve-flow's "Conflicts resolved."
-  // snackbar.
+  // Set by _cancel before dispatching AbortRebase. _cancel itself does NOT
+  // pop — if the abort fails (rare), the dialog must stay open (with the GIT
+  // ERROR dialog on top) so the user can retry rather than being left with a
+  // wedged rebase and no UI. The done-listener pops once the abort actually
+  // resolves to ConflictStatus.done, and — because this was an abort, not a
+  // resolve — skips the resolve-flow's "Conflicts resolved." snackbar and the
+  // tree-reload dispatch (pre-pull state already matches Hive).
   bool _aborting = false;
 
   @override
@@ -129,7 +132,9 @@ class _ConflictResolutionBodyState extends State<ConflictResolutionBody> {
   void _cancel(BuildContext context) {
     _aborting = true;
     context.read<ConflictBloc>().add(AbortRebase(widget.root));
-    unawaited(Navigator.of(context).maybePop());
+    // Does NOT pop here — see the _aborting doc comment. The done-listener
+    // pops once the abort actually completes; if it fails instead, the
+    // dialog stays open and the GIT ERROR dialog surfaces on top of it.
   }
 
   void _showError(BuildContext context, String message) {
@@ -163,9 +168,12 @@ class _ConflictResolutionBodyState extends State<ConflictResolutionBody> {
       listener: (context, state) {
         if (state.status == ConflictStatus.done) {
           if (_aborting) {
-            // _cancel already popped the dialog; the abort itself resolves
-            // to `done` too, but it must not also show the resolve-flow's
-            // snackbar or pop a second time.
+            // The abort itself resolved to `done`: pop now (CANCEL no
+            // longer pops synchronously — see _cancel), without the
+            // resolve-flow's "Conflicts resolved." snackbar or a tree
+            // reload — pre-pull state already matches Hive, there is
+            // nothing to reload.
+            unawaited(Navigator.of(context).maybePop());
             return;
           }
           // Capture before popping: the dialog's own context is about to be
@@ -174,7 +182,12 @@ class _ConflictResolutionBodyState extends State<ConflictResolutionBody> {
           final gitBloc = context.read<GitSyncBloc>();
           unawaited(Navigator.of(context).maybePop());
           showAppSnackBarVia(messenger, 'Conflicts resolved.');
-          gitBloc.add(LoadBranchStatus(widget.root));
+          // ConflictsResolved (not LoadBranchStatus) both refreshes branch
+          // status AND bumps reloadToken so BranchSyncListener reloads the
+          // merged tree — otherwise the resolved files sit on disk while
+          // Hive still holds the pre-pull tree, and the next edit's mirror
+          // silently reverts the merge.
+          gitBloc.add(ConflictsResolved(widget.root));
         } else if (state.status == ConflictStatus.error) {
           _showError(context, state.errorMessage!);
         }
@@ -467,15 +480,23 @@ class _CoarseTile extends StatelessWidget {
 
   bool get _isDeleteModify => conflict.kind == ConflictKind.deleteModify;
 
+  /// For a delete/modify conflict, labels by orientation instead of a
+  /// hardcoded side: the side that actually deleted the file
+  /// ([FileConflict.deletedSide]) always reads "Accept the deletion"; the
+  /// other side always reads "Keep the edited request" — whichever of
+  /// incoming/yours that happens to be. Hardcoding these to
+  /// incoming/yours inverted the buttons whenever *you* were the deleting
+  /// side (FIX C1).
+  String _label(FileSide side, String defaultLabel) {
+    if (!_isDeleteModify) return defaultLabel;
+    return side == conflict.deletedSide
+        ? 'Accept the deletion'
+        : 'Keep the edited request';
+  }
+
   @override
   Widget build(BuildContext context) {
     final layout = context.appLayout;
-    final incomingLabel = _isDeleteModify
-        ? 'Accept the deletion'
-        : 'TAKE INCOMING';
-    final yoursLabel = _isDeleteModify
-        ? 'Keep your edited request'
-        : 'KEEP YOURS';
     return Container(
       key: ValueKey('conflict_file_${conflict.path}'),
       padding: EdgeInsets.all(layout.tabSpacing),
@@ -496,7 +517,7 @@ class _CoarseTile extends StatelessWidget {
               Expanded(
                 child: _SideButton(
                   key: ValueKey('take_incoming_${conflict.path}'),
-                  label: incomingLabel,
+                  label: _label(FileSide.incoming, 'TAKE INCOMING'),
                   selected: picked == FileSide.incoming,
                   onTap: () => onPick(FileSide.incoming),
                 ),
@@ -505,7 +526,7 @@ class _CoarseTile extends StatelessWidget {
               Expanded(
                 child: _SideButton(
                   key: ValueKey('keep_yours_${conflict.path}'),
-                  label: yoursLabel,
+                  label: _label(FileSide.yours, 'KEEP YOURS'),
                   selected: picked == FileSide.yours,
                   onTap: () => onPick(FileSide.yours),
                 ),

--- a/lib/features/collections/presentation/widgets/conflict_resolution_dialog.dart
+++ b/lib/features/collections/presentation/widgets/conflict_resolution_dialog.dart
@@ -1,0 +1,523 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:getman/core/theme/app_theme.dart';
+import 'package:getman/core/ui/widgets/app_snack_bar.dart';
+import 'package:getman/core/ui/widgets/responsive_dialog.dart';
+import 'package:getman/features/collections/domain/entities/file_conflict.dart';
+import 'package:getman/features/collections/domain/logic/three_way_merge.dart';
+import 'package:getman/features/collections/presentation/bloc/conflict_bloc.dart';
+import 'package:getman/features/collections/presentation/bloc/conflict_event.dart';
+import 'package:getman/features/collections/presentation/bloc/conflict_state.dart';
+import 'package:getman/features/collections/presentation/bloc/git_sync_bloc.dart';
+import 'package:getman/features/collections/presentation/bloc/git_sync_event.dart';
+import 'package:getman/features/tabs/presentation/widgets/json_code_editor.dart';
+import 'package:re_editor/re_editor.dart';
+
+/// Drives the resolve → continue loop for an in-progress rebase, opened from
+/// the branch chip when a pull halts on conflicts (`GitSyncState.
+/// conflictToken`). One `ConflictState.conflicts` batch is one paused
+/// commit's worth of files; RESOLVE & CONTINUE may surface another batch
+/// before the rebase finishes.
+class ConflictResolutionDialog {
+  const ConflictResolutionDialog._();
+
+  static Future<void> show(BuildContext context, {required String root}) {
+    // Capture both blocs before the dialog's own subtree: the conflict list
+    // lives under ConflictBloc; a successful resolve nudges the branch chip
+    // via GitSyncBloc (widget-layer coordination — no bloc→bloc coupling).
+    final conflict = context.read<ConflictBloc>();
+    final git = context.read<GitSyncBloc>();
+    return showResponsiveDialog<void>(
+      context,
+      barrierDismissible: false,
+      builder: (_) => MultiBlocProvider(
+        providers: [
+          BlocProvider<ConflictBloc>.value(value: conflict),
+          BlocProvider<GitSyncBloc>.value(value: git),
+        ],
+        child: ConflictResolutionBody(root: root),
+      ),
+    );
+  }
+}
+
+/// The dialog content (public for widget testing). Stateful to hold the
+/// in-progress picks for the current batch — the bloc only knows resolved
+/// choices once RESOLVE & CONTINUE is dispatched.
+class ConflictResolutionBody extends StatefulWidget {
+  const ConflictResolutionBody({required this.root, super.key});
+  final String root;
+
+  @override
+  State<ConflictResolutionBody> createState() => _ConflictResolutionBodyState();
+}
+
+class _ConflictResolutionBodyState extends State<ConflictResolutionBody> {
+  // path -> field label -> pick. Field-level conflicts only.
+  final Map<String, Map<String, FieldPick>> _fieldPicks = {};
+  // path -> whole-file side. Coarse conflicts only.
+  final Map<String, FileSide> _wholeFilePicks = {};
+  int _picksForBatch = -1;
+
+  @override
+  void initState() {
+    super.initState();
+    context.read<ConflictBloc>().add(LoadConflicts(widget.root));
+  }
+
+  /// Picks are scoped to one batch of conflicts — a new batch is a different
+  /// set of files/fields entirely, so stale picks from the previous commit
+  /// must not leak into the next one.
+  void _resetPicksIfNewBatch(int batch) {
+    if (batch == _picksForBatch) return;
+    _picksForBatch = batch;
+    _fieldPicks.clear();
+    _wholeFilePicks.clear();
+  }
+
+  void _onFieldPick(String path, String field, FieldPick pick) {
+    setState(() => _fieldPicks.putIfAbsent(path, () => {})[field] = pick);
+  }
+
+  void _onWholeFilePick(String path, FileSide side) {
+    setState(() => _wholeFilePicks[path] = side);
+  }
+
+  bool _allPicked(List<FileConflict> conflicts) {
+    for (final fc in conflicts) {
+      if (fc.node != null) {
+        final fieldConflicts = fc.node!.conflicts;
+        if (fieldConflicts.isEmpty) continue; // auto-merged
+        final picks = _fieldPicks[fc.path];
+        if (picks == null) return false;
+        for (final fieldConflict in fieldConflicts) {
+          if (!picks.containsKey(fieldConflict.field)) return false;
+        }
+      } else {
+        if (_wholeFilePicks[fc.path] == null) return false;
+      }
+    }
+    return true;
+  }
+
+  void _submit(BuildContext context, List<FileConflict> conflicts) {
+    final resolutions = [
+      for (final fc in conflicts)
+        if (fc.node != null)
+          FileResolution(
+            path: fc.path,
+            fieldChoices: {
+              for (final entry in (_fieldPicks[fc.path] ?? const {}).entries)
+                entry.key: entry.value.value,
+            },
+          )
+        else
+          FileResolution(path: fc.path, wholeFile: _wholeFilePicks[fc.path]),
+    ];
+    context.read<ConflictBloc>().add(
+      ResolveAndContinue(widget.root, resolutions),
+    );
+  }
+
+  void _cancel(BuildContext context) {
+    context.read<ConflictBloc>().add(AbortRebase(widget.root));
+    unawaited(Navigator.of(context).maybePop());
+  }
+
+  void _showError(BuildContext context, String message) {
+    unawaited(
+      showDialog<void>(
+        context: context,
+        builder: (dialogContext) => AlertDialog(
+          key: const ValueKey('conflict_error_dialog'),
+          title: const Text('GIT ERROR'),
+          content: SingleChildScrollView(child: Text(message)),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(),
+              child: const Text('CLOSE'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final layout = context.appLayout;
+    return BlocConsumer<ConflictBloc, ConflictState>(
+      listenWhen: (p, c) =>
+          (c.status == ConflictStatus.error &&
+              p.errorMessage != c.errorMessage &&
+              c.errorMessage != null) ||
+          (c.status == ConflictStatus.done && p.status != ConflictStatus.done),
+      listener: (context, state) {
+        if (state.status == ConflictStatus.done) {
+          // Capture before popping: the dialog's own context is about to be
+          // deactivated, so the snackbar goes through the captured messenger.
+          final messenger = ScaffoldMessenger.of(context);
+          final gitBloc = context.read<GitSyncBloc>();
+          unawaited(Navigator.of(context).maybePop());
+          showAppSnackBarVia(messenger, 'Conflicts resolved.');
+          gitBloc.add(LoadBranchStatus(widget.root));
+        } else if (state.status == ConflictStatus.error) {
+          _showError(context, state.errorMessage!);
+        }
+      },
+      builder: (context, state) {
+        if (state.status == ConflictStatus.ready ||
+            state.status == ConflictStatus.error) {
+          _resetPicksIfNewBatch(state.batch);
+        }
+        final busy = state.isBusy;
+        return ResponsiveDialogScaffold(
+          title: Text('Resolving conflicts — commit ${state.batch + 1}'),
+          content: SizedBox(
+            width: layout.dialogWidth,
+            height: layout.settingsDialogHeight,
+            child: _content(context, state),
+          ),
+          actions: [
+            TextButton(
+              key: const ValueKey('conflict_cancel'),
+              onPressed: busy ? null : () => _cancel(context),
+              child: const Text('CANCEL'),
+            ),
+            FilledButton(
+              key: const ValueKey('conflict_resolve'),
+              onPressed: (!busy && _allPicked(state.conflicts))
+                  ? () => _submit(context, state.conflicts)
+                  : null,
+              child: const Text('RESOLVE & CONTINUE'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _content(BuildContext context, ConflictState state) {
+    switch (state.status) {
+      case ConflictStatus.initial:
+      case ConflictStatus.loading:
+      case ConflictStatus.resolving:
+        return const Center(child: CircularProgressIndicator());
+      case ConflictStatus.done:
+        return const SizedBox.shrink();
+      case ConflictStatus.ready:
+      case ConflictStatus.error:
+        final layout = context.appLayout;
+        return ListView.separated(
+          itemCount: state.conflicts.length,
+          separatorBuilder: (_, _) => SizedBox(height: layout.tabSpacing),
+          itemBuilder: (context, i) => _fileTile(context, state.conflicts[i]),
+        );
+    }
+  }
+
+  Widget _fileTile(BuildContext context, FileConflict fc) {
+    if (fc.node != null) {
+      return _FieldLevelTile(
+        conflict: fc,
+        picks: _fieldPicks[fc.path] ?? const {},
+        onPick: (field, pick) => _onFieldPick(fc.path, field, pick),
+      );
+    }
+    return _CoarseTile(
+      conflict: fc,
+      picked: _wholeFilePicks[fc.path],
+      onPick: (side) => _onWholeFilePick(fc.path, side),
+    );
+  }
+}
+
+/// One resolved field: which side was picked, and the (possibly
+/// user-edited) resolved value. For opaque/list conflicts [value] is always
+/// the literal marker `'incoming'`/`'yours'` — never a real value.
+class FieldPick {
+  const FieldPick({required this.side, required this.value});
+  final FileSide side;
+  final String value;
+}
+
+class _FieldLevelTile extends StatelessWidget {
+  const _FieldLevelTile({
+    required this.conflict,
+    required this.picks,
+    required this.onPick,
+  });
+  final FileConflict conflict;
+  final Map<String, FieldPick> picks;
+  final void Function(String field, FieldPick pick) onPick;
+
+  @override
+  Widget build(BuildContext context) {
+    final layout = context.appLayout;
+    final node = conflict.node!;
+    return Container(
+      key: ValueKey('conflict_file_${conflict.path}'),
+      padding: EdgeInsets.all(layout.tabSpacing),
+      decoration: context.appDecoration.panelBox(context),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            conflict.path,
+            style: TextStyle(
+              fontWeight: context.appTypography.titleWeight,
+              fontFamily: context.appTypography.codeFontFamily,
+            ),
+          ),
+          SizedBox(height: layout.tabSpacing),
+          if (node.conflicts.isEmpty)
+            Text(
+              'Auto-merged.',
+              key: ValueKey('conflict_automerged_${conflict.path}'),
+              style: TextStyle(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+            )
+          else
+            for (final fieldConflict in node.conflicts)
+              Padding(
+                padding: EdgeInsets.only(top: layout.tabSpacing),
+                child: _FieldConflictRow(
+                  path: conflict.path,
+                  fieldConflict: fieldConflict,
+                  pick: picks[fieldConflict.field],
+                  onPick: (pick) => onPick(fieldConflict.field, pick),
+                ),
+              ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FieldConflictRow extends StatefulWidget {
+  const _FieldConflictRow({
+    required this.path,
+    required this.fieldConflict,
+    required this.pick,
+    required this.onPick,
+  });
+  final String path;
+  final FieldConflict fieldConflict;
+  final FieldPick? pick;
+  final ValueChanged<FieldPick> onPick;
+
+  @override
+  State<_FieldConflictRow> createState() => _FieldConflictRowState();
+}
+
+class _FieldConflictRowState extends State<_FieldConflictRow> {
+  TextEditingController? _textController;
+  CodeLineEditingController? _codeController;
+  FileSide? _controllerSide;
+
+  bool get _isBody => widget.fieldConflict.field == 'body';
+
+  /// `scalar`/`mapEntry` show an editable value; `opaque`/`list` (auth, form
+  /// fields) never do — the CRITICAL CONTRACT is that those store only the
+  /// literal `'incoming'`/`'yours'` marker, never free text.
+  bool get _editable =>
+      widget.fieldConflict.kind == FieldConflictKind.scalar ||
+      widget.fieldConflict.kind == FieldConflictKind.mapEntry;
+
+  @override
+  void initState() {
+    super.initState();
+    if (!_editable) return;
+    if (_isBody) {
+      _codeController = createJsonCodeController()..addListener(_onCodeChanged);
+    } else {
+      _textController = TextEditingController()..addListener(_onTextChanged);
+    }
+    final pick = widget.pick;
+    if (pick != null) {
+      _controllerSide = pick.side;
+      _setControllerText(pick.value);
+    }
+  }
+
+  @override
+  void dispose() {
+    _textController?.dispose();
+    _codeController?.dispose();
+    super.dispose();
+  }
+
+  void _setControllerText(String text) {
+    if (_isBody) {
+      _codeController!.text = text;
+    } else {
+      _textController!.text = text;
+    }
+  }
+
+  void _onTextChanged() {
+    final side = _controllerSide;
+    if (side == null) return;
+    widget.onPick(FieldPick(side: side, value: _textController!.text));
+  }
+
+  void _onCodeChanged() {
+    final side = _controllerSide;
+    if (side == null) return;
+    widget.onPick(FieldPick(side: side, value: _codeController!.text));
+  }
+
+  void _pickSide(FileSide side) {
+    final fc = widget.fieldConflict;
+    if (_editable) {
+      final value = side == FileSide.incoming
+          ? (fc.incoming ?? '')
+          : (fc.yours ?? '');
+      _controllerSide = side;
+      _setControllerText(value);
+      widget.onPick(FieldPick(side: side, value: value));
+    } else {
+      final value = side == FileSide.incoming ? 'incoming' : 'yours';
+      widget.onPick(FieldPick(side: side, value: value));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final layout = context.appLayout;
+    final fc = widget.fieldConflict;
+    final pick = widget.pick;
+    final keyBase = '${widget.path}_${fc.field}';
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(
+          fc.field,
+          style: TextStyle(fontWeight: context.appTypography.bodyWeight),
+        ),
+        SizedBox(height: layout.tabSpacing / 2),
+        Row(
+          children: [
+            Expanded(
+              child: _SideButton(
+                key: ValueKey('take_incoming_$keyBase'),
+                label: 'TAKE INCOMING',
+                selected: pick?.side == FileSide.incoming,
+                onTap: () => _pickSide(FileSide.incoming),
+              ),
+            ),
+            SizedBox(width: layout.tabSpacing),
+            Expanded(
+              child: _SideButton(
+                key: ValueKey('keep_yours_$keyBase'),
+                label: 'KEEP YOURS',
+                selected: pick?.side == FileSide.yours,
+                onTap: () => _pickSide(FileSide.yours),
+              ),
+            ),
+          ],
+        ),
+        if (_editable && pick != null)
+          Padding(
+            padding: EdgeInsets.only(top: layout.tabSpacing),
+            child: _isBody
+                ? SizedBox(
+                    key: ValueKey('edit_body_$keyBase'),
+                    height: 160,
+                    child: JsonCodeEditor(controller: _codeController!),
+                  )
+                : TextField(
+                    key: ValueKey('edit_field_$keyBase'),
+                    controller: _textController,
+                  ),
+          ),
+      ],
+    );
+  }
+}
+
+class _CoarseTile extends StatelessWidget {
+  const _CoarseTile({
+    required this.conflict,
+    required this.picked,
+    required this.onPick,
+  });
+  final FileConflict conflict;
+  final FileSide? picked;
+  final ValueChanged<FileSide> onPick;
+
+  bool get _isDeleteModify => conflict.kind == ConflictKind.deleteModify;
+
+  @override
+  Widget build(BuildContext context) {
+    final layout = context.appLayout;
+    final incomingLabel = _isDeleteModify
+        ? 'Accept the deletion'
+        : 'TAKE INCOMING';
+    final yoursLabel = _isDeleteModify
+        ? 'Keep your edited request'
+        : 'KEEP YOURS';
+    return Container(
+      key: ValueKey('conflict_file_${conflict.path}'),
+      padding: EdgeInsets.all(layout.tabSpacing),
+      decoration: context.appDecoration.panelBox(context),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            conflict.path,
+            style: TextStyle(
+              fontWeight: context.appTypography.titleWeight,
+              fontFamily: context.appTypography.codeFontFamily,
+            ),
+          ),
+          SizedBox(height: layout.tabSpacing),
+          Row(
+            children: [
+              Expanded(
+                child: _SideButton(
+                  key: ValueKey('take_incoming_${conflict.path}'),
+                  label: incomingLabel,
+                  selected: picked == FileSide.incoming,
+                  onTap: () => onPick(FileSide.incoming),
+                ),
+              ),
+              SizedBox(width: layout.tabSpacing),
+              Expanded(
+                child: _SideButton(
+                  key: ValueKey('keep_yours_${conflict.path}'),
+                  label: yoursLabel,
+                  selected: picked == FileSide.yours,
+                  onTap: () => onPick(FileSide.yours),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// A single two-state pick button: filled when selected, outlined otherwise.
+class _SideButton extends StatelessWidget {
+  const _SideButton({
+    required this.label,
+    required this.selected,
+    required this.onTap,
+    super.key,
+  });
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return selected
+        ? FilledButton(onPressed: onTap, child: Text(label))
+        : OutlinedButton(onPressed: onTap, child: Text(label));
+  }
+}

--- a/lib/features/collections/presentation/widgets/conflict_resolution_dialog.dart
+++ b/lib/features/collections/presentation/widgets/conflict_resolution_dialog.dart
@@ -12,6 +12,7 @@ import 'package:getman/features/collections/presentation/bloc/conflict_event.dar
 import 'package:getman/features/collections/presentation/bloc/conflict_state.dart';
 import 'package:getman/features/collections/presentation/bloc/git_sync_bloc.dart';
 import 'package:getman/features/collections/presentation/bloc/git_sync_event.dart';
+import 'package:getman/features/settings/presentation/bloc/settings_bloc.dart';
 import 'package:getman/features/tabs/presentation/widgets/json_code_editor.dart';
 import 'package:re_editor/re_editor.dart';
 
@@ -29,6 +30,11 @@ class ConflictResolutionDialog {
     // via GitSyncBloc (widget-layer coordination — no bloc→bloc coupling).
     final conflict = context.read<ConflictBloc>();
     final git = context.read<GitSyncBloc>();
+    // Also re-provided (mirroring conflict/git above): the fullscreen route
+    // path in showResponsiveDialog pushes onto the root Navigator, so the
+    // RESOLVE & CONTINUE identity read below needs SettingsBloc reachable
+    // from that subtree.
+    final settings = context.read<SettingsBloc>();
     return showResponsiveDialog<void>(
       context,
       barrierDismissible: false,
@@ -36,6 +42,7 @@ class ConflictResolutionDialog {
         providers: [
           BlocProvider<ConflictBloc>.value(value: conflict),
           BlocProvider<GitSyncBloc>.value(value: git),
+          BlocProvider<SettingsBloc>.value(value: settings),
         ],
         child: ConflictResolutionBody(root: root),
       ),
@@ -124,8 +131,14 @@ class _ConflictResolutionBodyState extends State<ConflictResolutionBody> {
         else
           FileResolution(path: fc.path, wholeFile: _wholeFilePicks[fc.path]),
     ];
+    final identity = context.read<SettingsBloc>().state.settings;
     context.read<ConflictBloc>().add(
-      ResolveAndContinue(widget.root, resolutions),
+      ResolveAndContinue(
+        widget.root,
+        resolutions,
+        authorName: identity.gitUserName,
+        authorEmail: identity.gitUserEmail,
+      ),
     );
   }
 

--- a/lib/features/collections/presentation/widgets/pull_requests_dialog.dart
+++ b/lib/features/collections/presentation/widgets/pull_requests_dialog.dart
@@ -1,0 +1,452 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:getman/core/theme/app_theme.dart';
+import 'package:getman/core/ui/widgets/app_snack_bar.dart';
+import 'package:getman/core/ui/widgets/responsive_dialog.dart';
+import 'package:getman/core/utils/open_url.dart';
+import 'package:getman/features/collections/domain/entities/pull_request.dart';
+import 'package:getman/features/collections/presentation/bloc/git_sync_bloc.dart';
+import 'package:getman/features/collections/presentation/bloc/git_sync_event.dart';
+import 'package:getman/features/collections/presentation/bloc/pull_requests_bloc.dart';
+import 'package:getman/features/collections/presentation/bloc/pull_requests_event.dart';
+import 'package:getman/features/collections/presentation/bloc/pull_requests_state.dart';
+
+/// GitHub pull-request panel reached from the branch chip. Renders one of three
+/// views off `availability`: install prompt / auth prompt / the open-PR list
+/// with create + refresh. Rides on the user's `gh auth` — stores no credential.
+class PullRequestsDialog {
+  const PullRequestsDialog._();
+
+  static Future<void> show(BuildContext context, {required String root}) {
+    // Capture both blocs before the dialog's own subtree: the list lives under
+    // PullRequestsBloc; a create that pushed nudges the branch chip via
+    // GitSyncBloc (widget-layer coordination — no bloc→bloc coupling).
+    final prs = context.read<PullRequestsBloc>();
+    final git = context.read<GitSyncBloc>();
+    return showResponsiveDialog<void>(
+      context,
+      builder: (_) => MultiBlocProvider(
+        providers: [
+          BlocProvider<PullRequestsBloc>.value(value: prs),
+          BlocProvider<GitSyncBloc>.value(value: git),
+        ],
+        child: PullRequestsBody(root: root),
+      ),
+    );
+  }
+}
+
+/// The dialog content (public for widget testing). Stateful only to dispatch
+/// the one-shot [LoadPullRequests] on open, mirroring `ReviewChangesButton`.
+class PullRequestsBody extends StatefulWidget {
+  const PullRequestsBody({required this.root, super.key});
+  final String root;
+
+  @override
+  State<PullRequestsBody> createState() => _PullRequestsBodyState();
+}
+
+class _PullRequestsBodyState extends State<PullRequestsBody> {
+  @override
+  void initState() {
+    super.initState();
+    context.read<PullRequestsBloc>().add(LoadPullRequests(widget.root));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final layout = context.appLayout;
+    return BlocConsumer<PullRequestsBloc, PullRequestsState>(
+      listenWhen: (p, c) =>
+          (c.status == PrStatus.error &&
+              p.errorMessage != c.errorMessage &&
+              c.errorMessage != null) ||
+          // Consume lastCreated exactly once — it is sticky, so gate on change.
+          (p.lastCreated != c.lastCreated && c.lastCreated != null),
+      listener: (context, state) {
+        if (state.status == PrStatus.error) {
+          _showError(context, state.errorMessage!);
+        } else {
+          _onCreated(context, state.lastCreated!);
+        }
+      },
+      builder: (context, state) {
+        return ResponsiveDialogScaffold(
+          title: const Text('PULL REQUESTS'),
+          content: SizedBox(
+            width: layout.dialogWidth,
+            height: layout.settingsDialogHeight,
+            child: _view(context, state),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).maybePop(),
+              child: const Text('CLOSE'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _view(BuildContext context, PullRequestsState state) {
+    switch (state.availability) {
+      case GhAvailability.notInstalled:
+        return const _InstallPrompt();
+      case GhAvailability.notAuthenticated:
+        return _AuthPrompt(root: widget.root);
+      case GhAvailability.available:
+        return _AvailableView(root: widget.root, state: state);
+    }
+  }
+
+  void _onCreated(BuildContext context, PullRequestRef ref) {
+    showAppSnackBar(context, 'PR #${ref.number} opened.');
+    // The push changed ahead/behind — refresh the branch chip.
+    context.read<GitSyncBloc>().add(LoadBranchStatus(widget.root));
+  }
+
+  void _showError(BuildContext context, String message) {
+    unawaited(
+      showDialog<void>(
+        context: context,
+        builder: (dialogContext) => AlertDialog(
+          key: const ValueKey('pr_error_dialog'),
+          title: const Text('GIT ERROR'),
+          content: SingleChildScrollView(child: Text(message)),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(),
+              child: const Text('CLOSE'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _InstallPrompt extends StatelessWidget {
+  const _InstallPrompt();
+
+  @override
+  Widget build(BuildContext context) {
+    final layout = context.appLayout;
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        const Text(
+          'GitHub CLI (gh) not found',
+          textAlign: TextAlign.center,
+        ),
+        SizedBox(height: layout.tabSpacing),
+        const Text(
+          'Getman opens pull requests through the gh command-line tool.',
+          textAlign: TextAlign.center,
+        ),
+        SizedBox(height: layout.pagePadding),
+        FilledButton(
+          key: const ValueKey('pr_install_gh'),
+          onPressed: () => unawaited(openUrl('https://cli.github.com')),
+          child: const Text('INSTALL GH'),
+        ),
+      ],
+    );
+  }
+}
+
+class _AuthPrompt extends StatelessWidget {
+  const _AuthPrompt({required this.root});
+  final String root;
+
+  @override
+  Widget build(BuildContext context) {
+    final layout = context.appLayout;
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        const Text(
+          'Sign in with the GitHub CLI',
+          textAlign: TextAlign.center,
+        ),
+        SizedBox(height: layout.tabSpacing),
+        const Text(
+          'Run this in a terminal, then refresh:',
+          textAlign: TextAlign.center,
+        ),
+        SizedBox(height: layout.tabSpacing),
+        SelectableText(
+          'gh auth login',
+          style: TextStyle(
+            fontFamily: context.appTypography.codeFontFamily,
+          ),
+        ),
+        SizedBox(height: layout.pagePadding),
+        OutlinedButton(
+          onPressed: () =>
+              context.read<PullRequestsBloc>().add(LoadPullRequests(root)),
+          child: const Text('REFRESH'),
+        ),
+      ],
+    );
+  }
+}
+
+class _AvailableView extends StatelessWidget {
+  const _AvailableView({required this.root, required this.state});
+  final String root;
+  final PullRequestsState state;
+
+  // `initial` is the pre-first-load state; treat it like busy so the fresh
+  // bloc's first paint shows the spinner, not a one-frame "no PRs" flash.
+  bool get _busy => state.isBusy || state.status == PrStatus.initial;
+
+  @override
+  Widget build(BuildContext context) {
+    final layout = context.appLayout;
+    final busy = _busy;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Row(
+          children: [
+            OutlinedButton(
+              key: const ValueKey('pr_refresh'),
+              onPressed: busy
+                  ? null
+                  : () => context.read<PullRequestsBloc>().add(
+                      LoadPullRequests(root),
+                    ),
+              child: const Text('REFRESH'),
+            ),
+            const Spacer(),
+            FilledButton(
+              key: const ValueKey('pr_create'),
+              onPressed: busy ? null : () => _openCreateForm(context),
+              child: const Text('CREATE PULL REQUEST…'),
+            ),
+          ],
+        ),
+        SizedBox(height: layout.tabSpacing),
+        Expanded(child: _list(context)),
+      ],
+    );
+  }
+
+  Widget _list(BuildContext context) {
+    if (_busy) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (state.prs.isEmpty) {
+      return const Center(child: Text('No open pull requests.'));
+    }
+    return ListView.builder(
+      itemCount: state.prs.length,
+      itemBuilder: (context, i) => _PrRow(pr: state.prs[i]),
+    );
+  }
+
+  void _openCreateForm(BuildContext context) {
+    // Prefill base with a likely default from the known branches.
+    final branches = context.read<GitSyncBloc>().state.branch.branches;
+    final base = branches.contains('main')
+        ? 'main'
+        : branches.contains('master')
+        ? 'master'
+        : (branches.isNotEmpty ? branches.first : '');
+    unawaited(_CreatePrForm.show(context, root: root, initialBase: base));
+  }
+}
+
+class _PrRow extends StatelessWidget {
+  const _PrRow({required this.pr});
+  final PullRequestEntity pr;
+
+  @override
+  Widget build(BuildContext context) {
+    final layout = context.appLayout;
+    return ListTile(
+      key: ValueKey('pr_row_${pr.number}'),
+      dense: true,
+      leading: _ChecksGlyph(checks: pr.checks),
+      title: Text(pr.title, overflow: TextOverflow.ellipsis),
+      subtitle: Row(
+        children: [
+          Text('#${pr.number}'),
+          if (pr.isDraft) ...[
+            SizedBox(width: layout.tabSpacing),
+            Text(
+              'DRAFT',
+              style: TextStyle(
+                fontWeight: context.appTypography.titleWeight,
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ],
+      ),
+      trailing: Icon(Icons.open_in_new, size: layout.smallIconSize),
+      onTap: () => unawaited(_open(context)),
+    );
+  }
+
+  Future<void> _open(BuildContext context) async {
+    final messenger = ScaffoldMessenger.of(context);
+    final ok = await openUrl(pr.url);
+    if (!ok) showAppSnackBarVia(messenger, 'Could not open the PR url.');
+  }
+}
+
+class _ChecksGlyph extends StatelessWidget {
+  const _ChecksGlyph({required this.checks});
+  final PrChecks checks;
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.appPalette;
+    final size = context.appLayout.iconSize;
+    switch (checks) {
+      case PrChecks.passing:
+        return Icon(
+          Icons.check_circle,
+          size: size,
+          color: palette.statusAccentSuccess,
+        );
+      case PrChecks.failing:
+        return Icon(Icons.cancel, size: size, color: palette.statusAccentError);
+      case PrChecks.pending:
+        return Icon(
+          Icons.schedule,
+          size: size,
+          color: palette.statusAccentWarning,
+        );
+      case PrChecks.none:
+        return Icon(
+          Icons.remove,
+          size: size,
+          color: Theme.of(context).colorScheme.onSurfaceVariant,
+        );
+    }
+  }
+}
+
+/// The create form (a second dialog). Base + title + optional body + draft.
+class _CreatePrForm extends StatefulWidget {
+  const _CreatePrForm({required this.root, required this.initialBase});
+  final String root;
+  final String initialBase;
+
+  static Future<void> show(
+    BuildContext context, {
+    required String root,
+    required String initialBase,
+  }) {
+    final bloc = context.read<PullRequestsBloc>();
+    return showResponsiveDialog<void>(
+      context,
+      builder: (_) => BlocProvider<PullRequestsBloc>.value(
+        value: bloc,
+        child: _CreatePrForm(root: root, initialBase: initialBase),
+      ),
+    );
+  }
+
+  @override
+  State<_CreatePrForm> createState() => _CreatePrFormState();
+}
+
+class _CreatePrFormState extends State<_CreatePrForm> {
+  late final TextEditingController _base = TextEditingController(
+    text: widget.initialBase,
+  );
+  final TextEditingController _title = TextEditingController();
+  final TextEditingController _body = TextEditingController();
+  bool _draft = false;
+
+  @override
+  void dispose() {
+    _base.dispose();
+    _title.dispose();
+    _body.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final layout = context.appLayout;
+    return ResponsiveDialogScaffold(
+      title: const Text('CREATE PULL REQUEST'),
+      content: SizedBox(
+        width: layout.dialogWidth,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            TextField(
+              key: const ValueKey('pr_form_base'),
+              controller: _base,
+              decoration: const InputDecoration(
+                labelText: 'BASE BRANCH',
+                hintText: 'main',
+              ),
+            ),
+            SizedBox(height: layout.tabSpacing),
+            TextField(
+              key: const ValueKey('pr_form_title'),
+              controller: _title,
+              decoration: const InputDecoration(labelText: 'PR TITLE'),
+              onChanged: (_) => setState(() {}),
+            ),
+            SizedBox(height: layout.tabSpacing),
+            TextField(
+              key: const ValueKey('pr_form_body'),
+              controller: _body,
+              minLines: 3,
+              maxLines: 6,
+              decoration: const InputDecoration(
+                labelText: 'PR body (optional)',
+              ),
+            ),
+            SizedBox(height: layout.tabSpacing),
+            SwitchListTile(
+              key: const ValueKey('pr_form_draft'),
+              contentPadding: EdgeInsets.zero,
+              title: const Text('Create as draft'),
+              value: _draft,
+              onChanged: (v) => setState(() => _draft = v),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).maybePop(),
+          child: const Text('CANCEL'),
+        ),
+        FilledButton(
+          key: const ValueKey('pr_form_submit'),
+          onPressed: _canSubmit ? _submit : null,
+          child: const Text('CREATE'),
+        ),
+      ],
+    );
+  }
+
+  bool get _canSubmit =>
+      _base.text.trim().isNotEmpty && _title.text.trim().isNotEmpty;
+
+  void _submit() {
+    context.read<PullRequestsBloc>().add(
+      CreatePullRequest(
+        widget.root,
+        base: _base.text.trim(),
+        title: _title.text.trim(),
+        body: _body.text,
+        draft: _draft,
+      ),
+    );
+    unawaited(Navigator.of(context).maybePop());
+  }
+}

--- a/lib/features/collections/presentation/widgets/pull_requests_dialog.dart
+++ b/lib/features/collections/presentation/widgets/pull_requests_dialog.dart
@@ -249,14 +249,17 @@ class _AvailableView extends StatelessWidget {
   }
 
   void _openCreateForm(BuildContext context) {
-    // Prefill base with a likely default from the known branches.
-    final branches = context.read<GitSyncBloc>().state.branch.branches;
-    final base = branches.contains('main')
-        ? 'main'
-        : branches.contains('master')
-        ? 'master'
-        : (branches.isNotEmpty ? branches.first : '');
+    // Prefer the repo's real default branch (gh repo view); fall back to a
+    // main/master/first-branch heuristic only when it couldn't be resolved.
+    final base = state.defaultBase ?? _heuristicBase(context);
     unawaited(_CreatePrForm.show(context, root: root, initialBase: base));
+  }
+
+  String _heuristicBase(BuildContext context) {
+    final branches = context.read<GitSyncBloc>().state.branch.branches;
+    if (branches.contains('main')) return 'main';
+    if (branches.contains('master')) return 'master';
+    return branches.isNotEmpty ? branches.first : '';
   }
 }
 
@@ -387,6 +390,7 @@ class _CreatePrFormState extends State<_CreatePrForm> {
             TextField(
               key: const ValueKey('pr_form_base'),
               controller: _base,
+              onChanged: (_) => setState(() {}),
               decoration: const InputDecoration(
                 labelText: 'BASE BRANCH',
                 hintText: 'main',

--- a/lib/features/collections/presentation/widgets/review_changes_dialog.dart
+++ b/lib/features/collections/presentation/widgets/review_changes_dialog.dart
@@ -89,8 +89,7 @@ class _ReviewChangesBodyState extends State<ReviewChangesBody> {
   void _push(BuildContext context) {
     final gitSyncBloc = context.read<GitSyncBloc>();
     if (gitSyncBloc.state.branch.hasRemote) {
-      gitSyncBloc.add(PushChanges(widget.root));
-      _afterPushDispatched(context);
+      _dispatchPush(context, gitSyncBloc, null);
       return;
     }
     unawaited(
@@ -102,14 +101,27 @@ class _ReviewChangesBodyState extends State<ReviewChangesBody> {
         onConfirm: (url) {
           final trimmed = url.trim();
           if (trimmed.isEmpty) return;
-          gitSyncBloc.add(PushChanges(widget.root, addRemoteUrl: trimmed));
-          _afterPushDispatched(context);
+          _dispatchPush(context, gitSyncBloc, trimmed);
         },
       ),
     );
   }
 
-  void _afterPushDispatched(BuildContext context) {
+  /// Dispatches the actual `PushChanges` — checked here, at the point of
+  /// dispatch (after any add-remote prompt is confirmed), so it reflects
+  /// current bloc state: `GitSyncBloc` silently drops a `PushChanges` while
+  /// another op is in flight (e.g. the 5-min auto-fetch), so an unconditional
+  /// "Pushing to remote…" would lie to the user.
+  void _dispatchPush(
+    BuildContext context,
+    GitSyncBloc gitSyncBloc,
+    String? addRemoteUrl,
+  ) {
+    if (gitSyncBloc.state.isBusy) {
+      showAppSnackBar(context, 'Git is busy — try again in a moment.');
+      return;
+    }
+    gitSyncBloc.add(PushChanges(widget.root, addRemoteUrl: addRemoteUrl));
     showAppSnackBar(context, 'Pushing to remote…');
     unawaited(Navigator.of(context).maybePop());
   }

--- a/lib/features/collections/presentation/widgets/review_changes_dialog.dart
+++ b/lib/features/collections/presentation/widgets/review_changes_dialog.dart
@@ -292,6 +292,8 @@ class _GitIdentityDialogState extends State<_GitIdentityDialog> {
   @override
   Widget build(BuildContext context) {
     final layout = context.appLayout;
+    final canSave =
+        _name.text.trim().isNotEmpty && _email.text.trim().isNotEmpty;
     return AlertDialog(
       key: const ValueKey('git_identity_dialog'),
       title: const Text('WHO ARE YOU?'),
@@ -307,12 +309,14 @@ class _GitIdentityDialogState extends State<_GitIdentityDialog> {
             key: const ValueKey('git_identity_name_field'),
             controller: _name,
             autofocus: true,
+            onChanged: (_) => setState(() {}),
             decoration: const InputDecoration(labelText: 'Your name'),
           ),
           SizedBox(height: layout.inputPadding),
           TextField(
             key: const ValueKey('git_identity_email_field'),
             controller: _email,
+            onChanged: (_) => setState(() {}),
             decoration: const InputDecoration(labelText: 'Your email'),
           ),
         ],
@@ -324,7 +328,7 @@ class _GitIdentityDialogState extends State<_GitIdentityDialog> {
         ),
         FilledButton(
           key: const ValueKey('git_identity_save'),
-          onPressed: _save,
+          onPressed: canSave ? _save : null,
           child: const Text('SAVE'),
         ),
       ],

--- a/lib/features/collections/presentation/widgets/review_changes_dialog.dart
+++ b/lib/features/collections/presentation/widgets/review_changes_dialog.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:getman/core/theme/app_theme.dart';
@@ -7,6 +9,8 @@ import 'package:getman/features/collections/presentation/bloc/review_bloc.dart';
 import 'package:getman/features/collections/presentation/bloc/review_event.dart';
 import 'package:getman/features/collections/presentation/bloc/review_state.dart';
 import 'package:getman/features/collections/presentation/widgets/semantic_diff_view.dart';
+import 'package:getman/features/settings/presentation/bloc/settings_bloc.dart';
+import 'package:getman/features/settings/presentation/bloc/settings_event.dart';
 
 /// Opens the Review Changes dialog and dispatches the initial [LoadReview].
 class ReviewChangesDialog {
@@ -14,10 +18,18 @@ class ReviewChangesDialog {
 
   static Future<void> show(BuildContext context, {required String root}) {
     final reviewBloc = context.read<ReviewBloc>()..add(LoadReview(root));
+    // Captured + re-provided (not just read at dispatch time below): the
+    // fullscreen route path in showResponsiveDialog pushes onto the root
+    // Navigator, so the identity-prompt flow needs SettingsBloc reachable
+    // from that subtree the same way ReviewBloc already is.
+    final settingsBloc = context.read<SettingsBloc>();
     return showResponsiveDialog<void>(
       context,
-      builder: (dialogContext) => BlocProvider<ReviewBloc>.value(
-        value: reviewBloc,
+      builder: (dialogContext) => MultiBlocProvider(
+        providers: [
+          BlocProvider<ReviewBloc>.value(value: reviewBloc),
+          BlocProvider<SettingsBloc>.value(value: settingsBloc),
+        ],
         child: ReviewChangesBody(root: root),
       ),
     );
@@ -48,10 +60,54 @@ class _ReviewChangesBodyState extends State<ReviewChangesBody> {
     ChangeType.modified => Icons.edit,
   };
 
+  void _commit(BuildContext context) {
+    final identity = context.read<SettingsBloc>().state.settings;
+    context.read<ReviewBloc>().add(
+      Commit(
+        widget.root,
+        _message.text.trim(),
+        authorName: identity.gitUserName,
+        authorEmail: identity.gitUserEmail,
+      ),
+    );
+  }
+
+  /// A commit failed because neither Getman nor the OS git has a configured
+  /// commit identity — prompt for name/email, save it, and retry the same
+  /// commit message.
+  void _promptIdentity(BuildContext context) {
+    final settingsBloc = context.read<SettingsBloc>();
+    final reviewBloc = context.read<ReviewBloc>();
+    unawaited(
+      showDialog<void>(
+        context: context,
+        builder: (dialogContext) => _GitIdentityDialog(
+          initialName: settingsBloc.state.settings.gitUserName,
+          initialEmail: settingsBloc.state.settings.gitUserEmail,
+          onSave: (name, email) {
+            settingsBloc.add(UpdateGitIdentity(name: name, email: email));
+            reviewBloc.add(
+              Commit(
+                widget.root,
+                _message.text.trim(),
+                authorName: name,
+                authorEmail: email,
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final layout = context.appLayout;
-    return BlocBuilder<ReviewBloc, ReviewState>(
+    return BlocConsumer<ReviewBloc, ReviewState>(
+      listenWhen: (p, c) =>
+          p.status != ReviewStatus.needsIdentity &&
+          c.status == ReviewStatus.needsIdentity,
+      listener: (context, state) => _promptIdentity(context),
       builder: (context, state) {
         return ResponsiveDialogScaffold(
           title: Text(
@@ -177,11 +233,7 @@ class _ReviewChangesBodyState extends State<ReviewChangesBody> {
             SizedBox(width: context.appLayout.inputPadding),
             ElevatedButton(
               key: const ValueKey('review_commit_button'),
-              onPressed: canCommit
-                  ? () => context.read<ReviewBloc>().add(
-                      Commit(widget.root, _message.text.trim()),
-                    )
-                  : null,
+              onPressed: canCommit ? () => _commit(context) : null,
               child: Text(
                 state.status == ReviewStatus.committing
                     ? 'COMMITTING…'
@@ -189,6 +241,91 @@ class _ReviewChangesBodyState extends State<ReviewChangesBody> {
               ),
             ),
           ],
+        ),
+      ],
+    );
+  }
+}
+
+/// Just-in-time prompt for a Getman-owned commit identity, shown when a
+/// commit fails because neither Getman's stored identity nor the OS git
+/// config has one. Prefilled from the current Settings value (if any); SAVE
+/// hands the trimmed name/email back to the caller, which persists it and
+/// retries the commit.
+class _GitIdentityDialog extends StatefulWidget {
+  const _GitIdentityDialog({
+    required this.onSave,
+    this.initialName,
+    this.initialEmail,
+  });
+  final String? initialName;
+  final String? initialEmail;
+  final void Function(String name, String email) onSave;
+
+  @override
+  State<_GitIdentityDialog> createState() => _GitIdentityDialogState();
+}
+
+class _GitIdentityDialogState extends State<_GitIdentityDialog> {
+  late final TextEditingController _name;
+  late final TextEditingController _email;
+
+  @override
+  void initState() {
+    super.initState();
+    _name = TextEditingController(text: widget.initialName ?? '');
+    _email = TextEditingController(text: widget.initialEmail ?? '');
+  }
+
+  @override
+  void dispose() {
+    _name.dispose();
+    _email.dispose();
+    super.dispose();
+  }
+
+  void _save() {
+    Navigator.of(context).pop();
+    widget.onSave(_name.text.trim(), _email.text.trim());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final layout = context.appLayout;
+    return AlertDialog(
+      key: const ValueKey('git_identity_dialog'),
+      title: const Text('WHO ARE YOU?'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Text(
+            'Getman needs a name and email to author commits — this is '
+            'stored in Getman only, never written to your git config.',
+          ),
+          SizedBox(height: layout.inputPadding),
+          TextField(
+            key: const ValueKey('git_identity_name_field'),
+            controller: _name,
+            autofocus: true,
+            decoration: const InputDecoration(labelText: 'Your name'),
+          ),
+          SizedBox(height: layout.inputPadding),
+          TextField(
+            key: const ValueKey('git_identity_email_field'),
+            controller: _email,
+            decoration: const InputDecoration(labelText: 'Your email'),
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('CANCEL'),
+        ),
+        FilledButton(
+          key: const ValueKey('git_identity_save'),
+          onPressed: _save,
+          child: const Text('SAVE'),
         ),
       ],
     );

--- a/lib/features/collections/presentation/widgets/review_changes_dialog.dart
+++ b/lib/features/collections/presentation/widgets/review_changes_dialog.dart
@@ -3,8 +3,12 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:getman/core/theme/app_theme.dart';
+import 'package:getman/core/ui/widgets/app_snack_bar.dart';
+import 'package:getman/core/ui/widgets/name_prompt_dialog.dart';
 import 'package:getman/core/ui/widgets/responsive_dialog.dart';
 import 'package:getman/features/collections/domain/entities/review_entry.dart';
+import 'package:getman/features/collections/presentation/bloc/git_sync_bloc.dart';
+import 'package:getman/features/collections/presentation/bloc/git_sync_event.dart';
 import 'package:getman/features/collections/presentation/bloc/review_bloc.dart';
 import 'package:getman/features/collections/presentation/bloc/review_event.dart';
 import 'package:getman/features/collections/presentation/bloc/review_state.dart';
@@ -21,14 +25,18 @@ class ReviewChangesDialog {
     // Captured + re-provided (not just read at dispatch time below): the
     // fullscreen route path in showResponsiveDialog pushes onto the root
     // Navigator, so the identity-prompt flow needs SettingsBloc reachable
-    // from that subtree the same way ReviewBloc already is.
+    // from that subtree the same way ReviewBloc already is. GitSyncBloc is
+    // captured the same way so the PUSH button can read `hasRemote` and
+    // dispatch — it's provided at the app root (main.dart), reachable here.
     final settingsBloc = context.read<SettingsBloc>();
+    final gitSyncBloc = context.read<GitSyncBloc>();
     return showResponsiveDialog<void>(
       context,
       builder: (dialogContext) => MultiBlocProvider(
         providers: [
           BlocProvider<ReviewBloc>.value(value: reviewBloc),
           BlocProvider<SettingsBloc>.value(value: settingsBloc),
+          BlocProvider<GitSyncBloc>.value(value: gitSyncBloc),
         ],
         child: ReviewChangesBody(root: root),
       ),
@@ -70,6 +78,40 @@ class _ReviewChangesBodyState extends State<ReviewChangesBody> {
         authorEmail: identity.gitUserEmail,
       ),
     );
+  }
+
+  /// PUSH from the review dialog. When the repo has a remote, pushes right
+  /// away; otherwise prompts for a URL first (the bloc adds it as `origin`
+  /// before pushing — see `GitSyncBloc._maybeAddRemote`). Either way, this
+  /// only *starts* the push: feedback (busy/error/updated ahead-count) surfaces
+  /// on the branch chip, not here — closing the dialog hands the user back to
+  /// it immediately.
+  void _push(BuildContext context) {
+    final gitSyncBloc = context.read<GitSyncBloc>();
+    if (gitSyncBloc.state.branch.hasRemote) {
+      gitSyncBloc.add(PushChanges(widget.root));
+      _afterPushDispatched(context);
+      return;
+    }
+    unawaited(
+      NamePromptDialog.show(
+        context,
+        title: 'ADD REMOTE',
+        hintText: 'https://github.com/you/repo.git',
+        confirmLabel: 'ADD REMOTE',
+        onConfirm: (url) {
+          final trimmed = url.trim();
+          if (trimmed.isEmpty) return;
+          gitSyncBloc.add(PushChanges(widget.root, addRemoteUrl: trimmed));
+          _afterPushDispatched(context);
+        },
+      ),
+    );
+  }
+
+  void _afterPushDispatched(BuildContext context) {
+    showAppSnackBar(context, 'Pushing to remote…');
+    unawaited(Navigator.of(context).maybePop());
   }
 
   /// A commit failed because neither Getman nor the OS git has a configured
@@ -121,6 +163,12 @@ class _ReviewChangesBodyState extends State<ReviewChangesBody> {
             child: _body(context, state),
           ),
           actions: [
+            if (state.repoExists)
+              TextButton(
+                key: const ValueKey('review_push_button'),
+                onPressed: () => _push(context),
+                child: const Text('PUSH'),
+              ),
             TextButton(
               onPressed: () => Navigator.of(context).maybePop(),
               child: const Text('CLOSE'),

--- a/lib/features/settings/data/models/settings_model.dart
+++ b/lib/features/settings/data/models/settings_model.dart
@@ -35,6 +35,8 @@ class SettingsModel extends HiveObject {
     this.saveLargeResponsesInHistory = true,
     this.checkForUpdatesOnStartup = true,
     this.skippedUpdateVersion,
+    this.gitUserName,
+    this.gitUserEmail,
   });
 
   factory SettingsModel.fromJson(Map<String, dynamic> json) => SettingsModel(
@@ -66,6 +68,8 @@ class SettingsModel extends HiveObject {
         json['saveLargeResponsesInHistory'] as bool? ?? true,
     checkForUpdatesOnStartup: json['checkForUpdatesOnStartup'] as bool? ?? true,
     skippedUpdateVersion: json['skippedUpdateVersion'] as String?,
+    gitUserName: json['gitUserName'] as String?,
+    gitUserEmail: json['gitUserEmail'] as String?,
   );
 
   factory SettingsModel.fromEntity(SettingsEntity entity) => SettingsModel(
@@ -95,6 +99,8 @@ class SettingsModel extends HiveObject {
     saveLargeResponsesInHistory: entity.saveLargeResponsesInHistory,
     checkForUpdatesOnStartup: entity.checkForUpdatesOnStartup,
     skippedUpdateVersion: entity.skippedUpdateVersion,
+    gitUserName: entity.gitUserName,
+    gitUserEmail: entity.gitUserEmail,
   );
   @HiveField(0, defaultValue: 100)
   int historyLimit;
@@ -174,6 +180,15 @@ class SettingsModel extends HiveObject {
   @HiveField(26)
   String? skippedUpdateVersion;
 
+  /// Commit author identity Getman uses for git ops it performs (never
+  /// written to the user's global git config; passed inline via
+  /// `git -c user.name=… -c user.email=…`). `null` = not yet configured.
+  @HiveField(28)
+  String? gitUserName;
+
+  @HiveField(29)
+  String? gitUserEmail;
+
   SettingsModel copyWith({
     int? historyLimit,
     bool? saveResponseInHistory,
@@ -201,6 +216,8 @@ class SettingsModel extends HiveObject {
     bool? saveLargeResponsesInHistory,
     bool? checkForUpdatesOnStartup,
     Object? skippedUpdateVersion = _unchanged,
+    Object? gitUserName = _unchanged,
+    Object? gitUserEmail = _unchanged,
   }) {
     return SettingsModel(
       historyLimit: historyLimit ?? this.historyLimit,
@@ -249,6 +266,12 @@ class SettingsModel extends HiveObject {
       skippedUpdateVersion: identical(skippedUpdateVersion, _unchanged)
           ? this.skippedUpdateVersion
           : skippedUpdateVersion as String?,
+      gitUserName: identical(gitUserName, _unchanged)
+          ? this.gitUserName
+          : gitUserName as String?,
+      gitUserEmail: identical(gitUserEmail, _unchanged)
+          ? this.gitUserEmail
+          : gitUserEmail as String?,
     );
   }
 
@@ -279,6 +302,8 @@ class SettingsModel extends HiveObject {
     'saveLargeResponsesInHistory': saveLargeResponsesInHistory,
     'checkForUpdatesOnStartup': checkForUpdatesOnStartup,
     'skippedUpdateVersion': skippedUpdateVersion,
+    'gitUserName': gitUserName,
+    'gitUserEmail': gitUserEmail,
   };
 
   SettingsEntity toEntity() => SettingsEntity(
@@ -308,5 +333,7 @@ class SettingsModel extends HiveObject {
     saveLargeResponsesInHistory: saveLargeResponsesInHistory,
     checkForUpdatesOnStartup: checkForUpdatesOnStartup,
     skippedUpdateVersion: skippedUpdateVersion,
+    gitUserName: gitUserName,
+    gitUserEmail: gitUserEmail,
   );
 }

--- a/lib/features/settings/data/models/settings_model.g.dart
+++ b/lib/features/settings/data/models/settings_model.g.dart
@@ -51,13 +51,15 @@ class SettingsModelAdapter extends TypeAdapter<SettingsModel> {
           : fields[24] as bool,
       checkForUpdatesOnStartup: fields[25] == null ? true : fields[25] as bool,
       skippedUpdateVersion: fields[26] as String?,
+      gitUserName: fields[28] as String?,
+      gitUserEmail: fields[29] as String?,
     );
   }
 
   @override
   void write(BinaryWriter writer, SettingsModel obj) {
     writer
-      ..writeByte(26)
+      ..writeByte(28)
       ..writeByte(0)
       ..write(obj.historyLimit)
       ..writeByte(1)
@@ -109,7 +111,11 @@ class SettingsModelAdapter extends TypeAdapter<SettingsModel> {
       ..writeByte(25)
       ..write(obj.checkForUpdatesOnStartup)
       ..writeByte(26)
-      ..write(obj.skippedUpdateVersion);
+      ..write(obj.skippedUpdateVersion)
+      ..writeByte(28)
+      ..write(obj.gitUserName)
+      ..writeByte(29)
+      ..write(obj.gitUserEmail);
   }
 
   @override

--- a/lib/features/settings/domain/entities/settings_entity.dart
+++ b/lib/features/settings/domain/entities/settings_entity.dart
@@ -32,6 +32,8 @@ class SettingsEntity extends Equatable {
     this.saveLargeResponsesInHistory = true,
     this.checkForUpdatesOnStartup = true,
     this.skippedUpdateVersion,
+    this.gitUserName,
+    this.gitUserEmail,
   });
   final int historyLimit;
   final bool saveResponseInHistory;
@@ -96,6 +98,14 @@ class SettingsEntity extends Equatable {
   /// `null` = nothing skipped.
   final String? skippedUpdateVersion;
 
+  /// Commit author identity Getman uses for git ops it performs (name +
+  /// email passed inline via `git -c user.name=… -c user.email=…` on
+  /// commit-creating operations — never written to the user's global git
+  /// config). `null` = not yet configured; Getman prompts just-in-time when a
+  /// commit fails because neither Getman nor the OS git has an identity.
+  final String? gitUserName;
+  final String? gitUserEmail;
+
   SettingsEntity copyWith({
     int? historyLimit,
     bool? saveResponseInHistory,
@@ -123,6 +133,8 @@ class SettingsEntity extends Equatable {
     bool? saveLargeResponsesInHistory,
     bool? checkForUpdatesOnStartup,
     Object? skippedUpdateVersion = _unchanged,
+    Object? gitUserName = _unchanged,
+    Object? gitUserEmail = _unchanged,
   }) {
     return SettingsEntity(
       historyLimit: historyLimit ?? this.historyLimit,
@@ -171,6 +183,12 @@ class SettingsEntity extends Equatable {
       skippedUpdateVersion: identical(skippedUpdateVersion, _unchanged)
           ? this.skippedUpdateVersion
           : skippedUpdateVersion as String?,
+      gitUserName: identical(gitUserName, _unchanged)
+          ? this.gitUserName
+          : gitUserName as String?,
+      gitUserEmail: identical(gitUserEmail, _unchanged)
+          ? this.gitUserEmail
+          : gitUserEmail as String?,
     );
   }
 
@@ -216,5 +234,7 @@ class SettingsEntity extends Equatable {
     saveLargeResponsesInHistory,
     checkForUpdatesOnStartup,
     skippedUpdateVersion,
+    gitUserName,
+    gitUserEmail,
   ];
 }

--- a/lib/features/settings/presentation/bloc/settings_bloc.dart
+++ b/lib/features/settings/presentation/bloc/settings_bloc.dart
@@ -129,6 +129,15 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
       (e, emit) =>
           _apply(emit, (s) => s.copyWith(skippedUpdateVersion: e.version)),
     );
+    // Both fields are passed explicitly (null clears them) so callers send
+    // the whole current pair with one changed, matching
+    // UpdateClientCertificate.
+    on<UpdateGitIdentity>(
+      (e, emit) => _apply(
+        emit,
+        (s) => s.copyWith(gitUserName: e.name, gitUserEmail: e.email),
+      ),
+    );
   }
   final SaveSettingsUseCase _saveSettingsUseCase;
 

--- a/lib/features/settings/presentation/bloc/settings_event.dart
+++ b/lib/features/settings/presentation/bloc/settings_event.dart
@@ -177,3 +177,15 @@ class SetSkippedUpdateVersion extends SettingsEvent {
   @override
   List<Object?> get props => [version];
 }
+
+/// Sets the Getman-owned git commit identity (name + email), passed inline
+/// via `git -c user.name=… -c user.email=…` on commit-creating operations —
+/// never written to the user's global git config. Either field may be
+/// `null` to clear it.
+class UpdateGitIdentity extends SettingsEvent {
+  const UpdateGitIdentity({this.name, this.email});
+  final String? name;
+  final String? email;
+  @override
+  List<Object?> get props => [name, email];
+}

--- a/lib/features/settings/presentation/widgets/git_identity_settings_tile.dart
+++ b/lib/features/settings/presentation/widgets/git_identity_settings_tile.dart
@@ -1,0 +1,136 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:getman/core/theme/app_theme.dart';
+import 'package:getman/features/settings/presentation/bloc/settings_bloc.dart';
+import 'package:getman/features/settings/presentation/bloc/settings_event.dart';
+
+/// Settings control for the Getman-owned git commit identity: name + email
+/// used to author commits Getman makes (Review Changes / pull-rebase /
+/// conflict-resolve continue), passed inline via `git -c user.name=… -c
+/// user.email=…` — never written to the user's git config. Lives next to the
+/// WORKSPACE settings tile since it only matters once a workspace folder is
+/// git-managed. Desktop/mobile only (there is no git on web).
+class GitIdentitySettingsTile extends StatefulWidget {
+  const GitIdentitySettingsTile({super.key});
+
+  @override
+  State<GitIdentitySettingsTile> createState() =>
+      _GitIdentitySettingsTileState();
+}
+
+class _GitIdentitySettingsTileState extends State<GitIdentitySettingsTile> {
+  late final TextEditingController _nameController;
+  late final TextEditingController _emailController;
+
+  @override
+  void initState() {
+    super.initState();
+    final s = context.read<SettingsBloc>().state.settings;
+    _nameController = TextEditingController(text: s.gitUserName ?? '');
+    _emailController = TextEditingController(text: s.gitUserEmail ?? '');
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _emailController.dispose();
+    super.dispose();
+  }
+
+  void _update(BuildContext context, {String? name, String? email}) {
+    final current = context.read<SettingsBloc>().state.settings;
+    context.read<SettingsBloc>().add(
+      UpdateGitIdentity(
+        name: name ?? current.gitUserName,
+        email: email ?? current.gitUserEmail,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final layout = context.appLayout;
+    final theme = Theme.of(context);
+
+    return Padding(
+      padding: EdgeInsets.symmetric(
+        horizontal: layout.inputPadding,
+        vertical: layout.tabSpacing,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.badge_outlined, size: layout.iconSize),
+              SizedBox(width: layout.tabSpacing),
+              Text(
+                'COMMIT IDENTITY',
+                style: TextStyle(
+                  fontSize: layout.fontSizeNormal,
+                  fontWeight: context.appTypography.titleWeight,
+                ),
+              ),
+            ],
+          ),
+          SizedBox(height: layout.tabSpacing),
+          if (kIsWeb)
+            Text(
+              'Available in the desktop/mobile app.',
+              style: TextStyle(
+                fontSize: layout.fontSizeSmall,
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+              ),
+            )
+          else ...[
+            Text(
+              'Used to author commits Getman makes. Stored in Getman, never '
+              'written to your git config.',
+              style: TextStyle(
+                fontSize: layout.fontSizeSmall,
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.75),
+              ),
+            ),
+            SizedBox(height: layout.tabSpacing),
+            TextField(
+              key: const ValueKey('git_identity_name_field'),
+              controller: _nameController,
+              decoration: InputDecoration(
+                labelText: 'YOUR NAME',
+                isDense: true,
+                contentPadding: EdgeInsets.symmetric(
+                  horizontal: layout.inputPadding,
+                  vertical: layout.inputPaddingVertical,
+                ),
+              ),
+              onChanged: (val) {
+                final trimmed = val.trim();
+                _update(context, name: trimmed.isEmpty ? null : trimmed);
+              },
+            ),
+            SizedBox(height: layout.tabSpacing),
+            TextField(
+              key: const ValueKey('git_identity_email_field'),
+              controller: _emailController,
+              autocorrect: false,
+              enableSuggestions: false,
+              decoration: InputDecoration(
+                labelText: 'YOUR EMAIL',
+                isDense: true,
+                contentPadding: EdgeInsets.symmetric(
+                  horizontal: layout.inputPadding,
+                  vertical: layout.inputPaddingVertical,
+                ),
+              ),
+              onChanged: (val) {
+                final trimmed = val.trim();
+                _update(context, email: trimmed.isEmpty ? null : trimmed);
+              },
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/settings/presentation/widgets/settings_dialog.dart
+++ b/lib/features/settings/presentation/widgets/settings_dialog.dart
@@ -18,6 +18,7 @@ import 'package:getman/features/settings/presentation/bloc/settings_bloc.dart';
 import 'package:getman/features/settings/presentation/bloc/settings_event.dart';
 import 'package:getman/features/settings/presentation/bloc/settings_state.dart';
 import 'package:getman/features/settings/presentation/widgets/client_certificate_tile.dart';
+import 'package:getman/features/settings/presentation/widgets/git_identity_settings_tile.dart';
 import 'package:getman/features/updates/presentation/widgets/update_settings_section.dart';
 
 /// Fixed width of the small numeric input boxes (history limit, timeouts, …).
@@ -398,7 +399,10 @@ class _SettingsDialogState extends State<SettingsDialog>
   }
 
   Widget _workspaceTab(BuildContext context) {
-    return _pane(context, const [WorkspaceSettingsTile()]);
+    return _pane(context, const [
+      WorkspaceSettingsTile(),
+      GitIdentitySettingsTile(),
+    ]);
   }
 
   /// A read-only reference of every global keyboard shortcut, grouped by area.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,6 +18,7 @@ import 'package:getman/features/collections/data/services/workspace_sync_service
 import 'package:getman/features/collections/presentation/bloc/collections_bloc.dart';
 import 'package:getman/features/collections/presentation/bloc/collections_event.dart';
 import 'package:getman/features/collections/presentation/bloc/git_sync_bloc.dart';
+import 'package:getman/features/collections/presentation/bloc/pull_requests_bloc.dart';
 import 'package:getman/features/collections/presentation/bloc/review_bloc.dart';
 import 'package:getman/features/collections/presentation/widgets/branch_sync_listener.dart';
 import 'package:getman/features/collections/presentation/widgets/workspace_sync_listener.dart';
@@ -202,6 +203,7 @@ class MyApp extends StatelessWidget {
           BlocProvider(create: (_) => di.sl<McpBloc>()),
           BlocProvider(create: (_) => di.sl<ReviewBloc>()),
           BlocProvider(create: (_) => di.sl<GitSyncBloc>()),
+          BlocProvider(create: (_) => di.sl<PullRequestsBloc>()),
         ],
         child: NetworkSettingsListener(
           child: WorkspaceSyncListener(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,6 +17,7 @@ import 'package:getman/features/chaining/presentation/bloc/rules_bloc.dart';
 import 'package:getman/features/collections/data/services/workspace_sync_service.dart';
 import 'package:getman/features/collections/presentation/bloc/collections_bloc.dart';
 import 'package:getman/features/collections/presentation/bloc/collections_event.dart';
+import 'package:getman/features/collections/presentation/bloc/conflict_bloc.dart';
 import 'package:getman/features/collections/presentation/bloc/git_sync_bloc.dart';
 import 'package:getman/features/collections/presentation/bloc/pull_requests_bloc.dart';
 import 'package:getman/features/collections/presentation/bloc/review_bloc.dart';
@@ -204,6 +205,7 @@ class MyApp extends StatelessWidget {
           BlocProvider(create: (_) => di.sl<ReviewBloc>()),
           BlocProvider(create: (_) => di.sl<GitSyncBloc>()),
           BlocProvider(create: (_) => di.sl<PullRequestsBloc>()),
+          BlocProvider(create: (_) => di.sl<ConflictBloc>()),
         ],
         child: NetworkSettingsListener(
           child: WorkspaceSyncListener(

--- a/test/core/git/gh_output_parser_test.dart
+++ b/test/core/git/gh_output_parser_test.dart
@@ -56,4 +56,15 @@ void main() {
     expect(parsePrList(json).single.isDraft, isTrue);
     expect(parsePrList(json).single.checks, 'none');
   });
+
+  test('parsePrUrl returns the PR url gh printed on the last line', () {
+    const out =
+        'Warning: 3 uncommitted changes\n'
+        'https://github.com/o/r/pull/456\n';
+    expect(parsePrUrl(out), 'https://github.com/o/r/pull/456');
+  });
+
+  test('parsePrUrl returns empty when no url is present', () {
+    expect(parsePrUrl('nothing here'), '');
+  });
 }

--- a/test/core/git/gh_output_parser_test.dart
+++ b/test/core/git/gh_output_parser_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/core/git/gh_output_parser.dart';
+
+void main() {
+  test('parsePrList maps fields and rolls up passing checks', () {
+    const json = '''
+    [
+      {"number":123,"title":"feat: x","state":"OPEN",
+       "url":"https://github.com/o/r/pull/123","isDraft":false,
+       "statusCheckRollup":[
+         {"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"},
+         {"__typename":"StatusContext","state":"SUCCESS"}]}
+    ]''';
+    final prs = parsePrList(json);
+    expect(prs.single.number, 123);
+    expect(prs.single.title, 'feat: x');
+    expect(prs.single.state, 'OPEN');
+    expect(prs.single.url, endsWith('/pull/123'));
+    expect(prs.single.isDraft, isFalse);
+    expect(prs.single.checks, 'passing');
+  });
+
+  test('rollupChecks: empty rollup is none', () {
+    expect(rollupChecks(const <Object?>[]), 'none');
+    expect(rollupChecks(null), 'none');
+  });
+
+  test('rollupChecks: an unfinished check is pending', () {
+    final rollup = [
+      {'__typename': 'CheckRun', 'status': 'IN_PROGRESS'},
+      {
+        '__typename': 'CheckRun',
+        'status': 'COMPLETED',
+        'conclusion': 'SUCCESS',
+      },
+    ];
+    expect(rollupChecks(rollup), 'pending');
+  });
+
+  test('rollupChecks: a completed failure (all finished) is failing', () {
+    final rollup = [
+      {
+        '__typename': 'CheckRun',
+        'status': 'COMPLETED',
+        'conclusion': 'FAILURE',
+      },
+      {'__typename': 'StatusContext', 'state': 'SUCCESS'},
+    ];
+    expect(rollupChecks(rollup), 'failing');
+  });
+
+  test('rollupChecks: draft PR still parses', () {
+    const json = '''
+    [{"number":9,"title":"wip","state":"OPEN","url":"u","isDraft":true,
+      "statusCheckRollup":[]}]''';
+    expect(parsePrList(json).single.isDraft, isTrue);
+    expect(parsePrList(json).single.checks, 'none');
+  });
+}

--- a/test/core/git/gh_output_parser_test.dart
+++ b/test/core/git/gh_output_parser_test.dart
@@ -37,6 +37,20 @@ void main() {
     expect(rollupChecks(rollup), 'pending');
   });
 
+  test('rollupChecks: pending wins over failing in the same rollup', () {
+    // Guards the spec's headline precedence: an unfinished check alongside a
+    // completed failure must report `pending`, not `failing`.
+    final rollup = [
+      {'__typename': 'CheckRun', 'status': 'IN_PROGRESS'},
+      {
+        '__typename': 'CheckRun',
+        'status': 'COMPLETED',
+        'conclusion': 'FAILURE',
+      },
+    ];
+    expect(rollupChecks(rollup), 'pending');
+  });
+
   test('rollupChecks: a completed failure (all finished) is failing', () {
     final rollup = [
       {
@@ -57,9 +71,30 @@ void main() {
     expect(parsePrList(json).single.checks, 'none');
   });
 
-  test('parsePrUrl returns the PR url gh printed on the last line', () {
+  test('parsePrList tolerates wrong-typed fields instead of throwing', () {
+    // A malformed entry (number as string, isDraft as int) must degrade to
+    // defaults, not abort the whole parse with a CastError.
+    const json = '''
+    [{"number":"oops","title":42,"state":null,"url":true,"isDraft":1,
+      "statusCheckRollup":null}]''';
+    final pr = parsePrList(json).single;
+    expect(pr.number, 0);
+    expect(pr.title, '');
+    expect(pr.state, 'OPEN');
+    expect(pr.url, '');
+    expect(pr.isDraft, isFalse);
+    expect(pr.checks, 'none');
+  });
+
+  test('parsePrList degrades a non-list to empty', () {
+    expect(parsePrList('{"not":"a list"}'), isEmpty);
+  });
+
+  test('parsePrUrl returns the last url when gh prints more than one', () {
+    // gh may echo a remote/branch URL before the created PR URL; the PR URL is
+    // last. Guards the `match.last` selection against a `.first` regression.
     const out =
-        'Warning: 3 uncommitted changes\n'
+        'https://github.com/o/r/tree/my-branch\n'
         'https://github.com/o/r/pull/456\n';
     expect(parsePrUrl(out), 'https://github.com/o/r/pull/456');
   });

--- a/test/core/git/gh_service_io_test.dart
+++ b/test/core/git/gh_service_io_test.dart
@@ -1,0 +1,44 @@
+@TestOn('vm')
+library;
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/core/git/gh_service.dart';
+
+void main() {
+  late GhService gh;
+  late Directory tmp;
+
+  Future<bool> ghPresent() async => gh.isAvailable();
+
+  setUp(() async {
+    gh = createGhService();
+    tmp = await Directory.systemTemp.createTemp('getman_gh_test');
+  });
+
+  tearDown(() async {
+    if (tmp.existsSync()) await tmp.delete(recursive: true);
+  });
+
+  test('isAvailable reflects whether the gh binary runs', () async {
+    // Either result is valid depending on the machine; the call must not throw.
+    expect(await gh.isAvailable(), isA<bool>());
+  });
+
+  test('isAuthenticated is false in a non-repo dir when gh is present or '
+      'absent (never throws)', () async {
+    // In a bare temp dir with no gh host context, auth status is false; and if
+    // gh is missing the catch returns false. Either way: no throw, a bool.
+    final result = await gh.isAuthenticated(tmp.path);
+    expect(result, isA<bool>());
+    if (!await ghPresent()) expect(result, isFalse);
+  });
+
+  test('GhException carries the exit code and message', () {
+    final e = GhException('boom', exitCode: 3);
+    expect(e.message, 'boom');
+    expect(e.exitCode, 3);
+    expect(e.toString(), contains('boom'));
+  });
+}

--- a/test/core/git/git_conflict_primitives_io_test.dart
+++ b/test/core/git/git_conflict_primitives_io_test.dart
@@ -1,0 +1,90 @@
+@TestOn('vm')
+library;
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/core/git/git_service.dart';
+
+void main() {
+  late GitService git;
+  late Directory tmp;
+
+  Future<bool> gitPresent() async => git.isAvailable();
+  Future<void> run(String dir, List<String> args) async {
+    final r = await Process.run('git', args, workingDirectory: dir);
+    if (r.exitCode != 0) throw Exception('git ${args.join(' ')}: ${r.stderr}');
+  }
+
+  Future<String> setUpConflictedRebase() async {
+    final root = tmp.path;
+    await run(root, ['init', '-b', 'main']);
+    await run(root, ['config', 'user.email', 't@t.co']);
+    await run(root, ['config', 'user.name', 't']);
+    final f = File('$root/a.req.json')..writeAsStringSync('{"v":0}\n');
+    await run(root, ['add', '.']);
+    await run(root, ['commit', '-m', 'base']);
+    // upstream commit
+    f.writeAsStringSync('{"v":1}\n');
+    await run(root, ['commit', '-am', 'upstream']);
+    await run(root, ['branch', 'feature', 'HEAD~1']);
+    await run(root, ['switch', 'feature']);
+    f.writeAsStringSync('{"v":2}\n');
+    await run(root, ['commit', '-am', 'yours']);
+    // rebase feature onto main -> conflict
+    final r = await Process.run('git', [
+      'rebase',
+      'main',
+    ], workingDirectory: root);
+    expect(r.exitCode, isNot(0));
+    return root;
+  }
+
+  setUp(() async {
+    git = createGitService();
+    tmp = await Directory.systemTemp.createTemp('getman_conflict');
+  });
+  tearDown(() async {
+    if (tmp.existsSync()) await tmp.delete(recursive: true);
+  });
+
+  test(
+    'a conflicting rebase exposes stages, resolves, and continues',
+    () async {
+      if (!await gitPresent()) return; // skip when git is absent
+      final root = await setUpConflictedRebase();
+
+      expect(await git.isRebaseInProgress(root), isTrue);
+      expect(await git.conflictedPaths(root), contains('a.req.json'));
+      expect(await git.showStage(root, 'a.req.json', 1), contains('"v":0'));
+      expect(
+        await git.showStage(root, 'a.req.json', 2),
+        contains('"v":1'),
+      ); // incoming (main)
+      expect(
+        await git.showStage(root, 'a.req.json', 3),
+        contains('"v":2'),
+      ); // yours
+
+      await git.writeWorkingFile(root, 'a.req.json', '{"v":9}\n');
+      await git.add(root, 'a.req.json');
+      await git.rebaseContinue(root);
+      expect(await git.isRebaseInProgress(root), isFalse);
+      expect(File('$root/a.req.json').readAsStringSync(), contains('"v":9'));
+    },
+  );
+
+  test('rebaseAbort restores the pre-rebase tree', () async {
+    if (!await gitPresent()) return;
+    final root = await setUpConflictedRebase();
+    expect(await git.isRebaseInProgress(root), isTrue);
+
+    await git.rebaseAbort(root);
+
+    expect(await git.isRebaseInProgress(root), isFalse);
+    // Back on `feature`, at the pre-rebase content (not the conflict markers).
+    expect(await git.currentBranch(root), 'feature');
+    expect(File('$root/a.req.json').readAsStringSync(), contains('"v":2'));
+    expect(await git.conflictedPaths(root), isEmpty);
+  });
+}

--- a/test/core/git/git_identity_io_test.dart
+++ b/test/core/git/git_identity_io_test.dart
@@ -50,9 +50,11 @@ void main() {
         '-1',
         '--format=%an <%ae>',
       ], workingDirectory: tmp.path);
+      // The name carries the " via Getman" attribution suffix (applied only at
+      // commit time); the email is verbatim so GitHub still credits the user.
       expect(
         (log.stdout as String).trim(),
-        'A Getman User <a.getman.user@example.com>',
+        'A Getman User via Getman <a.getman.user@example.com>',
       );
     },
   );

--- a/test/core/git/git_identity_io_test.dart
+++ b/test/core/git/git_identity_io_test.dart
@@ -1,0 +1,80 @@
+@TestOn('vm')
+library;
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/core/git/git_service.dart';
+
+/// Real-git coverage for the Getman-owned commit identity: a `commit`
+/// creating a commit succeeds even when the repo has no local *or* global
+/// git identity configured, as long as [GitService.commit] is given one
+/// inline — and, conversely, a commit attempted with none at all fails with
+/// [GitException.isMissingIdentity].
+///
+/// Deliberately does **not** run `git config user.name/user.email` in
+/// [setUp] (unlike `git_service_io_test.dart`'s shared fixture) — the whole
+/// point is a repo with no identity of its own.
+void main() {
+  late GitService git;
+  late Directory tmp;
+
+  Future<bool> gitPresent() async => git.isAvailable();
+
+  setUp(() async {
+    git = createGitService();
+    tmp = await Directory.systemTemp.createTemp('getman_git_identity_test');
+    await Process.run('git', ['init'], workingDirectory: tmp.path);
+  });
+
+  tearDown(() async {
+    if (tmp.existsSync()) await tmp.delete(recursive: true);
+  });
+
+  test(
+    'commit with an inline identity succeeds and authors as that identity',
+    () async {
+      if (!await gitPresent()) return; // skip when git missing
+      File('${tmp.path}/a.req.json').writeAsStringSync('{"x":1}');
+      await git.stage(tmp.path, ['a.req.json']);
+
+      await git.commit(
+        tmp.path,
+        'seed',
+        authorName: 'A Getman User',
+        authorEmail: 'a.getman.user@example.com',
+      );
+
+      final log = await Process.run('git', [
+        'log',
+        '-1',
+        '--format=%an <%ae>',
+      ], workingDirectory: tmp.path);
+      expect(
+        (log.stdout as String).trim(),
+        'A Getman User <a.getman.user@example.com>',
+      );
+    },
+  );
+
+  test(
+    'commit with no identity at all (repo and inline both absent) throws a '
+    'GitException whose message is detected as a missing identity',
+    () async {
+      if (!await gitPresent()) return; // skip when git missing
+      File('${tmp.path}/a.req.json').writeAsStringSync('{"x":1}');
+      await git.stage(tmp.path, ['a.req.json']);
+
+      await expectLater(
+        git.commit(tmp.path, 'seed'),
+        throwsA(
+          isA<GitException>().having(
+            (e) => GitException.isMissingIdentity(e.message),
+            'isMissingIdentity',
+            isTrue,
+          ),
+        ),
+      );
+    },
+  );
+}

--- a/test/core/git/git_identity_io_test.dart
+++ b/test/core/git/git_identity_io_test.dart
@@ -79,4 +79,41 @@ void main() {
       );
     },
   );
+
+  test(
+    'commit with only a partial inline identity (name without email, or '
+    'vice versa) is treated as no identity and throws a GitException '
+    'detected as a missing identity',
+    () async {
+      if (!await gitPresent()) return; // skip when git missing
+      File('${tmp.path}/a.req.json').writeAsStringSync('{"x":1}');
+      await git.stage(tmp.path, ['a.req.json']);
+
+      // Name without email: _identityArgs must produce no -c args at all
+      // (not a garbage user.email=), so git falls back to its own
+      // resolution and fails the same way as with no identity.
+      await expectLater(
+        git.commit(tmp.path, 'seed', authorName: 'X'),
+        throwsA(
+          isA<GitException>().having(
+            (e) => GitException.isMissingIdentity(e.message),
+            'isMissingIdentity',
+            isTrue,
+          ),
+        ),
+      );
+
+      // Email without name: same expectation, reversed.
+      await expectLater(
+        git.commit(tmp.path, 'seed', authorEmail: 'x@example.com'),
+        throwsA(
+          isA<GitException>().having(
+            (e) => GitException.isMissingIdentity(e.message),
+            'isMissingIdentity',
+            isTrue,
+          ),
+        ),
+      );
+    },
+  );
 }

--- a/test/core/git/git_service_io_test.dart
+++ b/test/core/git/git_service_io_test.dart
@@ -130,6 +130,20 @@ void main() {
     expect(await git.hasRemote(tmp.path), isFalse);
   });
 
+  test('addRemote adds a remote and hasRemote becomes true', () async {
+    if (!await gitPresent()) return;
+    await seedCommit();
+    expect(await git.hasRemote(tmp.path), isFalse);
+
+    await git.addRemote(
+      tmp.path,
+      'origin',
+      'https://example.invalid/x/y.git',
+    );
+
+    expect(await git.hasRemote(tmp.path), isTrue);
+  });
+
   test('aheadBehind is (0,0) when the branch has no upstream', () async {
     if (!await gitPresent()) return;
     await seedCommit();

--- a/test/core/git/git_service_test.dart
+++ b/test/core/git/git_service_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/core/git/git_service.dart';
+
+void main() {
+  group('GitException.isMissingIdentity', () {
+    test('matches the classic "Please tell me who you are" failure', () {
+      expect(
+        GitException.isMissingIdentity('''
+*** Please tell me who you are.
+
+Run
+
+  git config --global user.email "you@example.com"
+  git config --global user.name "Your Name"
+
+fatal: unable to auto-detect email address (got 'user@host.(none)')
+'''),
+        isTrue,
+      );
+    });
+
+    test('matches "Author identity unknown"', () {
+      expect(
+        GitException.isMissingIdentity(
+          'fatal: unable to auto-detect email address (got '
+          "'user@host.(none)')\n\n*** Please tell me who you are.",
+        ),
+        isTrue,
+      );
+      expect(
+        GitException.isMissingIdentity(
+          'Author identity unknown\n\n*** empty ident name',
+        ),
+        isTrue,
+      );
+    });
+
+    test('matches "unable to auto-detect email" on its own', () {
+      expect(
+        GitException.isMissingIdentity(
+          "fatal: unable to auto-detect email address (got 'a@b.(none)')",
+        ),
+        isTrue,
+      );
+    });
+
+    test('is case-insensitive', () {
+      expect(
+        GitException.isMissingIdentity('PLEASE TELL ME WHO YOU ARE.'),
+        isTrue,
+      );
+    });
+
+    test('does not match an unrelated git failure', () {
+      expect(
+        GitException.isMissingIdentity('fatal: not a git repository'),
+        isFalse,
+      );
+      expect(
+        GitException.isMissingIdentity(
+          'CONFLICT (content): Merge conflict in a.json',
+        ),
+        isFalse,
+      );
+    });
+  });
+}

--- a/test/core/git/git_sync_io_test.dart
+++ b/test/core/git/git_sync_io_test.dart
@@ -99,6 +99,33 @@ void main() {
   });
 
   test(
+    'pull with unstaged local edits autostashes and reapplies them',
+    () async {
+      if (!await gitPresent()) return;
+      // Teammate publishes a change to a *different* file.
+      await commitFile(b.path, 'teammate.req.json', '{"v":9}');
+      await run(b.path, ['push', 'origin', 'main']);
+      await run(a.path, ['fetch', 'origin']);
+      // A local uncommitted edit — exactly how Getman's mirror leaves the tree
+      // (this is what made a plain `git pull --rebase` fail with "cannot pull
+      // with rebase: You have unstaged changes").
+      File('${a.path}/a.req.json').writeAsStringSync('{"v":"local-wip"}');
+      expect(await git.status(a.path), isNotEmpty); // dirty tree
+
+      final outcome = await git.pull(a.path);
+
+      // --autostash: the pull succeeds, the teammate change lands, AND the
+      // local edit is reapplied on top rather than rejected.
+      expect(outcome, PullOutcome.clean);
+      expect(File('${a.path}/teammate.req.json').existsSync(), isTrue);
+      expect(
+        File('${a.path}/a.req.json').readAsStringSync(),
+        '{"v":"local-wip"}',
+      );
+    },
+  );
+
+  test(
     'a conflicting pull pauses the rebase (PullOutcome.conflicted)',
     () async {
       if (!await gitPresent()) return;

--- a/test/core/git/git_sync_io_test.dart
+++ b/test/core/git/git_sync_io_test.dart
@@ -92,31 +92,50 @@ void main() {
     await run(b.path, ['push', 'origin', 'main']);
     await run(a.path, ['fetch', 'origin']);
 
-    await git.pull(a.path);
+    final outcome = await git.pull(a.path);
 
+    expect(outcome, PullOutcome.clean);
     expect(File('${a.path}/teammate.req.json').existsSync(), isTrue);
   });
 
-  test('a conflicting pull aborts and leaves the tree untouched', () async {
-    if (!await gitPresent()) return;
-    // Both sides edit the same file differently.
-    await commitFile(b.path, 'a.req.json', '{"v":"theirs"}');
-    await run(b.path, ['push', 'origin', 'main']);
-    await commitFile(a.path, 'a.req.json', '{"v":"mine"}');
+  test(
+    'a conflicting pull pauses the rebase (PullOutcome.conflicted)',
+    () async {
+      if (!await gitPresent()) return;
+      // Both sides edit the same file differently.
+      await commitFile(b.path, 'a.req.json', '{"v":"theirs"}');
+      await run(b.path, ['push', 'origin', 'main']);
+      await commitFile(a.path, 'a.req.json', '{"v":"mine"}');
 
-    await expectLater(
-      git.pull(a.path),
-      throwsA(isA<GitException>()),
-    );
+      final outcome = await git.pull(a.path);
 
-    // The abort must restore the pre-pull state exactly: our content is
-    // intact, no conflict markers, no rebase in progress, and the tree is
-    // clean.
-    expect(File('${a.path}/a.req.json').readAsStringSync(), '{"v":"mine"}');
-    expect(await git.status(a.path), isEmpty);
-    expect(Directory('${a.path}/.git/rebase-merge').existsSync(), isFalse);
-    expect(Directory('${a.path}/.git/rebase-apply').existsSync(), isFalse);
-  });
+      // Left paused mid-rebase, not aborted — the conflict-resolution
+      // primitives (Task 1) take it from here.
+      expect(outcome, PullOutcome.conflicted);
+      expect(await git.isRebaseInProgress(a.path), isTrue);
+      expect(await git.conflictedPaths(a.path), contains('a.req.json'));
+
+      // Clean up so tearDown's rmdir doesn't fight a paused rebase.
+      await git.rebaseAbort(a.path);
+    },
+  );
+
+  test(
+    'a non-resolvable pull failure aborts and leaves the tree untouched',
+    () async {
+      if (!await gitPresent()) return;
+      // No remote configured: `git pull --rebase` fails outright (no
+      // upstream), which is not a conflict — the rebase is never started.
+      await run(a.path, ['remote', 'remove', 'origin']);
+
+      await expectLater(git.pull(a.path), throwsA(isA<GitException>()));
+
+      expect(File('${a.path}/a.req.json').readAsStringSync(), '{"v":1}');
+      expect(await git.status(a.path), isEmpty);
+      expect(Directory('${a.path}/.git/rebase-merge').existsSync(), isFalse);
+      expect(Directory('${a.path}/.git/rebase-apply').existsSync(), isFalse);
+    },
+  );
 
   test(
     'aheadBehind reports ahead and behind against a real upstream',

--- a/test/features/collections/data/services/gh_pull_request_service_test.dart
+++ b/test/features/collections/data/services/gh_pull_request_service_test.dart
@@ -1,0 +1,178 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/core/git/gh_service.dart';
+import 'package:getman/features/collections/data/services/gh_pull_request_service.dart';
+import 'package:getman/features/collections/domain/branch_service.dart';
+import 'package:getman/features/collections/domain/entities/pull_request.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockGh extends Mock implements GhService {}
+
+class _MockBranch extends Mock implements BranchService {}
+
+void main() {
+  const root = '/ws';
+  late _MockGh gh;
+  late _MockBranch branch;
+  late GhPullRequestService service;
+
+  setUp(() {
+    gh = _MockGh();
+    branch = _MockBranch();
+    service = GhPullRequestService(gh, branch);
+  });
+
+  test('availability: notInstalled when gh is absent', () async {
+    when(gh.isAvailable).thenAnswer((_) async => false);
+    expect(await service.availability(root), GhAvailability.notInstalled);
+    verifyNever(() => gh.isAuthenticated(any()));
+  });
+
+  test(
+    'availability: notAuthenticated when gh present but not logged in',
+    () async {
+      when(gh.isAvailable).thenAnswer((_) async => true);
+      when(() => gh.isAuthenticated(root)).thenAnswer((_) async => false);
+      expect(await service.availability(root), GhAvailability.notAuthenticated);
+    },
+  );
+
+  test('availability: available when installed + authenticated', () async {
+    when(gh.isAvailable).thenAnswer((_) async => true);
+    when(() => gh.isAuthenticated(root)).thenAnswer((_) async => true);
+    expect(await service.availability(root), GhAvailability.available);
+  });
+
+  test('list maps gh state + checks strings to domain enums', () async {
+    when(() => gh.listPrs(root)).thenAnswer(
+      (_) async => const [
+        PullRequestInfo(
+          number: 12,
+          title: 't',
+          state: 'OPEN',
+          url: 'https://github.com/o/r/pull/12',
+          isDraft: true,
+          checks: 'failing',
+        ),
+        PullRequestInfo(
+          number: 8,
+          title: 'merged one',
+          state: 'MERGED',
+          url: 'https://github.com/o/r/pull/8',
+          isDraft: false,
+          checks: 'passing',
+        ),
+        PullRequestInfo(
+          number: 5,
+          title: 'closed one',
+          state: 'CLOSED',
+          url: 'https://github.com/o/r/pull/5',
+          isDraft: false,
+          checks: 'pending',
+        ),
+        PullRequestInfo(
+          number: 3,
+          title: 'no checks',
+          state: 'OPEN',
+          url: 'https://github.com/o/r/pull/3',
+          isDraft: false,
+          checks: 'none',
+        ),
+      ],
+    );
+    final prs = await service.list(root);
+    expect(prs[0].number, 12);
+    expect(prs[0].state, PrState.open);
+    expect(prs[0].checks, PrChecks.failing);
+    expect(prs[0].isDraft, isTrue);
+    expect(prs[1].state, PrState.merged);
+    expect(prs[1].checks, PrChecks.passing);
+    expect(prs[2].state, PrState.closed);
+    expect(prs[2].checks, PrChecks.pending);
+    expect(prs[3].checks, PrChecks.none);
+  });
+
+  test('create pushes BEFORE gh.createPr, and parses the PR number from the '
+      'url', () async {
+    final pushGate = Completer<void>();
+    var pushed = false;
+    var createdBeforePush = false;
+    when(() => branch.push(root)).thenAnswer((_) async {
+      await pushGate.future;
+      pushed = true;
+    });
+    when(
+      () => gh.createPr(
+        root,
+        base: any(named: 'base'),
+        title: any(named: 'title'),
+        body: any(named: 'body'),
+        draft: any(named: 'draft'),
+      ),
+    ).thenAnswer((_) async {
+      if (!pushed) createdBeforePush = true;
+      return 'https://github.com/o/r/pull/77';
+    });
+
+    final op = service.create(
+      root,
+      base: 'main',
+      title: 't',
+      body: 'b',
+      draft: false,
+    );
+    await Future<void>.delayed(Duration.zero);
+    // gh.createPr must not have fired yet — push is gated open.
+    verifyNever(
+      () => gh.createPr(
+        root,
+        base: any(named: 'base'),
+        title: any(named: 'title'),
+        body: any(named: 'body'),
+        draft: any(named: 'draft'),
+      ),
+    );
+    pushGate.complete();
+    final ref = await op;
+
+    expect(
+      createdBeforePush,
+      isFalse,
+      reason: 'push must finish before create',
+    );
+    expect(ref.number, 77);
+    expect(ref.url, endsWith('/pull/77'));
+  });
+
+  test(
+    'create parses the PR number even when the url carries a query',
+    () async {
+      when(() => branch.push(root)).thenAnswer((_) async {});
+      when(
+        () => gh.createPr(
+          root,
+          base: any(named: 'base'),
+          title: any(named: 'title'),
+          body: any(named: 'body'),
+          draft: any(named: 'draft'),
+        ),
+      ).thenAnswer((_) async => 'https://github.com/o/r/pull/91?tab=files');
+      final ref = await service.create(
+        root,
+        base: 'main',
+        title: 't',
+        body: 'b',
+        draft: false,
+      );
+      expect(ref.number, 91);
+    },
+  );
+
+  test('defaultBase delegates to gh.defaultBranch (incl. null)', () async {
+    when(() => gh.defaultBranch(root)).thenAnswer((_) async => 'main');
+    expect(await service.defaultBase(root), 'main');
+    when(() => gh.defaultBranch(root)).thenAnswer((_) async => null);
+    expect(await service.defaultBase(root), isNull);
+  });
+}

--- a/test/features/collections/data/services/git_branch_service_test.dart
+++ b/test/features/collections/data/services/git_branch_service_test.dart
@@ -57,6 +57,7 @@ void main() {
       () => git.push(root, setUpstream: any(named: 'setUpstream')),
     ).thenAnswer((_) async {});
     when(() => git.hasUpstream(root)).thenAnswer((_) async => true);
+    when(() => git.addRemote(root, any(), any())).thenAnswer((_) async {});
   });
 
   // NB: not `tearDown(sync.dispose)` — a tear-off would read the late `sync`
@@ -275,6 +276,22 @@ void main() {
 
     verifyNever(() => ds.write(any(), any()));
     verify(() => git.stashDrop(root, 1)).called(1);
+  });
+
+  test('addRemote delegates to git', () async {
+    await service.addRemote(root, 'origin', 'https://example.invalid/x.git');
+    verify(
+      () => git.addRemote(root, 'origin', 'https://example.invalid/x.git'),
+    ).called(1);
+  });
+
+  test('addRemote does not flush: it never touches the tree', () async {
+    sync.scheduleMirror(root, const []);
+
+    await service.addRemote(root, 'origin', 'https://example.invalid/x.git');
+
+    verifyNever(() => ds.write(any(), any()));
+    verify(() => git.addRemote(root, 'origin', any())).called(1);
   });
 
   group(

--- a/test/features/collections/data/services/git_branch_service_test.dart
+++ b/test/features/collections/data/services/git_branch_service_test.dart
@@ -46,7 +46,7 @@ void main() {
     when(() => git.stashPush(root, any())).thenAnswer((_) async {});
     when(() => git.stashPop(root, any())).thenAnswer((_) async {});
     when(() => git.stashDrop(root, any())).thenAnswer((_) async {});
-    when(() => git.pull(root)).thenAnswer((_) async {});
+    when(() => git.pull(root)).thenAnswer((_) async => PullOutcome.clean);
     when(
       () => git.push(root, setUpstream: any(named: 'setUpstream')),
     ).thenAnswer((_) async {});
@@ -199,7 +199,10 @@ void main() {
   test('pull waits for the pending mirror to land first', () {
     return expectGitWaitsForMirror(
       stubGitOp: (onGitOp) {
-        when(() => git.pull(root)).thenAnswer((_) async => onGitOp());
+        when(() => git.pull(root)).thenAnswer((_) async {
+          onGitOp();
+          return PullOutcome.clean;
+        });
       },
       invoke: () => service.pull(root),
     );
@@ -329,8 +332,10 @@ void main() {
             () => service.switchTo(root, 'feat/x'),
           ),
           'pull': (
-            (onOp) =>
-                when(() => git.pull(root)).thenAnswer((_) async => onOp()),
+            (onOp) => when(() => git.pull(root)).thenAnswer((_) async {
+              onOp();
+              return PullOutcome.clean;
+            }),
             () => service.pull(root),
           ),
           'stash': (

--- a/test/features/collections/data/services/git_branch_service_test.dart
+++ b/test/features/collections/data/services/git_branch_service_test.dart
@@ -46,7 +46,13 @@ void main() {
     when(() => git.stashPush(root, any())).thenAnswer((_) async {});
     when(() => git.stashPop(root, any())).thenAnswer((_) async {});
     when(() => git.stashDrop(root, any())).thenAnswer((_) async {});
-    when(() => git.pull(root)).thenAnswer((_) async => PullOutcome.clean);
+    when(
+      () => git.pull(
+        root,
+        authorName: any(named: 'authorName'),
+        authorEmail: any(named: 'authorEmail'),
+      ),
+    ).thenAnswer((_) async => PullOutcome.clean);
     when(
       () => git.push(root, setUpstream: any(named: 'setUpstream')),
     ).thenAnswer((_) async {});
@@ -199,7 +205,13 @@ void main() {
   test('pull waits for the pending mirror to land first', () {
     return expectGitWaitsForMirror(
       stubGitOp: (onGitOp) {
-        when(() => git.pull(root)).thenAnswer((_) async {
+        when(
+          () => git.pull(
+            root,
+            authorName: any(named: 'authorName'),
+            authorEmail: any(named: 'authorEmail'),
+          ),
+        ).thenAnswer((_) async {
           onGitOp();
           return PullOutcome.clean;
         });
@@ -282,7 +294,13 @@ void main() {
         failTheMirrorWrite();
 
         await expectLater(service.pull(root), throwsA(isA<GitException>()));
-        verifyNever(() => git.pull(root));
+        verifyNever(
+          () => git.pull(
+            root,
+            authorName: any(named: 'authorName'),
+            authorEmail: any(named: 'authorEmail'),
+          ),
+        );
       });
 
       test('isDirty throws and never asks git', () async {
@@ -332,10 +350,17 @@ void main() {
             () => service.switchTo(root, 'feat/x'),
           ),
           'pull': (
-            (onOp) => when(() => git.pull(root)).thenAnswer((_) async {
-              onOp();
-              return PullOutcome.clean;
-            }),
+            (onOp) =>
+                when(
+                  () => git.pull(
+                    root,
+                    authorName: any(named: 'authorName'),
+                    authorEmail: any(named: 'authorEmail'),
+                  ),
+                ).thenAnswer((_) async {
+                  onOp();
+                  return PullOutcome.clean;
+                }),
             () => service.pull(root),
           ),
           'stash': (

--- a/test/features/collections/data/services/git_conflict_service_test.dart
+++ b/test/features/collections/data/services/git_conflict_service_test.dart
@@ -1,0 +1,404 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/core/domain/entities/request_config_entity.dart';
+import 'package:getman/core/git/git_service.dart';
+import 'package:getman/core/utils/workspace/workspace_collection_serializer.dart';
+import 'package:getman/features/collections/data/services/git_conflict_service.dart';
+import 'package:getman/features/collections/domain/entities/collection_node_entity.dart';
+import 'package:getman/features/collections/domain/entities/file_conflict.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockGit extends Mock implements GitService {}
+
+CollectionNodeEntity _leaf({
+  String id = 'r1',
+  String name = 'Req',
+  bool isFavorite = false,
+  String method = 'GET',
+  String url = '',
+  Map<String, String> headers = const {},
+  String body = '',
+  Map<String, String> auth = const {},
+}) => CollectionNodeEntity(
+  id: id,
+  name: name,
+  isFolder: false,
+  isFavorite: isFavorite,
+  config: HttpRequestConfigEntity(
+    id: id,
+    method: method,
+    url: url,
+    headers: headers,
+    body: body,
+    auth: auth,
+  ),
+);
+
+CollectionNodeEntity _folder({
+  String id = 'f1',
+  String name = 'Folder',
+  bool isFavorite = false,
+  Map<String, String> variables = const {},
+  Set<String> secretKeys = const {},
+}) => CollectionNodeEntity(
+  id: id,
+  name: name,
+  isFavorite: isFavorite,
+  variables: variables,
+  secretKeys: secretKeys,
+);
+
+String _reqStage(CollectionNodeEntity leaf) =>
+    jsonEncode(WorkspaceCollectionSerializer.requestToJson(leaf));
+
+String _folderStage(CollectionNodeEntity folder, List<String> order) =>
+    jsonEncode(WorkspaceCollectionSerializer.folderToJson(folder, order));
+
+void main() {
+  const root = '/ws';
+  late _MockGit git;
+  late GitConflictService service;
+
+  setUp(() {
+    git = _MockGit();
+    service = GitConflictService(git);
+  });
+
+  group('currentConflicts / classify', () {
+    test('a .req.json changed on both sides classifies as request', () async {
+      when(() => git.conflictedPaths(root)).thenAnswer(
+        (_) async => [
+          'a.req.json',
+        ],
+      );
+      when(
+        () => git.showStage(root, 'a.req.json', 1),
+      ).thenAnswer((_) async => _reqStage(_leaf(url: 'https://a')));
+      when(
+        () => git.showStage(root, 'a.req.json', 2),
+      ).thenAnswer((_) async => _reqStage(_leaf(url: 'https://b')));
+      when(
+        () => git.showStage(root, 'a.req.json', 3),
+      ).thenAnswer((_) async => _reqStage(_leaf(url: 'https://c')));
+
+      final conflicts = await service.currentConflicts(root);
+
+      expect(conflicts, hasLength(1));
+      final c = conflicts.single;
+      expect(c.path, 'a.req.json');
+      expect(c.kind, ConflictKind.request);
+      expect(c.node, isNotNull);
+      expect(c.node!.conflicts.map((f) => f.field), contains('url'));
+    });
+
+    test('a .req.json missing the incoming stage is deleteModify', () async {
+      when(() => git.conflictedPaths(root)).thenAnswer(
+        (_) async => [
+          'a.req.json',
+        ],
+      );
+      when(
+        () => git.showStage(root, 'a.req.json', 1),
+      ).thenAnswer((_) async => _reqStage(_leaf()));
+      when(
+        () => git.showStage(root, 'a.req.json', 2),
+      ).thenAnswer((_) async => null);
+      when(
+        () => git.showStage(root, 'a.req.json', 3),
+      ).thenAnswer((_) async => _reqStage(_leaf()));
+
+      final conflicts = await service.currentConflicts(root);
+
+      expect(conflicts.single.kind, ConflictKind.deleteModify);
+      expect(conflicts.single.node, isNull);
+    });
+
+    test('a .req.json missing the yours stage is deleteModify', () async {
+      when(() => git.conflictedPaths(root)).thenAnswer(
+        (_) async => [
+          'a.req.json',
+        ],
+      );
+      when(
+        () => git.showStage(root, 'a.req.json', 1),
+      ).thenAnswer((_) async => _reqStage(_leaf()));
+      when(
+        () => git.showStage(root, 'a.req.json', 2),
+      ).thenAnswer((_) async => _reqStage(_leaf()));
+      when(
+        () => git.showStage(root, 'a.req.json', 3),
+      ).thenAnswer((_) async => null);
+
+      final conflicts = await service.currentConflicts(root);
+
+      expect(conflicts.single.kind, ConflictKind.deleteModify);
+    });
+
+    test('a .req.json with no base stage (add/add) is addAdd', () async {
+      when(() => git.conflictedPaths(root)).thenAnswer(
+        (_) async => [
+          'a.req.json',
+        ],
+      );
+      when(
+        () => git.showStage(root, 'a.req.json', 1),
+      ).thenAnswer((_) async => null);
+      when(
+        () => git.showStage(root, 'a.req.json', 2),
+      ).thenAnswer((_) async => _reqStage(_leaf(name: 'Incoming')));
+      when(
+        () => git.showStage(root, 'a.req.json', 3),
+      ).thenAnswer((_) async => _reqStage(_leaf(name: 'Yours')));
+
+      final conflicts = await service.currentConflicts(root);
+
+      expect(conflicts.single.kind, ConflictKind.addAdd);
+      expect(conflicts.single.node, isNotNull);
+    });
+
+    test('a .req.json with unparseable content is structural', () async {
+      when(() => git.conflictedPaths(root)).thenAnswer(
+        (_) async => [
+          'a.req.json',
+        ],
+      );
+      when(
+        () => git.showStage(root, 'a.req.json', 1),
+      ).thenAnswer((_) async => null);
+      when(
+        () => git.showStage(root, 'a.req.json', 2),
+      ).thenAnswer((_) async => 'not json');
+      when(
+        () => git.showStage(root, 'a.req.json', 3),
+      ).thenAnswer((_) async => _reqStage(_leaf()));
+
+      final conflicts = await service.currentConflicts(root);
+
+      expect(conflicts.single.kind, ConflictKind.structural);
+      expect(conflicts.single.node, isNull);
+    });
+
+    test('a .folder.json changed on both sides classifies as folder', () async {
+      when(() => git.conflictedPaths(root)).thenAnswer(
+        (_) async => [
+          'x/.folder.json',
+        ],
+      );
+      when(() => git.showStage(root, 'x/.folder.json', 1)).thenAnswer(
+        (_) async => _folderStage(_folder(variables: {'k': 'base'}), ['a']),
+      );
+      when(() => git.showStage(root, 'x/.folder.json', 2)).thenAnswer(
+        (_) async =>
+            _folderStage(_folder(variables: {'k': 'incoming'}), ['a', 'b']),
+      );
+      when(() => git.showStage(root, 'x/.folder.json', 3)).thenAnswer(
+        (_) async =>
+            _folderStage(_folder(variables: {'k': 'yours'}), ['a', 'c']),
+      );
+
+      final conflicts = await service.currentConflicts(root);
+
+      final c = conflicts.single;
+      expect(c.path, 'x/.folder.json');
+      expect(c.kind, ConflictKind.folder);
+      expect(c.node, isNotNull);
+      expect(c.node!.conflicts.map((f) => f.field), contains("variable 'k'"));
+    });
+
+    test('workspace.json (neither req nor folder) is structural', () async {
+      when(() => git.conflictedPaths(root)).thenAnswer(
+        (_) async => [
+          '.getman/workspace.json',
+        ],
+      );
+
+      final conflicts = await service.currentConflicts(root);
+
+      expect(conflicts.single.kind, ConflictKind.structural);
+      expect(conflicts.single.node, isNull);
+      verifyNever(() => git.showStage(root, '.getman/workspace.json', any()));
+    });
+  });
+
+  group('resolve', () {
+    test(
+      'coarse wholeFile: incoming writes stage-2 content and stages it',
+      () async {
+        when(
+          () => git.showStage(root, 'a.req.json', 2),
+        ).thenAnswer((_) async => 'INCOMING CONTENT');
+        when(
+          () => git.writeWorkingFile(root, 'a.req.json', any()),
+        ).thenAnswer((_) async {});
+        when(() => git.add(root, 'a.req.json')).thenAnswer((_) async {});
+
+        await service.resolve(root, const [
+          FileResolution(path: 'a.req.json', wholeFile: FileSide.incoming),
+        ]);
+
+        verify(
+          () => git.writeWorkingFile(root, 'a.req.json', 'INCOMING CONTENT'),
+        ).called(1);
+        verify(() => git.add(root, 'a.req.json')).called(1);
+        verifyNever(() => git.showStage(root, 'a.req.json', 3));
+      },
+    );
+
+    test('coarse wholeFile: yours writes stage-3 content', () async {
+      when(
+        () => git.showStage(root, 'a.req.json', 3),
+      ).thenAnswer((_) async => 'YOURS CONTENT');
+      when(
+        () => git.writeWorkingFile(root, 'a.req.json', any()),
+      ).thenAnswer((_) async {});
+      when(() => git.add(root, 'a.req.json')).thenAnswer((_) async {});
+
+      await service.resolve(root, const [
+        FileResolution(path: 'a.req.json', wholeFile: FileSide.yours),
+      ]);
+
+      verify(
+        () => git.writeWorkingFile(root, 'a.req.json', 'YOURS CONTENT'),
+      ).called(1);
+    });
+
+    test(
+      'field-level resolution writes the merged node with picks applied',
+      () async {
+        when(
+          () => git.showStage(root, 'a.req.json', 1),
+        ).thenAnswer((_) async => _reqStage(_leaf(url: 'https://a')));
+        when(
+          () => git.showStage(root, 'a.req.json', 2),
+        ).thenAnswer((_) async => _reqStage(_leaf(url: 'https://b')));
+        when(
+          () => git.showStage(root, 'a.req.json', 3),
+        ).thenAnswer((_) async => _reqStage(_leaf(url: 'https://c')));
+        String? written;
+        when(() => git.writeWorkingFile(root, 'a.req.json', any())).thenAnswer((
+          i,
+        ) async {
+          written = i.positionalArguments[2] as String;
+        });
+        when(() => git.add(root, 'a.req.json')).thenAnswer((_) async {});
+
+        await service.resolve(root, const [
+          FileResolution(
+            path: 'a.req.json',
+            fieldChoices: {'url': 'https://mine'},
+          ),
+        ]);
+
+        expect(written, isNotNull);
+        final decoded = jsonDecode(written!) as Map<String, dynamic>;
+        final node = WorkspaceCollectionSerializer.requestFromJson(decoded);
+        expect(node.config!.url, 'https://mine');
+        verify(() => git.add(root, 'a.req.json')).called(1);
+      },
+    );
+
+    test(
+      'an opaque field pick (authentication) takes the whole side',
+      () async {
+        when(() => git.showStage(root, 'a.req.json', 1)).thenAnswer(
+          (_) async => _reqStage(_leaf(auth: const {'type': 'none'})),
+        );
+        when(() => git.showStage(root, 'a.req.json', 2)).thenAnswer(
+          (_) async => _reqStage(
+            _leaf(auth: const {'type': 'bearer', 'token': 'incoming-token'}),
+          ),
+        );
+        when(() => git.showStage(root, 'a.req.json', 3)).thenAnswer(
+          (_) async => _reqStage(
+            _leaf(auth: const {'type': 'bearer', 'token': 'yours-token'}),
+          ),
+        );
+        String? written;
+        when(() => git.writeWorkingFile(root, 'a.req.json', any())).thenAnswer((
+          i,
+        ) async {
+          written = i.positionalArguments[2] as String;
+        });
+        when(() => git.add(root, 'a.req.json')).thenAnswer((_) async {});
+
+        await service.resolve(root, const [
+          FileResolution(
+            path: 'a.req.json',
+            fieldChoices: {'authentication': 'yours'},
+          ),
+        ]);
+
+        final node = WorkspaceCollectionSerializer.requestFromJson(
+          jsonDecode(written!) as Map<String, dynamic>,
+        );
+        expect(node.config!.auth['token'], 'yours-token');
+      },
+    );
+
+    test('a folder field-level resolution merges variables', () async {
+      when(() => git.showStage(root, 'x/.folder.json', 1)).thenAnswer(
+        (_) async => _folderStage(_folder(variables: {'k': 'base'}), ['a']),
+      );
+      when(() => git.showStage(root, 'x/.folder.json', 2)).thenAnswer(
+        (_) async => _folderStage(_folder(variables: {'k': 'incoming'}), ['a']),
+      );
+      when(() => git.showStage(root, 'x/.folder.json', 3)).thenAnswer(
+        (_) async => _folderStage(_folder(variables: {'k': 'yours'}), ['a']),
+      );
+      String? written;
+      when(
+        () => git.writeWorkingFile(root, 'x/.folder.json', any()),
+      ).thenAnswer((i) async {
+        written = i.positionalArguments[2] as String;
+      });
+      when(() => git.add(root, 'x/.folder.json')).thenAnswer((_) async {});
+
+      await service.resolve(root, const [
+        FileResolution(
+          path: 'x/.folder.json',
+          fieldChoices: {"variable 'k'": 'picked-value'},
+        ),
+      ]);
+
+      final decoded = jsonDecode(written!) as Map<String, dynamic>;
+      expect((decoded['variables'] as Map)['k'], 'picked-value');
+      verify(() => git.add(root, 'x/.folder.json')).called(1);
+    });
+  });
+
+  group('continueRebase', () {
+    test('maps a still-in-progress rebase to moreConflicts', () async {
+      when(() => git.rebaseContinue(root)).thenAnswer((_) async {});
+      when(() => git.isRebaseInProgress(root)).thenAnswer((_) async => true);
+
+      expect(await service.continueRebase(root), RebaseStep.moreConflicts);
+      verify(() => git.rebaseContinue(root)).called(1);
+    });
+
+    test('maps a finished rebase to done', () async {
+      when(() => git.rebaseContinue(root)).thenAnswer((_) async {});
+      when(() => git.isRebaseInProgress(root)).thenAnswer((_) async => false);
+
+      expect(await service.continueRebase(root), RebaseStep.done);
+    });
+  });
+
+  test('abort delegates to git.rebaseAbort', () async {
+    when(() => git.rebaseAbort(root)).thenAnswer((_) async {});
+    await service.abort(root);
+    verify(() => git.rebaseAbort(root)).called(1);
+  });
+
+  test('fetch delegates to git.fetch', () async {
+    when(() => git.fetch(root)).thenAnswer((_) async {});
+    await service.fetch(root);
+    verify(() => git.fetch(root)).called(1);
+  });
+
+  test('pullOrConflict delegates to git.pull', () async {
+    when(() => git.pull(root)).thenAnswer((_) async => PullOutcome.conflicted);
+    expect(await service.pullOrConflict(root), PullOutcome.conflicted);
+    verify(() => git.pull(root)).called(1);
+  });
+}

--- a/test/features/collections/data/services/git_conflict_service_test.dart
+++ b/test/features/collections/data/services/git_conflict_service_test.dart
@@ -4,12 +4,26 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:getman/core/domain/entities/request_config_entity.dart';
 import 'package:getman/core/git/git_service.dart';
 import 'package:getman/core/utils/workspace/workspace_collection_serializer.dart';
+import 'package:getman/features/collections/data/datasources/workspace_collections_data_source.dart';
 import 'package:getman/features/collections/data/services/git_conflict_service.dart';
+import 'package:getman/features/collections/data/services/workspace_sync_service.dart';
 import 'package:getman/features/collections/domain/entities/collection_node_entity.dart';
 import 'package:getman/features/collections/domain/entities/file_conflict.dart';
 import 'package:mocktail/mocktail.dart';
 
 class _MockGit extends Mock implements GitService {}
+
+/// A real [WorkspaceSyncService] over a no-op data source: `resolve` and
+/// `continueRebase` wrap their bodies in `withMirroringSuspended` (FIX I1),
+/// whose real implementation just runs the action — no need to mock it, and
+/// this exercises the actual suspend/resume pairing instead of stubbing it
+/// away.
+class _NoopWorkspaceDataSource implements WorkspaceCollectionsDataSource {
+  @override
+  Future<List<CollectionNodeEntity>> read(String root) async => const [];
+  @override
+  Future<void> write(String root, List<CollectionNodeEntity> forest) async {}
+}
 
 CollectionNodeEntity _leaf({
   String id = 'r1',
@@ -62,7 +76,10 @@ void main() {
 
   setUp(() {
     git = _MockGit();
-    service = GitConflictService(git);
+    service = GitConflictService(
+      git,
+      WorkspaceSyncService(_NoopWorkspaceDataSource()),
+    );
   });
 
   group('currentConflicts / classify', () {
@@ -92,48 +109,84 @@ void main() {
       expect(c.node!.conflicts.map((f) => f.field), contains('url'));
     });
 
-    test('a .req.json missing the incoming stage is deleteModify', () async {
-      when(() => git.conflictedPaths(root)).thenAnswer(
-        (_) async => [
-          'a.req.json',
-        ],
-      );
-      when(
-        () => git.showStage(root, 'a.req.json', 1),
-      ).thenAnswer((_) async => _reqStage(_leaf()));
-      when(
-        () => git.showStage(root, 'a.req.json', 2),
-      ).thenAnswer((_) async => null);
-      when(
-        () => git.showStage(root, 'a.req.json', 3),
-      ).thenAnswer((_) async => _reqStage(_leaf()));
+    test(
+      'a .req.json missing the incoming stage is deleteModify with '
+      'deletedSide=incoming (upstream deleted)',
+      () async {
+        when(() => git.conflictedPaths(root)).thenAnswer(
+          (_) async => [
+            'a.req.json',
+          ],
+        );
+        when(
+          () => git.showStage(root, 'a.req.json', 1),
+        ).thenAnswer((_) async => _reqStage(_leaf()));
+        when(
+          () => git.showStage(root, 'a.req.json', 2),
+        ).thenAnswer((_) async => null);
+        when(
+          () => git.showStage(root, 'a.req.json', 3),
+        ).thenAnswer((_) async => _reqStage(_leaf()));
 
-      final conflicts = await service.currentConflicts(root);
+        final conflicts = await service.currentConflicts(root);
 
-      expect(conflicts.single.kind, ConflictKind.deleteModify);
-      expect(conflicts.single.node, isNull);
-    });
+        expect(conflicts.single.kind, ConflictKind.deleteModify);
+        expect(conflicts.single.node, isNull);
+        expect(conflicts.single.deletedSide, FileSide.incoming);
+      },
+    );
 
-    test('a .req.json missing the yours stage is deleteModify', () async {
-      when(() => git.conflictedPaths(root)).thenAnswer(
-        (_) async => [
-          'a.req.json',
-        ],
-      );
-      when(
-        () => git.showStage(root, 'a.req.json', 1),
-      ).thenAnswer((_) async => _reqStage(_leaf()));
-      when(
-        () => git.showStage(root, 'a.req.json', 2),
-      ).thenAnswer((_) async => _reqStage(_leaf()));
-      when(
-        () => git.showStage(root, 'a.req.json', 3),
-      ).thenAnswer((_) async => null);
+    test(
+      'a .req.json missing the yours stage is deleteModify with '
+      'deletedSide=yours (you deleted it)',
+      () async {
+        when(() => git.conflictedPaths(root)).thenAnswer(
+          (_) async => [
+            'a.req.json',
+          ],
+        );
+        when(
+          () => git.showStage(root, 'a.req.json', 1),
+        ).thenAnswer((_) async => _reqStage(_leaf()));
+        when(
+          () => git.showStage(root, 'a.req.json', 2),
+        ).thenAnswer((_) async => _reqStage(_leaf()));
+        when(
+          () => git.showStage(root, 'a.req.json', 3),
+        ).thenAnswer((_) async => null);
 
-      final conflicts = await service.currentConflicts(root);
+        final conflicts = await service.currentConflicts(root);
 
-      expect(conflicts.single.kind, ConflictKind.deleteModify);
-    });
+        expect(conflicts.single.kind, ConflictKind.deleteModify);
+        expect(conflicts.single.deletedSide, FileSide.yours);
+      },
+    );
+
+    test(
+      'a .folder.json missing the yours stage is deleteModify with '
+      'deletedSide=yours (you deleted the folder)',
+      () async {
+        when(() => git.conflictedPaths(root)).thenAnswer(
+          (_) async => [
+            'x/.folder.json',
+          ],
+        );
+        when(
+          () => git.showStage(root, 'x/.folder.json', 1),
+        ).thenAnswer((_) async => _folderStage(_folder(), ['a']));
+        when(
+          () => git.showStage(root, 'x/.folder.json', 2),
+        ).thenAnswer((_) async => _folderStage(_folder(), ['a']));
+        when(
+          () => git.showStage(root, 'x/.folder.json', 3),
+        ).thenAnswer((_) async => null);
+
+        final conflicts = await service.currentConflicts(root);
+
+        expect(conflicts.single.kind, ConflictKind.deleteModify);
+        expect(conflicts.single.deletedSide, FileSide.yours);
+      },
+    );
 
     test('a .req.json with no base stage (add/add) is addAdd', () async {
       when(() => git.conflictedPaths(root)).thenAnswer(
@@ -454,6 +507,31 @@ void main() {
         );
       },
     );
+
+    // FIX I1: the mirror-suspension gate must be held while resolve() writes
+    // to the working tree, so a debounced Hive→disk mirror can't fire mid-way
+    // and clobber the resolution.
+    test('holds mirroring suspended for its whole duration', () async {
+      final sync = WorkspaceSyncService(_NoopWorkspaceDataSource());
+      final svc = GitConflictService(git, sync);
+      when(
+        () => git.showStage(root, 'a.req.json', 2),
+      ).thenAnswer((_) async => 'INCOMING CONTENT');
+      when(
+        () => git.writeWorkingFile(root, 'a.req.json', any()),
+      ).thenAnswer((_) async {
+        expect(sync.isMirroringSuspended, isTrue);
+      });
+      when(() => git.add(root, 'a.req.json')).thenAnswer((_) async {
+        expect(sync.isMirroringSuspended, isTrue);
+      });
+
+      expect(sync.isMirroringSuspended, isFalse);
+      await svc.resolve(root, const [
+        FileResolution(path: 'a.req.json', wholeFile: FileSide.incoming),
+      ]);
+      expect(sync.isMirroringSuspended, isFalse);
+    });
   });
 
   group('continueRebase', () {
@@ -470,6 +548,20 @@ void main() {
       when(() => git.isRebaseInProgress(root)).thenAnswer((_) async => false);
 
       expect(await service.continueRebase(root), RebaseStep.done);
+    });
+
+    // FIX I1: same gate must be held across `rebase --continue`.
+    test('holds mirroring suspended for its whole duration', () async {
+      final sync = WorkspaceSyncService(_NoopWorkspaceDataSource());
+      final svc = GitConflictService(git, sync);
+      when(() => git.rebaseContinue(root)).thenAnswer((_) async {
+        expect(sync.isMirroringSuspended, isTrue);
+      });
+      when(() => git.isRebaseInProgress(root)).thenAnswer((_) async => false);
+
+      expect(sync.isMirroringSuspended, isFalse);
+      await svc.continueRebase(root);
+      expect(sync.isMirroringSuspended, isFalse);
     });
   });
 

--- a/test/features/collections/data/services/git_conflict_service_test.dart
+++ b/test/features/collections/data/services/git_conflict_service_test.dart
@@ -536,15 +536,33 @@ void main() {
 
   group('continueRebase', () {
     test('maps a still-in-progress rebase to moreConflicts', () async {
-      when(() => git.rebaseContinue(root)).thenAnswer((_) async {});
+      when(
+        () => git.rebaseContinue(
+          root,
+          authorName: any(named: 'authorName'),
+          authorEmail: any(named: 'authorEmail'),
+        ),
+      ).thenAnswer((_) async {});
       when(() => git.isRebaseInProgress(root)).thenAnswer((_) async => true);
 
       expect(await service.continueRebase(root), RebaseStep.moreConflicts);
-      verify(() => git.rebaseContinue(root)).called(1);
+      verify(
+        () => git.rebaseContinue(
+          root,
+          authorName: any(named: 'authorName'),
+          authorEmail: any(named: 'authorEmail'),
+        ),
+      ).called(1);
     });
 
     test('maps a finished rebase to done', () async {
-      when(() => git.rebaseContinue(root)).thenAnswer((_) async {});
+      when(
+        () => git.rebaseContinue(
+          root,
+          authorName: any(named: 'authorName'),
+          authorEmail: any(named: 'authorEmail'),
+        ),
+      ).thenAnswer((_) async {});
       when(() => git.isRebaseInProgress(root)).thenAnswer((_) async => false);
 
       expect(await service.continueRebase(root), RebaseStep.done);
@@ -554,7 +572,13 @@ void main() {
     test('holds mirroring suspended for its whole duration', () async {
       final sync = WorkspaceSyncService(_NoopWorkspaceDataSource());
       final svc = GitConflictService(git, sync);
-      when(() => git.rebaseContinue(root)).thenAnswer((_) async {
+      when(
+        () => git.rebaseContinue(
+          root,
+          authorName: any(named: 'authorName'),
+          authorEmail: any(named: 'authorEmail'),
+        ),
+      ).thenAnswer((_) async {
         expect(sync.isMirroringSuspended, isTrue);
       });
       when(() => git.isRebaseInProgress(root)).thenAnswer((_) async => false);

--- a/test/features/collections/data/services/git_conflict_service_test.dart
+++ b/test/features/collections/data/services/git_conflict_service_test.dart
@@ -245,6 +245,58 @@ void main() {
       },
     );
 
+    test(
+      'coarse wholeFile: keeping the deleting side removes the file, not '
+      'an empty write',
+      () async {
+        // Delete/modify: incoming deleted the file (stage 2 absent), yours
+        // kept editing it (stage 3 present). The user picks "incoming"
+        // (i.e. keep the deletion).
+        when(
+          () => git.showStage(root, 'a.req.json', 2),
+        ).thenAnswer((_) async => null);
+        when(() => git.removeFile(root, 'a.req.json')).thenAnswer(
+          (
+            _,
+          ) async {},
+        );
+
+        await service.resolve(root, const [
+          FileResolution(path: 'a.req.json', wholeFile: FileSide.incoming),
+        ]);
+
+        verify(() => git.removeFile(root, 'a.req.json')).called(1);
+        verifyNever(() => git.writeWorkingFile(root, 'a.req.json', any()));
+        verifyNever(() => git.add(root, 'a.req.json'));
+      },
+    );
+
+    test(
+      'coarse wholeFile: keeping the modified side writes its content and '
+      'stages it',
+      () async {
+        // Same delete/modify conflict, but the user picks "yours" (the
+        // side that still has content) — content is written + staged.
+        when(
+          () => git.showStage(root, 'a.req.json', 3),
+        ).thenAnswer((_) async => 'YOURS CONTENT');
+        when(
+          () => git.writeWorkingFile(root, 'a.req.json', any()),
+        ).thenAnswer((_) async {});
+        when(() => git.add(root, 'a.req.json')).thenAnswer((_) async {});
+
+        await service.resolve(root, const [
+          FileResolution(path: 'a.req.json', wholeFile: FileSide.yours),
+        ]);
+
+        verify(
+          () => git.writeWorkingFile(root, 'a.req.json', 'YOURS CONTENT'),
+        ).called(1);
+        verify(() => git.add(root, 'a.req.json')).called(1);
+        verifyNever(() => git.removeFile(root, 'a.req.json'));
+      },
+    );
+
     test('coarse wholeFile: yours writes stage-3 content', () async {
       when(
         () => git.showStage(root, 'a.req.json', 3),
@@ -365,6 +417,43 @@ void main() {
       expect((decoded['variables'] as Map)['k'], 'picked-value');
       verify(() => git.add(root, 'x/.folder.json')).called(1);
     });
+
+    test(
+      'a folder "child order" pick round-trips the chosen side\'s order',
+      () async {
+        when(() => git.showStage(root, 'x/.folder.json', 1)).thenAnswer(
+          (_) async => _folderStage(_folder(), ['a']),
+        );
+        when(() => git.showStage(root, 'x/.folder.json', 2)).thenAnswer(
+          (_) async => _folderStage(_folder(), ['a', 'b']),
+        );
+        when(() => git.showStage(root, 'x/.folder.json', 3)).thenAnswer(
+          (_) async => _folderStage(_folder(), ['a', 'c']),
+        );
+        String? written;
+        when(
+          () => git.writeWorkingFile(root, 'x/.folder.json', any()),
+        ).thenAnswer((i) async {
+          written = i.positionalArguments[2] as String;
+        });
+        when(() => git.add(root, 'x/.folder.json')).thenAnswer((_) async {});
+
+        // The user picks yours' order, rendered by ThreeWayMerge as the
+        // comma-joined string "a, c".
+        await service.resolve(root, const [
+          FileResolution(
+            path: 'x/.folder.json',
+            fieldChoices: {'child order': 'a, c'},
+          ),
+        ]);
+
+        final decoded = jsonDecode(written!) as Map<String, dynamic>;
+        expect(
+          WorkspaceCollectionSerializer.childOrder(decoded),
+          ['a', 'c'],
+        );
+      },
+    );
   });
 
   group('continueRebase', () {

--- a/test/features/collections/domain/entities/file_conflict_test.dart
+++ b/test/features/collections/domain/entities/file_conflict_test.dart
@@ -1,0 +1,101 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/features/collections/domain/entities/collection_node_entity.dart';
+import 'package:getman/features/collections/domain/entities/file_conflict.dart';
+import 'package:getman/features/collections/domain/logic/three_way_merge.dart';
+
+void main() {
+  group('FileConflict', () {
+    test('equal by path + kind, ignoring node identity', () {
+      const a = FileConflict(path: 'a.json', kind: ConflictKind.request);
+      const b = FileConflict(path: 'a.json', kind: ConflictKind.request);
+
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('differing path makes instances unequal', () {
+      const a = FileConflict(path: 'a.json', kind: ConflictKind.request);
+      const b = FileConflict(path: 'b.json', kind: ConflictKind.request);
+
+      expect(a, isNot(equals(b)));
+    });
+
+    test('differing kind makes instances unequal', () {
+      const a = FileConflict(path: 'a.json', kind: ConflictKind.request);
+      const b = FileConflict(path: 'a.json', kind: ConflictKind.folder);
+
+      expect(a, isNot(equals(b)));
+    });
+
+    test('isFieldLevel is true when node is present', () {
+      const withNode = FileConflict(
+        path: 'a.json',
+        kind: ConflictKind.request,
+        node: NodeMergeResult(
+          merged: CollectionNodeEntity(id: 'r1', name: 'Req'),
+          conflicts: [],
+        ),
+      );
+      const withoutNode = FileConflict(
+        path: 'a.json',
+        kind: ConflictKind.addAdd,
+      );
+
+      expect(withNode.isFieldLevel, isTrue);
+      expect(withoutNode.isFieldLevel, isFalse);
+    });
+  });
+
+  group('FileResolution', () {
+    test('equal when path, fieldChoices, and wholeFile all match', () {
+      const a = FileResolution(
+        path: 'a.json',
+        fieldChoices: {'url': 'https://a'},
+        wholeFile: FileSide.incoming,
+      );
+      const b = FileResolution(
+        path: 'a.json',
+        fieldChoices: {'url': 'https://a'},
+        wholeFile: FileSide.incoming,
+      );
+
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('differing wholeFile makes instances unequal', () {
+      const a = FileResolution(
+        path: 'a.json',
+        fieldChoices: {'url': 'https://a'},
+        wholeFile: FileSide.incoming,
+      );
+      const b = FileResolution(
+        path: 'a.json',
+        fieldChoices: {'url': 'https://a'},
+        wholeFile: FileSide.yours,
+      );
+
+      expect(a, isNot(equals(b)));
+    });
+
+    test('differing fieldChoices makes instances unequal', () {
+      const a = FileResolution(
+        path: 'a.json',
+        fieldChoices: {'url': 'https://a'},
+      );
+      const b = FileResolution(
+        path: 'a.json',
+        fieldChoices: {'url': 'https://b'},
+      );
+
+      expect(a, isNot(equals(b)));
+    });
+
+    test('defaults are empty fieldChoices and null wholeFile', () {
+      const a = FileResolution(path: 'a.json');
+
+      expect(a.fieldChoices, isEmpty);
+      expect(a.wholeFile, isNull);
+    });
+  });
+}

--- a/test/features/collections/domain/logic/three_way_merge_test.dart
+++ b/test/features/collections/domain/logic/three_way_merge_test.dart
@@ -1,0 +1,302 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/core/domain/entities/body_type.dart';
+import 'package:getman/core/domain/entities/multipart_field_entity.dart';
+import 'package:getman/core/domain/entities/request_config_entity.dart';
+import 'package:getman/features/collections/domain/entities/collection_node_entity.dart';
+import 'package:getman/features/collections/domain/logic/three_way_merge.dart';
+
+CollectionNodeEntity _leaf({
+  String id = 'r1',
+  String name = 'Req',
+  bool isFavorite = false,
+  String method = 'GET',
+  String url = '',
+  Map<String, String> headers = const {},
+  String body = '',
+  Map<String, String> auth = const {},
+  BodyType bodyType = BodyType.raw,
+  List<MultipartFieldEntity> formFields = const [],
+  String? bodyFilePath,
+  String graphqlVariables = '',
+}) => CollectionNodeEntity(
+  id: id,
+  name: name,
+  isFolder: false,
+  isFavorite: isFavorite,
+  config: HttpRequestConfigEntity(
+    id: id,
+    method: method,
+    url: url,
+    headers: headers,
+    body: body,
+    auth: auth,
+    bodyType: bodyType,
+    formFields: formFields,
+    bodyFilePath: bodyFilePath,
+    graphqlVariables: graphqlVariables,
+  ),
+);
+
+CollectionNodeEntity _folder({
+  String id = 'f1',
+  String name = 'Folder',
+  bool isFavorite = false,
+  Map<String, String> variables = const {},
+  Set<String> secretKeys = const {},
+  List<CollectionNodeEntity> children = const [],
+}) => CollectionNodeEntity(
+  id: id,
+  name: name,
+  isFavorite: isFavorite,
+  variables: variables,
+  secretKeys: secretKeys,
+  children: children,
+);
+
+void main() {
+  group('ThreeWayMerge.mergeRequest — scalars', () {
+    test('non-overlapping scalar edits auto-merge with no conflict', () {
+      final base = _leaf(url: 'a');
+      final incoming = _leaf(url: 'b'); // changed url
+      final yours = _leaf(url: 'a', method: 'POST'); // changed method
+      final r = ThreeWayMerge.mergeRequest(base, incoming, yours);
+      expect(r.conflicts, isEmpty);
+      expect(r.merged.config!.url, 'b');
+      expect(r.merged.config!.method, 'POST');
+    });
+
+    test('a true url overlap is one conflict', () {
+      final r = ThreeWayMerge.mergeRequest(
+        _leaf(url: 'a'),
+        _leaf(url: 'b'),
+        _leaf(url: 'c'),
+      );
+      expect(r.conflicts.map((c) => c.field), ['url']);
+      expect(r.conflicts.single.incoming, 'b');
+      expect(r.conflicts.single.yours, 'c');
+      // Unresolved scalar stays at the incoming value in the merged entity.
+      expect(r.merged.config!.url, 'b');
+    });
+
+    test('identical edits on both sides agree with no conflict', () {
+      final base = _leaf();
+      final incoming = _leaf(method: 'POST');
+      final yours = _leaf(method: 'POST');
+      final r = ThreeWayMerge.mergeRequest(base, incoming, yours);
+      expect(r.conflicts, isEmpty);
+      expect(r.merged.config!.method, 'POST');
+    });
+
+    test(
+      'name and isFavorite (leaf top-level scalars) follow the same rule',
+      () {
+        final base = _leaf(name: 'Old');
+        final incoming = _leaf(name: 'New'); // renamed
+        final yours = _leaf(name: 'Old', isFavorite: true); // favorited
+        final r = ThreeWayMerge.mergeRequest(base, incoming, yours);
+        expect(r.conflicts, isEmpty);
+        expect(r.merged.name, 'New');
+        expect(r.merged.isFavorite, isTrue);
+      },
+    );
+
+    test('bodyType is merged as a scalar over its wire string', () {
+      final base = _leaf();
+      final incoming = _leaf();
+      final yours = _leaf(bodyType: BodyType.graphql);
+      final r = ThreeWayMerge.mergeRequest(base, incoming, yours);
+      expect(r.conflicts, isEmpty);
+      expect(r.merged.config!.bodyType, BodyType.graphql);
+    });
+  });
+
+  group('ThreeWayMerge.mergeRequest — maps', () {
+    test('different header keys auto-merge (union, no conflict)', () {
+      final base = _leaf(headers: const {'A': '1'});
+      final incoming = _leaf(headers: const {'A': '1', 'B': '2'});
+      final yours = _leaf(headers: const {'A': '1', 'C': '3'});
+      final r = ThreeWayMerge.mergeRequest(base, incoming, yours);
+      expect(r.conflicts, isEmpty);
+      expect(r.merged.config!.headers, {'A': '1', 'B': '2', 'C': '3'});
+    });
+
+    test('same header key changed differently on both sides collides', () {
+      final base = _leaf(headers: const {'X': '1'});
+      final incoming = _leaf(headers: const {'X': '2'});
+      final yours = _leaf(headers: const {'X': '3'});
+      final r = ThreeWayMerge.mergeRequest(base, incoming, yours);
+      expect(r.conflicts.map((c) => c.field), ["header 'X'"]);
+      expect(r.conflicts.single.kind, FieldConflictKind.mapEntry);
+      expect(r.conflicts.single.incoming, '2');
+      expect(r.conflicts.single.yours, '3');
+      expect(r.merged.config!.headers['X'], '2');
+    });
+  });
+
+  group('ThreeWayMerge.mergeRequest — opaque fields', () {
+    test('auth conflict carries null values (opaque)', () {
+      final base = _leaf(auth: const {'type': 'none'});
+      final incoming = _leaf(auth: const {'type': 'bearer', 'token': 't1'});
+      final yours = _leaf(auth: const {'type': 'basic', 'user': 'u'});
+      final r = ThreeWayMerge.mergeRequest(base, incoming, yours);
+      expect(r.conflicts.map((c) => c.field), ['authentication']);
+      expect(r.conflicts.single.kind, FieldConflictKind.opaque);
+      expect(r.conflicts.single.incoming, isNull);
+      expect(r.conflicts.single.yours, isNull);
+      expect(r.merged.config!.auth, incoming.config!.auth);
+    });
+
+    test('auth auto-merges when only one side changed it', () {
+      final base = _leaf();
+      final incoming = _leaf();
+      final yours = _leaf(auth: const {'type': 'bearer', 'token': 't1'});
+      final r = ThreeWayMerge.mergeRequest(base, incoming, yours);
+      expect(r.conflicts, isEmpty);
+      expect(r.merged.config!.auth, yours.config!.auth);
+    });
+
+    test('formFields conflict carries null values (whole-field)', () {
+      final base = _leaf();
+      final incoming = _leaf(
+        formFields: const [MultipartFieldEntity(name: 'a', value: '1')],
+      );
+      final yours = _leaf(
+        formFields: const [MultipartFieldEntity(name: 'b', value: '2')],
+      );
+      final r = ThreeWayMerge.mergeRequest(base, incoming, yours);
+      expect(r.conflicts.map((c) => c.field), ['form fields']);
+      expect(r.conflicts.single.kind, FieldConflictKind.list);
+      expect(r.conflicts.single.incoming, isNull);
+      expect(r.conflicts.single.yours, isNull);
+    });
+  });
+
+  group('ThreeWayMerge.mergeRequest — add/add (base null)', () {
+    test(
+      'both sides added the same path with different content: '
+      'conflicts, no crash',
+      () {
+        final incoming = _leaf(url: 'https://a');
+        final yours = _leaf(url: 'https://b', method: 'POST');
+        final r = ThreeWayMerge.mergeRequest(null, incoming, yours);
+        expect(
+          r.conflicts.map((c) => c.field),
+          containsAll(['url', 'method']),
+        );
+        expect(r.merged.config!.url, 'https://a');
+        expect(r.merged.config!.method, 'GET');
+      },
+    );
+
+    test('add/add with identical content agrees with no conflict', () {
+      final incoming = _leaf(url: 'https://same');
+      final yours = _leaf(url: 'https://same');
+      final r = ThreeWayMerge.mergeRequest(null, incoming, yours);
+      expect(r.conflicts, isEmpty);
+      expect(r.merged.config!.url, 'https://same');
+    });
+  });
+
+  group('ThreeWayMerge.mergeRequest — zero-true-conflict file', () {
+    test(
+      'fully auto-resolvable file: conflicts.isEmpty and merged carries '
+      'both sides',
+      () {
+        final base = _leaf(
+          url: 'https://api.dev',
+          headers: const {'A': '1'},
+        );
+        final incoming = _leaf(
+          url: 'https://api.dev/v2', // incoming changed url
+          headers: const {'A': '1', 'B': '2'}, // incoming added header
+        );
+        final yours = _leaf(
+          url: 'https://api.dev',
+          method: 'POST', // yours changed method
+          headers: const {'A': '1', 'C': '3'}, // yours added header
+        );
+        final r = ThreeWayMerge.mergeRequest(base, incoming, yours);
+        expect(r.conflicts, isEmpty);
+        expect(r.merged.config!.url, 'https://api.dev/v2');
+        expect(r.merged.config!.method, 'POST');
+        expect(r.merged.config!.headers, {'A': '1', 'B': '2', 'C': '3'});
+      },
+    );
+  });
+
+  group('ThreeWayMerge.mergeFolder', () {
+    test('folder scalar/map fields follow the same 3-way rule', () {
+      final base = _folder(name: 'Old', variables: const {'A': '1'});
+      final incoming = _folder(
+        name: 'New',
+        variables: const {'A': '1', 'B': '2'},
+      );
+      final yours = _folder(name: 'Old', variables: const {'A': '1', 'C': '3'});
+      final r = ThreeWayMerge.mergeFolder(
+        base,
+        ['x'],
+        incoming,
+        ['x'],
+        yours,
+        ['x'],
+      );
+      expect(r.conflicts, isEmpty);
+      expect(r.merged.name, 'New');
+      expect(r.merged.variables, {'A': '1', 'B': '2', 'C': '3'});
+    });
+
+    test(
+      'divergent childOrder on both sides is a single "child order" conflict',
+      () {
+        final base = _folder();
+        final incoming = _folder();
+        final yours = _folder();
+        final r = ThreeWayMerge.mergeFolder(
+          base,
+          ['A', 'B'],
+          incoming,
+          ['A', 'B', 'C'],
+          yours,
+          ['A', 'X', 'B'],
+        );
+        expect(r.conflicts.map((c) => c.field), ['child order']);
+        expect(r.conflicts.single.kind, FieldConflictKind.scalar);
+        expect(r.conflicts.single.incoming, 'A, B, C');
+        expect(r.conflicts.single.yours, 'A, X, B');
+      },
+    );
+
+    test(
+      'only one side reordering auto-merges childOrder with no conflict',
+      () {
+        final base = _folder();
+        final incoming = _folder();
+        final yours = _folder();
+        final r = ThreeWayMerge.mergeFolder(
+          base,
+          ['A'],
+          incoming,
+          ['A', 'B'],
+          yours,
+          ['A'],
+        );
+        expect(r.conflicts, isEmpty);
+      },
+    );
+
+    test('secretKeys collision is reported', () {
+      final base = _folder();
+      final incoming = _folder(secretKeys: const {'token'});
+      final yours = _folder(secretKeys: const {'apiKey'});
+      final r = ThreeWayMerge.mergeFolder(
+        base,
+        const [],
+        incoming,
+        const [],
+        yours,
+        const [],
+      );
+      expect(r.conflicts.any((c) => c.field == 'secret keys'), isTrue);
+    });
+  });
+}

--- a/test/features/collections/domain/logic/three_way_merge_test.dart
+++ b/test/features/collections/domain/logic/three_way_merge_test.dart
@@ -131,6 +131,33 @@ void main() {
       expect(r.conflicts.single.yours, '3');
       expect(r.merged.config!.headers['X'], '2');
     });
+
+    test(
+      'header deleted on incoming but unchanged on yours auto-merges to '
+      'deletion (no conflict)',
+      () {
+        final base = _leaf(headers: const {'X': '1'});
+        final incoming = _leaf(); // deleted X
+        final yours = _leaf(headers: const {'X': '1'}); // unchanged
+        final r = ThreeWayMerge.mergeRequest(base, incoming, yours);
+        expect(r.conflicts, isEmpty);
+        expect(r.merged.config!.headers.containsKey('X'), isFalse);
+      },
+    );
+
+    test(
+      'header deleted on incoming but edited on yours is a conflict',
+      () {
+        final base = _leaf(headers: const {'X': '1'});
+        final incoming = _leaf(); // deleted X
+        final yours = _leaf(headers: const {'X': '2'}); // edited X
+        final r = ThreeWayMerge.mergeRequest(base, incoming, yours);
+        expect(r.conflicts.map((c) => c.field), ["header 'X'"]);
+        expect(r.conflicts.single.kind, FieldConflictKind.mapEntry);
+        expect(r.conflicts.single.incoming, isNull);
+        expect(r.conflicts.single.yours, '2');
+      },
+    );
   });
 
   group('ThreeWayMerge.mergeRequest — opaque fields', () {
@@ -284,7 +311,7 @@ void main() {
       },
     );
 
-    test('secretKeys collision is reported', () {
+    test('secretKeys collision carries null values (whole-field)', () {
       final base = _folder();
       final incoming = _folder(secretKeys: const {'token'});
       final yours = _folder(secretKeys: const {'apiKey'});
@@ -296,7 +323,10 @@ void main() {
         yours,
         const [],
       );
-      expect(r.conflicts.any((c) => c.field == 'secret keys'), isTrue);
+      expect(r.conflicts.map((c) => c.field), ['secret keys']);
+      expect(r.conflicts.single.kind, FieldConflictKind.list);
+      expect(r.conflicts.single.incoming, isNull);
+      expect(r.conflicts.single.yours, isNull);
     });
   });
 }

--- a/test/features/collections/domain/pull_request_test.dart
+++ b/test/features/collections/domain/pull_request_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/features/collections/domain/entities/pull_request.dart';
+
+void main() {
+  test('PullRequestEntity equality is by value', () {
+    const a = PullRequestEntity(
+      number: 1,
+      title: 't',
+      state: PrState.open,
+      url: 'u',
+      isDraft: false,
+      checks: PrChecks.passing,
+    );
+    const b = PullRequestEntity(
+      number: 1,
+      title: 't',
+      state: PrState.open,
+      url: 'u',
+      isDraft: false,
+      checks: PrChecks.passing,
+    );
+    expect(a, b);
+  });
+
+  test('PullRequestEntity differs when any field differs', () {
+    const base = PullRequestEntity(
+      number: 1,
+      title: 't',
+      state: PrState.open,
+      url: 'u',
+      isDraft: false,
+      checks: PrChecks.passing,
+    );
+    expect(
+      base,
+      isNot(
+        const PullRequestEntity(
+          number: 1,
+          title: 't',
+          state: PrState.open,
+          url: 'u',
+          isDraft: false,
+          checks: PrChecks.failing,
+        ),
+      ),
+    );
+  });
+
+  test('PullRequestRef equality is by value', () {
+    expect(
+      const PullRequestRef(number: 5, url: 'u'),
+      const PullRequestRef(number: 5, url: 'u'),
+    );
+  });
+}

--- a/test/features/collections/presentation/bloc/conflict_bloc_test.dart
+++ b/test/features/collections/presentation/bloc/conflict_bloc_test.dart
@@ -84,7 +84,11 @@ void main() {
     build: () {
       when(() => service.resolve(root, any())).thenAnswer((_) async {});
       when(
-        () => service.continueRebase(root),
+        () => service.continueRebase(
+          root,
+          authorName: any(named: 'authorName'),
+          authorEmail: any(named: 'authorEmail'),
+        ),
       ).thenAnswer((_) async => RebaseStep.done);
       return ConflictBloc(service: service);
     },
@@ -112,7 +116,11 @@ void main() {
     build: () {
       when(() => service.resolve(root, any())).thenAnswer((_) async {});
       when(
-        () => service.continueRebase(root),
+        () => service.continueRebase(
+          root,
+          authorName: any(named: 'authorName'),
+          authorEmail: any(named: 'authorEmail'),
+        ),
       ).thenAnswer((_) async => RebaseStep.moreConflicts);
       when(
         () => service.currentConflicts(root),
@@ -138,7 +146,11 @@ void main() {
     build: () {
       when(() => service.resolve(root, any())).thenAnswer((_) async {});
       when(
-        () => service.continueRebase(root),
+        () => service.continueRebase(
+          root,
+          authorName: any(named: 'authorName'),
+          authorEmail: any(named: 'authorEmail'),
+        ),
       ).thenAnswer((_) async => RebaseStep.moreConflicts);
       when(() => service.currentConflicts(root)).thenAnswer((_) async => []);
       return ConflictBloc(service: service);
@@ -169,7 +181,13 @@ void main() {
       // verifyNever below catches.
       final gate = Completer<RebaseStep>();
       when(() => service.resolve(root, any())).thenAnswer((_) async {});
-      when(() => service.continueRebase(root)).thenAnswer((_) => gate.future);
+      when(
+        () => service.continueRebase(
+          root,
+          authorName: any(named: 'authorName'),
+          authorEmail: any(named: 'authorEmail'),
+        ),
+      ).thenAnswer((_) => gate.future);
       when(
         () => service.currentConflicts(root),
       ).thenAnswer((_) async => const [conflictB]);
@@ -253,7 +271,13 @@ void main() {
     ],
     verify: (_) {
       verifyNever(() => service.abort(root));
-      verifyNever(() => service.continueRebase(root));
+      verifyNever(
+        () => service.continueRebase(
+          root,
+          authorName: any(named: 'authorName'),
+          authorEmail: any(named: 'authorEmail'),
+        ),
+      );
     },
   );
 

--- a/test/features/collections/presentation/bloc/conflict_bloc_test.dart
+++ b/test/features/collections/presentation/bloc/conflict_bloc_test.dart
@@ -1,0 +1,291 @@
+import 'dart:async';
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/core/git/git_service.dart';
+import 'package:getman/features/collections/domain/conflict_service.dart';
+import 'package:getman/features/collections/domain/entities/file_conflict.dart';
+import 'package:getman/features/collections/presentation/bloc/conflict_bloc.dart';
+import 'package:getman/features/collections/presentation/bloc/conflict_event.dart';
+import 'package:getman/features/collections/presentation/bloc/conflict_state.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockService extends Mock implements ConflictService {}
+
+void main() {
+  const root = '/ws';
+  late _MockService service;
+
+  const conflictA = FileConflict(
+    path: 'a.req.json',
+    kind: ConflictKind.request,
+  );
+  const conflictB = FileConflict(
+    path: 'b.req.json',
+    kind: ConflictKind.request,
+  );
+  const resolutions = [
+    FileResolution(path: 'a.req.json', wholeFile: FileSide.yours),
+  ];
+
+  setUpAll(() {
+    registerFallbackValue(<FileResolution>[]);
+  });
+
+  setUp(() {
+    service = _MockService();
+  });
+
+  blocTest<ConflictBloc, ConflictState>(
+    'LoadConflicts populates the batch as ready',
+    build: () {
+      when(
+        () => service.currentConflicts(root),
+      ).thenAnswer((_) async => const [conflictA, conflictB]);
+      return ConflictBloc(service: service);
+    },
+    act: (b) => b.add(const LoadConflicts(root)),
+    expect: () => [
+      isA<ConflictState>().having(
+        (s) => s.status,
+        'status',
+        ConflictStatus.loading,
+      ),
+      isA<ConflictState>()
+          .having((s) => s.status, 'status', ConflictStatus.ready)
+          .having((s) => s.conflicts, 'conflicts', [conflictA, conflictB])
+          .having((s) => s.batch, 'batch', 0),
+    ],
+  );
+
+  blocTest<ConflictBloc, ConflictState>(
+    'LoadConflicts with nothing conflicted emits done',
+    build: () {
+      when(() => service.currentConflicts(root)).thenAnswer((_) async => []);
+      return ConflictBloc(service: service);
+    },
+    act: (b) => b.add(const LoadConflicts(root)),
+    expect: () => [
+      isA<ConflictState>().having(
+        (s) => s.status,
+        'status',
+        ConflictStatus.loading,
+      ),
+      isA<ConflictState>().having(
+        (s) => s.status,
+        'status',
+        ConflictStatus.done,
+      ),
+    ],
+  );
+
+  blocTest<ConflictBloc, ConflictState>(
+    'ResolveAndContinue: rebase finishes cleanly → done',
+    build: () {
+      when(() => service.resolve(root, any())).thenAnswer((_) async {});
+      when(
+        () => service.continueRebase(root),
+      ).thenAnswer((_) async => RebaseStep.done);
+      return ConflictBloc(service: service);
+    },
+    act: (b) => b.add(const ResolveAndContinue(root, resolutions)),
+    expect: () => [
+      isA<ConflictState>().having(
+        (s) => s.status,
+        'status',
+        ConflictStatus.resolving,
+      ),
+      isA<ConflictState>().having(
+        (s) => s.status,
+        'status',
+        ConflictStatus.done,
+      ),
+    ],
+    verify: (_) {
+      verify(() => service.resolve(root, resolutions)).called(1);
+      verifyNever(() => service.currentConflicts(root));
+    },
+  );
+
+  blocTest<ConflictBloc, ConflictState>(
+    'ResolveAndContinue: more conflicts → loads the next batch',
+    build: () {
+      when(() => service.resolve(root, any())).thenAnswer((_) async {});
+      when(
+        () => service.continueRebase(root),
+      ).thenAnswer((_) async => RebaseStep.moreConflicts);
+      when(
+        () => service.currentConflicts(root),
+      ).thenAnswer((_) async => const [conflictB]);
+      return ConflictBloc(service: service);
+    },
+    act: (b) => b.add(const ResolveAndContinue(root, resolutions)),
+    expect: () => [
+      isA<ConflictState>().having(
+        (s) => s.status,
+        'status',
+        ConflictStatus.resolving,
+      ),
+      isA<ConflictState>()
+          .having((s) => s.status, 'status', ConflictStatus.ready)
+          .having((s) => s.conflicts, 'conflicts', [conflictB])
+          .having((s) => s.batch, 'batch', 1),
+    ],
+  );
+
+  blocTest<ConflictBloc, ConflictState>(
+    'ResolveAndContinue: more conflicts but the reload is empty → done',
+    build: () {
+      when(() => service.resolve(root, any())).thenAnswer((_) async {});
+      when(
+        () => service.continueRebase(root),
+      ).thenAnswer((_) async => RebaseStep.moreConflicts);
+      when(() => service.currentConflicts(root)).thenAnswer((_) async => []);
+      return ConflictBloc(service: service);
+    },
+    act: (b) => b.add(const ResolveAndContinue(root, resolutions)),
+    expect: () => [
+      isA<ConflictState>().having(
+        (s) => s.status,
+        'status',
+        ConflictStatus.resolving,
+      ),
+      isA<ConflictState>().having(
+        (s) => s.status,
+        'status',
+        ConflictStatus.done,
+      ),
+    ],
+  );
+
+  test(
+    'ResolveAndContinue only reads the next batch after continueRebase '
+    'completes',
+    () async {
+      // Non-vacuous: gate continueRebase open so currentConflicts must not
+      // have run yet while it's pending. Removing the await-order in the
+      // handler (e.g. firing both calls concurrently) would let
+      // currentConflicts run before the gate completes, which the
+      // verifyNever below catches.
+      final gate = Completer<RebaseStep>();
+      when(() => service.resolve(root, any())).thenAnswer((_) async {});
+      when(() => service.continueRebase(root)).thenAnswer((_) => gate.future);
+      when(
+        () => service.currentConflicts(root),
+      ).thenAnswer((_) async => const [conflictB]);
+      final bloc = ConflictBloc(service: service)
+        ..add(const ResolveAndContinue(root, resolutions));
+      await Future<void>.delayed(Duration.zero);
+      // continueRebase is in flight — currentConflicts must not have run.
+      verifyNever(() => service.currentConflicts(root));
+
+      gate.complete(RebaseStep.moreConflicts);
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      verify(() => service.currentConflicts(root)).called(1);
+      expect(bloc.state.status, ConflictStatus.ready);
+      expect(bloc.state.batch, 1);
+      await bloc.close();
+    },
+  );
+
+  blocTest<ConflictBloc, ConflictState>(
+    'AbortRebase aborts and emits done',
+    build: () {
+      when(() => service.abort(root)).thenAnswer((_) async {});
+      return ConflictBloc(service: service);
+    },
+    act: (b) => b.add(const AbortRebase(root)),
+    expect: () => [
+      isA<ConflictState>().having(
+        (s) => s.status,
+        'status',
+        ConflictStatus.resolving,
+      ),
+      isA<ConflictState>().having(
+        (s) => s.status,
+        'status',
+        ConflictStatus.done,
+      ),
+    ],
+    verify: (_) => verify(() => service.abort(root)).called(1),
+  );
+
+  blocTest<ConflictBloc, ConflictState>(
+    'AbortRebase surfaces a service failure as error',
+    build: () {
+      when(() => service.abort(root)).thenThrow(GitException('abort failed'));
+      return ConflictBloc(service: service);
+    },
+    act: (b) => b.add(const AbortRebase(root)),
+    expect: () => [
+      isA<ConflictState>().having(
+        (s) => s.status,
+        'status',
+        ConflictStatus.resolving,
+      ),
+      isA<ConflictState>()
+          .having((s) => s.status, 'status', ConflictStatus.error)
+          .having(
+            (s) => s.errorMessage,
+            'errorMessage',
+            contains('abort failed'),
+          ),
+    ],
+  );
+
+  blocTest<ConflictBloc, ConflictState>(
+    'a resolve failure surfaces as error and leaves the rebase alone',
+    build: () {
+      when(() => service.resolve(root, any())).thenThrow(Exception('boom'));
+      return ConflictBloc(service: service);
+    },
+    act: (b) => b.add(const ResolveAndContinue(root, resolutions)),
+    expect: () => [
+      isA<ConflictState>().having(
+        (s) => s.status,
+        'status',
+        ConflictStatus.resolving,
+      ),
+      isA<ConflictState>()
+          .having((s) => s.status, 'status', ConflictStatus.error)
+          .having((s) => s.errorMessage, 'errorMessage', isNotNull),
+    ],
+    verify: (_) {
+      verifyNever(() => service.abort(root));
+      verifyNever(() => service.continueRebase(root));
+    },
+  );
+
+  blocTest<ConflictBloc, ConflictState>(
+    'a load failure surfaces as error',
+    build: () {
+      when(() => service.currentConflicts(root)).thenThrow(Exception('boom'));
+      return ConflictBloc(service: service);
+    },
+    act: (b) => b.add(const LoadConflicts(root)),
+    expect: () => [
+      isA<ConflictState>().having(
+        (s) => s.status,
+        'status',
+        ConflictStatus.loading,
+      ),
+      isA<ConflictState>()
+          .having((s) => s.status, 'status', ConflictStatus.error)
+          .having((s) => s.errorMessage, 'errorMessage', isNotNull),
+    ],
+  );
+
+  test('a second op is dropped while the first is in flight', () async {
+    final gate = Completer<List<FileConflict>>();
+    when(() => service.currentConflicts(root)).thenAnswer((_) => gate.future);
+    final bloc = ConflictBloc(service: service)..add(const LoadConflicts(root));
+    await Future<void>.delayed(Duration.zero);
+    bloc.add(const AbortRebase(root)); // dropped: bloc is busy
+    gate.complete(const [conflictA]);
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+    await bloc.close();
+
+    verifyNever(() => service.abort(root));
+  });
+}

--- a/test/features/collections/presentation/bloc/git_sync_bloc_test.dart
+++ b/test/features/collections/presentation/bloc/git_sync_bloc_test.dart
@@ -39,7 +39,13 @@ void main() {
     when(() => service.isDirty(root)).thenAnswer((_) async => false);
     when(() => service.switchTo(root, any())).thenAnswer((_) async {});
     when(() => service.create(root, any())).thenAnswer((_) async {});
-    when(() => service.pull(root)).thenAnswer((_) async => PullOutcome.clean);
+    when(
+      () => service.pull(
+        root,
+        authorName: any(named: 'authorName'),
+        authorEmail: any(named: 'authorEmail'),
+      ),
+    ).thenAnswer((_) async => PullOutcome.clean);
     when(() => service.push(root)).thenAnswer((_) async {});
     when(() => service.stash(root, any())).thenAnswer((_) async {});
     when(() => service.popStash(root, any())).thenAnswer((_) async {});
@@ -132,7 +138,13 @@ void main() {
   blocTest<GitSyncBloc, GitSyncState>(
     'PullChanges surfaces the git error and does not bump reloadToken',
     build: () {
-      when(() => service.pull(root)).thenThrow(Exception('CONFLICT in a.json'));
+      when(
+        () => service.pull(
+          root,
+          authorName: any(named: 'authorName'),
+          authorEmail: any(named: 'authorEmail'),
+        ),
+      ).thenThrow(Exception('CONFLICT in a.json'));
       return GitSyncBloc(service: service);
     },
     act: (b) => b.add(const PullChanges(root)),
@@ -146,7 +158,13 @@ void main() {
   blocTest<GitSyncBloc, GitSyncState>(
     'PullChanges surfaces a failed mirror flush',
     build: () {
-      when(() => service.pull(root)).thenThrow(flushFailure());
+      when(
+        () => service.pull(
+          root,
+          authorName: any(named: 'authorName'),
+          authorEmail: any(named: 'authorEmail'),
+        ),
+      ).thenThrow(flushFailure());
       return GitSyncBloc(service: service);
     },
     act: (b) => b.add(const PullChanges(root)),
@@ -169,7 +187,11 @@ void main() {
     'lands on a terminal ready state',
     build: () {
       when(
-        () => service.pull(root),
+        () => service.pull(
+          root,
+          authorName: any(named: 'authorName'),
+          authorEmail: any(named: 'authorEmail'),
+        ),
       ).thenAnswer((_) async => PullOutcome.conflicted);
       return GitSyncBloc(service: service);
     },
@@ -237,7 +259,13 @@ void main() {
     'ConflictsResolved dispatched while busy is dropped',
     build: () {
       pullGate = Completer<PullOutcome>();
-      when(() => service.pull(root)).thenAnswer((_) => pullGate.future);
+      when(
+        () => service.pull(
+          root,
+          authorName: any(named: 'authorName'),
+          authorEmail: any(named: 'authorEmail'),
+        ),
+      ).thenAnswer((_) => pullGate.future);
       return GitSyncBloc(service: service);
     },
     act: (b) async {
@@ -380,7 +408,13 @@ void main() {
   blocTest<GitSyncBloc, GitSyncState>(
     'a later success clears the stale error message',
     build: () {
-      when(() => service.pull(root)).thenThrow(GitException('boom'));
+      when(
+        () => service.pull(
+          root,
+          authorName: any(named: 'authorName'),
+          authorEmail: any(named: 'authorEmail'),
+        ),
+      ).thenThrow(GitException('boom'));
       return GitSyncBloc(service: service);
     },
     act: (b) async {
@@ -432,7 +466,13 @@ void main() {
     'an event dispatched while an op is in flight is dropped',
     build: () {
       pullGate = Completer<PullOutcome>();
-      when(() => service.pull(root)).thenAnswer((_) => pullGate.future);
+      when(
+        () => service.pull(
+          root,
+          authorName: any(named: 'authorName'),
+          authorEmail: any(named: 'authorEmail'),
+        ),
+      ).thenAnswer((_) => pullGate.future);
       return GitSyncBloc(service: service);
     },
     act: (b) async {

--- a/test/features/collections/presentation/bloc/git_sync_bloc_test.dart
+++ b/test/features/collections/presentation/bloc/git_sync_bloc_test.dart
@@ -320,6 +320,39 @@ void main() {
   );
 
   blocTest<GitSyncBloc, GitSyncState>(
+    'PullChanges with addRemoteUrl adds origin before pulling',
+    build: () => GitSyncBloc(service: service),
+    act: (b) => b.add(const PullChanges(root, addRemoteUrl: 'u')),
+    verify: (b) {
+      verifyInOrder([
+        () => service.addRemote(root, 'origin', 'u'),
+        () => service.pull(
+          root,
+          authorName: any(named: 'authorName'),
+          authorEmail: any(named: 'authorEmail'),
+        ),
+      ]);
+      expect(b.state.status, GitSyncStatus.ready);
+    },
+  );
+
+  blocTest<GitSyncBloc, GitSyncState>(
+    'PullChanges without addRemoteUrl never calls addRemote',
+    build: () => GitSyncBloc(service: service),
+    act: (b) => b.add(const PullChanges(root)),
+    verify: (b) {
+      verifyNever(() => service.addRemote(root, any(), any()));
+      verify(
+        () => service.pull(
+          root,
+          authorName: any(named: 'authorName'),
+          authorEmail: any(named: 'authorEmail'),
+        ),
+      ).called(1);
+    },
+  );
+
+  blocTest<GitSyncBloc, GitSyncState>(
     'FetchRemote with addRemoteUrl adds origin before fetching',
     build: () => GitSyncBloc(service: service),
     act: (b) => b.add(const FetchRemote(root, addRemoteUrl: 'u')),

--- a/test/features/collections/presentation/bloc/git_sync_bloc_test.dart
+++ b/test/features/collections/presentation/bloc/git_sync_bloc_test.dart
@@ -15,7 +15,7 @@ class _MockService extends Mock implements BranchService {}
 void main() {
   const root = '/ws';
   late _MockService service;
-  late Completer<void> pullGate;
+  late Completer<PullOutcome> pullGate;
 
   const status = BranchStatus(
     isRepo: true,
@@ -39,11 +39,12 @@ void main() {
     when(() => service.isDirty(root)).thenAnswer((_) async => false);
     when(() => service.switchTo(root, any())).thenAnswer((_) async {});
     when(() => service.create(root, any())).thenAnswer((_) async {});
-    when(() => service.pull(root)).thenAnswer((_) async {});
+    when(() => service.pull(root)).thenAnswer((_) async => PullOutcome.clean);
     when(() => service.push(root)).thenAnswer((_) async {});
     when(() => service.stash(root, any())).thenAnswer((_) async {});
     when(() => service.popStash(root, any())).thenAnswer((_) async {});
     when(() => service.dropStash(root, any())).thenAnswer((_) async {});
+    when(() => service.fetch(root)).thenAnswer((_) async {});
   });
 
   blocTest<GitSyncBloc, GitSyncState>(
@@ -161,6 +162,61 @@ void main() {
     build: () => GitSyncBloc(service: service),
     act: (b) => b.add(const PullChanges(root)),
     verify: (b) => expect(b.state.reloadToken, 1),
+  );
+
+  blocTest<GitSyncBloc, GitSyncState>(
+    'PullChanges conflicted bumps conflictToken, not reloadToken, and still '
+    'lands on a terminal ready state',
+    build: () {
+      when(
+        () => service.pull(root),
+      ).thenAnswer((_) async => PullOutcome.conflicted);
+      return GitSyncBloc(service: service);
+    },
+    act: (b) => b.add(const PullChanges(root)),
+    verify: (b) {
+      expect(b.state.status, GitSyncStatus.ready);
+      expect(b.state.conflictToken, 1);
+      expect(b.state.reloadToken, 0);
+      expect(b.state.errorMessage, isNull);
+    },
+  );
+
+  blocTest<GitSyncBloc, GitSyncState>(
+    'FetchRemote(silent: true) swallows a failure — no error state',
+    build: () {
+      when(() => service.fetch(root)).thenThrow(Exception('offline'));
+      return GitSyncBloc(service: service);
+    },
+    act: (b) => b.add(const FetchRemote(root, silent: true)),
+    verify: (b) {
+      expect(b.state.status, GitSyncStatus.ready);
+      expect(b.state.errorMessage, isNull);
+    },
+  );
+
+  blocTest<GitSyncBloc, GitSyncState>(
+    'FetchRemote(silent: false) surfaces a failure as error',
+    build: () {
+      when(() => service.fetch(root)).thenThrow(Exception('auth required'));
+      return GitSyncBloc(service: service);
+    },
+    act: (b) => b.add(const FetchRemote(root)),
+    verify: (b) {
+      expect(b.state.status, GitSyncStatus.error);
+      expect(b.state.errorMessage, contains('auth required'));
+    },
+  );
+
+  blocTest<GitSyncBloc, GitSyncState>(
+    'FetchRemote success refreshes the branch status',
+    build: () => GitSyncBloc(service: service),
+    act: (b) => b.add(const FetchRemote(root)),
+    verify: (b) {
+      verify(() => service.fetch(root)).called(1);
+      expect(b.state.status, GitSyncStatus.ready);
+      expect(b.state.branch.current, 'main');
+    },
   );
 
   blocTest<GitSyncBloc, GitSyncState>(
@@ -340,7 +396,7 @@ void main() {
   blocTest<GitSyncBloc, GitSyncState>(
     'an event dispatched while an op is in flight is dropped',
     build: () {
-      pullGate = Completer<void>();
+      pullGate = Completer<PullOutcome>();
       when(() => service.pull(root)).thenAnswer((_) => pullGate.future);
       return GitSyncBloc(service: service);
     },
@@ -349,7 +405,7 @@ void main() {
       await Future<void>.delayed(Duration.zero);
       b.add(const SwitchBranch(root, 'feat/x')); // dropped: bloc is busy
       await Future<void>.delayed(Duration.zero);
-      pullGate.complete();
+      pullGate.complete(PullOutcome.clean);
       await Future<void>.delayed(Duration.zero);
     },
     verify: (b) {

--- a/test/features/collections/presentation/bloc/git_sync_bloc_test.dart
+++ b/test/features/collections/presentation/bloc/git_sync_bloc_test.dart
@@ -51,6 +51,9 @@ void main() {
     when(() => service.popStash(root, any())).thenAnswer((_) async {});
     when(() => service.dropStash(root, any())).thenAnswer((_) async {});
     when(() => service.fetch(root)).thenAnswer((_) async {});
+    when(
+      () => service.addRemote(root, any(), any()),
+    ).thenAnswer((_) async {});
   });
 
   blocTest<GitSyncBloc, GitSyncState>(
@@ -290,6 +293,42 @@ void main() {
       verify(() => service.push(root)).called(1);
       expect(b.state.status, GitSyncStatus.ready);
       expect(b.state.reloadToken, 0);
+    },
+  );
+
+  blocTest<GitSyncBloc, GitSyncState>(
+    'PushChanges with addRemoteUrl adds origin before pushing',
+    build: () => GitSyncBloc(service: service),
+    act: (b) => b.add(const PushChanges(root, addRemoteUrl: 'u')),
+    verify: (b) {
+      verifyInOrder([
+        () => service.addRemote(root, 'origin', 'u'),
+        () => service.push(root),
+      ]);
+      expect(b.state.status, GitSyncStatus.ready);
+    },
+  );
+
+  blocTest<GitSyncBloc, GitSyncState>(
+    'PushChanges without addRemoteUrl never calls addRemote',
+    build: () => GitSyncBloc(service: service),
+    act: (b) => b.add(const PushChanges(root)),
+    verify: (b) {
+      verifyNever(() => service.addRemote(root, any(), any()));
+      verify(() => service.push(root)).called(1);
+    },
+  );
+
+  blocTest<GitSyncBloc, GitSyncState>(
+    'FetchRemote with addRemoteUrl adds origin before fetching',
+    build: () => GitSyncBloc(service: service),
+    act: (b) => b.add(const FetchRemote(root, addRemoteUrl: 'u')),
+    verify: (b) {
+      verifyInOrder([
+        () => service.addRemote(root, 'origin', 'u'),
+        () => service.fetch(root),
+      ]);
+      expect(b.state.status, GitSyncStatus.ready);
     },
   );
 

--- a/test/features/collections/presentation/bloc/git_sync_bloc_test.dart
+++ b/test/features/collections/presentation/bloc/git_sync_bloc_test.dart
@@ -219,6 +219,41 @@ void main() {
     },
   );
 
+  // FIX C2: a conflicted pull only bumps conflictToken, never reloadToken —
+  // BranchSyncListener reloads solely on reloadToken, so without this event
+  // the resolved files sit on disk while the app's Hive tree stays pre-pull.
+  blocTest<GitSyncBloc, GitSyncState>(
+    'ConflictsResolved bumps reloadToken and reaches a terminal ready state',
+    build: () => GitSyncBloc(service: service),
+    act: (b) => b.add(const ConflictsResolved(root)),
+    verify: (b) {
+      expect(b.state.status, GitSyncStatus.ready);
+      expect(b.state.reloadToken, 1);
+      expect(b.state.branch.current, 'main');
+    },
+  );
+
+  blocTest<GitSyncBloc, GitSyncState>(
+    'ConflictsResolved dispatched while busy is dropped',
+    build: () {
+      pullGate = Completer<PullOutcome>();
+      when(() => service.pull(root)).thenAnswer((_) => pullGate.future);
+      return GitSyncBloc(service: service);
+    },
+    act: (b) async {
+      b.add(const PullChanges(root));
+      await Future<void>.delayed(Duration.zero);
+      b.add(const ConflictsResolved(root)); // dropped: bloc is busy
+      pullGate.complete(PullOutcome.conflicted);
+      await Future<void>.delayed(Duration.zero);
+    },
+    verify: (b) {
+      expect(b.state.status, GitSyncStatus.ready);
+      expect(b.state.conflictToken, 1);
+      expect(b.state.reloadToken, 0); // the dropped event never bumped it
+    },
+  );
+
   blocTest<GitSyncBloc, GitSyncState>(
     'PushChanges does not bump reloadToken (disk is unchanged)',
     build: () => GitSyncBloc(service: service),

--- a/test/features/collections/presentation/bloc/pull_requests_bloc_test.dart
+++ b/test/features/collections/presentation/bloc/pull_requests_bloc_test.dart
@@ -1,0 +1,185 @@
+import 'dart:async';
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/features/collections/domain/entities/pull_request.dart';
+import 'package:getman/features/collections/domain/pull_request_service.dart';
+import 'package:getman/features/collections/presentation/bloc/pull_requests_bloc.dart';
+import 'package:getman/features/collections/presentation/bloc/pull_requests_event.dart';
+import 'package:getman/features/collections/presentation/bloc/pull_requests_state.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockService extends Mock implements PullRequestService {}
+
+void main() {
+  const root = '/ws';
+  late _MockService service;
+
+  setUp(() => service = _MockService());
+
+  blocTest<PullRequestsBloc, PullRequestsState>(
+    'LoadPullRequests: available → loads PRs',
+    build: () {
+      when(
+        () => service.availability(root),
+      ).thenAnswer((_) async => GhAvailability.available);
+      when(() => service.list(root)).thenAnswer(
+        (_) async => const [
+          PullRequestEntity(
+            number: 1,
+            title: 't',
+            state: PrState.open,
+            url: 'u',
+            isDraft: false,
+            checks: PrChecks.passing,
+          ),
+        ],
+      );
+      return PullRequestsBloc(service: service);
+    },
+    act: (b) => b.add(const LoadPullRequests(root)),
+    expect: () => [
+      isA<PullRequestsState>().having(
+        (s) => s.status,
+        'status',
+        PrStatus.loading,
+      ),
+      isA<PullRequestsState>()
+          .having((s) => s.status, 'status', PrStatus.ready)
+          .having(
+            (s) => s.availability,
+            'availability',
+            GhAvailability.available,
+          )
+          .having((s) => s.prs.length, 'prs', 1),
+    ],
+  );
+
+  blocTest<PullRequestsBloc, PullRequestsState>(
+    'LoadPullRequests: notInstalled → ready with availability, no list call',
+    build: () {
+      when(
+        () => service.availability(root),
+      ).thenAnswer((_) async => GhAvailability.notInstalled);
+      return PullRequestsBloc(service: service);
+    },
+    act: (b) => b.add(const LoadPullRequests(root)),
+    expect: () => [
+      isA<PullRequestsState>().having(
+        (s) => s.status,
+        'status',
+        PrStatus.loading,
+      ),
+      isA<PullRequestsState>()
+          .having((s) => s.status, 'status', PrStatus.ready)
+          .having(
+            (s) => s.availability,
+            'availability',
+            GhAvailability.notInstalled,
+          ),
+    ],
+    verify: (_) => verifyNever(() => service.list(any())),
+  );
+
+  blocTest<PullRequestsBloc, PullRequestsState>(
+    'CreatePullRequest: creates, then reloads the list',
+    build: () {
+      when(
+        () => service.availability(root),
+      ).thenAnswer((_) async => GhAvailability.available);
+      when(
+        () => service.create(
+          root,
+          base: any(named: 'base'),
+          title: any(named: 'title'),
+          body: any(named: 'body'),
+          draft: any(named: 'draft'),
+        ),
+      ).thenAnswer(
+        (_) async => const PullRequestRef(number: 9, url: 'u/pull/9'),
+      );
+      when(() => service.list(root)).thenAnswer((_) async => const []);
+      return PullRequestsBloc(service: service);
+    },
+    act: (b) => b.add(
+      const CreatePullRequest(
+        root,
+        base: 'main',
+        title: 't',
+        body: 'b',
+        draft: false,
+      ),
+    ),
+    expect: () => [
+      isA<PullRequestsState>().having(
+        (s) => s.status,
+        'status',
+        PrStatus.creating,
+      ),
+      isA<PullRequestsState>()
+          .having((s) => s.lastCreated?.number, 'lastCreated', 9)
+          .having((s) => s.status, 'status', PrStatus.ready),
+    ],
+    verify: (_) {
+      verify(
+        () => service.create(
+          root,
+          base: 'main',
+          title: 't',
+          body: 'b',
+          draft: false,
+        ),
+      ).called(1);
+      verify(() => service.list(root)).called(1);
+    },
+  );
+
+  test('a second load is dropped while the first is in flight', () async {
+    // Non-vacuous: gate the first load open so it's still busy when the second
+    // arrives. Removing the `_dropWhileBusy` guard makes availability() run
+    // twice, which `.called(1)` catches (the duplicate emits alone would be
+    // suppressed by Equatable, so the call-count is the real proof).
+    final gate = Completer<void>();
+    when(() => service.availability(root)).thenAnswer((_) async {
+      await gate.future;
+      return GhAvailability.available;
+    });
+    when(() => service.list(root)).thenAnswer((_) async => const []);
+    final bloc = PullRequestsBloc(service: service);
+    final statuses = <PrStatus>[];
+    final sub = bloc.stream.listen((s) => statuses.add(s.status));
+
+    bloc.add(const LoadPullRequests(root));
+    await Future<void>.delayed(Duration.zero); // first handler emits loading
+    bloc.add(const LoadPullRequests(root)); // dropped: state is busy
+    gate.complete();
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+    await sub.cancel();
+    await bloc.close();
+
+    expect(statuses, [PrStatus.loading, PrStatus.ready]);
+    verify(() => service.availability(root)).called(1);
+  });
+
+  blocTest<PullRequestsBloc, PullRequestsState>(
+    'a service failure surfaces as an error state',
+    build: () {
+      when(
+        () => service.availability(root),
+      ).thenAnswer((_) async => GhAvailability.available);
+      when(() => service.list(root)).thenThrow(Exception('boom'));
+      return PullRequestsBloc(service: service);
+    },
+    act: (b) => b.add(const LoadPullRequests(root)),
+    expect: () => [
+      isA<PullRequestsState>().having(
+        (s) => s.status,
+        'status',
+        PrStatus.loading,
+      ),
+      isA<PullRequestsState>()
+          .having((s) => s.status, 'status', PrStatus.error)
+          .having((s) => s.errorMessage, 'errorMessage', isNotNull),
+    ],
+  );
+}

--- a/test/features/collections/presentation/bloc/pull_requests_bloc_test.dart
+++ b/test/features/collections/presentation/bloc/pull_requests_bloc_test.dart
@@ -15,7 +15,12 @@ void main() {
   const root = '/ws';
   late _MockService service;
 
-  setUp(() => service = _MockService());
+  setUp(() {
+    service = _MockService();
+    // _onLoad resolves the default base on the available path; give every test
+    // a benign default (specific tests override it).
+    when(() => service.defaultBase(root)).thenAnswer((_) async => 'main');
+  });
 
   blocTest<PullRequestsBloc, PullRequestsState>(
     'LoadPullRequests: available → loads PRs',
@@ -180,6 +185,68 @@ void main() {
       isA<PullRequestsState>()
           .having((s) => s.status, 'status', PrStatus.error)
           .having((s) => s.errorMessage, 'errorMessage', isNotNull),
+    ],
+  );
+
+  blocTest<PullRequestsBloc, PullRequestsState>(
+    'LoadPullRequests resolves the default base for the create form',
+    build: () {
+      when(
+        () => service.availability(root),
+      ).thenAnswer((_) async => GhAvailability.available);
+      when(() => service.list(root)).thenAnswer((_) async => const []);
+      when(() => service.defaultBase(root)).thenAnswer((_) async => 'develop');
+      return PullRequestsBloc(service: service);
+    },
+    act: (b) => b.add(const LoadPullRequests(root)),
+    expect: () => [
+      isA<PullRequestsState>().having(
+        (s) => s.status,
+        'status',
+        PrStatus.loading,
+      ),
+      isA<PullRequestsState>()
+          .having((s) => s.status, 'status', PrStatus.ready)
+          .having((s) => s.defaultBase, 'defaultBase', 'develop'),
+    ],
+  );
+
+  blocTest<PullRequestsBloc, PullRequestsState>(
+    'a created PR is surfaced even when the list refresh fails',
+    build: () {
+      when(
+        () => service.create(
+          root,
+          base: any(named: 'base'),
+          title: any(named: 'title'),
+          body: any(named: 'body'),
+          draft: any(named: 'draft'),
+        ),
+      ).thenAnswer(
+        (_) async => const PullRequestRef(number: 3, url: 'u/pull/3'),
+      );
+      when(() => service.list(root)).thenThrow(Exception('list boom'));
+      return PullRequestsBloc(service: service);
+    },
+    act: (b) => b.add(
+      const CreatePullRequest(
+        root,
+        base: 'main',
+        title: 't',
+        body: '',
+        draft: false,
+      ),
+    ),
+    // Refresh failed, but the PR exists → ready + lastCreated, NOT an error.
+    expect: () => [
+      isA<PullRequestsState>().having(
+        (s) => s.status,
+        'status',
+        PrStatus.creating,
+      ),
+      isA<PullRequestsState>()
+          .having((s) => s.status, 'status', PrStatus.ready)
+          .having((s) => s.lastCreated?.number, 'lastCreated', 3),
     ],
   );
 }

--- a/test/features/collections/presentation/bloc/review_bloc_test.dart
+++ b/test/features/collections/presentation/bloc/review_bloc_test.dart
@@ -1,5 +1,6 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/core/git/git_service.dart' show GitException;
 import 'package:getman/features/collections/domain/entities/review_entry.dart';
 import 'package:getman/features/collections/domain/logic/semantic_diff.dart';
 import 'package:getman/features/collections/domain/review_service.dart';
@@ -56,7 +57,14 @@ void main() {
     when(() => service.review(root)).thenAnswer((_) async => result);
     when(() => service.stage(root, any())).thenAnswer((_) async {});
     when(() => service.unstage(root, any())).thenAnswer((_) async {});
-    when(() => service.commit(root, any())).thenAnswer((_) async {});
+    when(
+      () => service.commit(
+        root,
+        any(),
+        authorName: any(named: 'authorName'),
+        authorEmail: any(named: 'authorEmail'),
+      ),
+    ).thenAnswer((_) async {});
   });
 
   blocTest<ReviewBloc, ReviewState>(
@@ -135,8 +143,47 @@ void main() {
       b.add(const Commit(root, 'msg'));
     },
     verify: (b) {
-      verify(() => service.commit(root, 'msg')).called(1);
+      verify(
+        () => service.commit(
+          root,
+          'msg',
+          authorName: any(named: 'authorName'),
+          authorEmail: any(named: 'authorEmail'),
+        ),
+      ).called(1);
     },
+  );
+
+  blocTest<ReviewBloc, ReviewState>(
+    'Commit failing with a missing-identity GitException → needsIdentity',
+    build: () {
+      when(
+        () => service.commit(
+          root,
+          any(),
+          authorName: any(named: 'authorName'),
+          authorEmail: any(named: 'authorEmail'),
+        ),
+      ).thenThrow(
+        GitException(
+          '*** Please tell me who you are.\n\nRun git config...',
+        ),
+      );
+      return ReviewBloc(service: service);
+    },
+    act: (b) => b.add(const Commit(root, 'msg')),
+    expect: () => [
+      isA<ReviewState>().having(
+        (s) => s.status,
+        'status',
+        ReviewStatus.committing,
+      ),
+      isA<ReviewState>().having(
+        (s) => s.status,
+        'status',
+        ReviewStatus.needsIdentity,
+      ),
+    ],
   );
 
   blocTest<ReviewBloc, ReviewState>(

--- a/test/features/collections/presentation/bloc/review_bloc_test.dart
+++ b/test/features/collections/presentation/bloc/review_bloc_test.dart
@@ -187,6 +187,34 @@ void main() {
   );
 
   blocTest<ReviewBloc, ReviewState>(
+    'Commit failing with a non-identity GitException → error, not '
+    'needsIdentity',
+    build: () {
+      when(
+        () => service.commit(
+          root,
+          any(),
+          authorName: any(named: 'authorName'),
+          authorEmail: any(named: 'authorEmail'),
+        ),
+      ).thenThrow(GitException('some other git failure'));
+      return ReviewBloc(service: service);
+    },
+    act: (b) => b.add(const Commit(root, 'msg')),
+    expect: () => [
+      isA<ReviewState>().having(
+        (s) => s.status,
+        'status',
+        ReviewStatus.committing,
+      ),
+      isA<ReviewState>().having((s) => s.status, 'status', ReviewStatus.error),
+    ],
+    verify: (b) {
+      expect(b.state.errorMessage, contains('some other git failure'));
+    },
+  );
+
+  blocTest<ReviewBloc, ReviewState>(
     'review failure → error status',
     build: () {
       when(() => service.review(root)).thenThrow(Exception('boom'));

--- a/test/features/collections/presentation/widgets/branch_chip_test.dart
+++ b/test/features/collections/presentation/widgets/branch_chip_test.dart
@@ -137,6 +137,30 @@ void main() {
     verify(() => bloc.add(const PullChanges(root))).called(1);
   });
 
+  testWidgets('FETCH dispatches FetchRemote', (tester) async {
+    await tester.pumpWidget(
+      host(
+        const GitSyncState(
+          status: GitSyncStatus.ready,
+          branch: BranchStatus(
+            isRepo: true,
+            current: 'main',
+            branches: ['main'],
+            hasRemote: true,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('branch_chip')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('branch_menu_fetch')));
+    await tester.pumpAndSettle();
+
+    verify(() => bloc.add(const FetchRemote(root))).called(1);
+  });
+
   testWidgets('a dirty-switch error shows the commit/stash prompt', (
     tester,
   ) async {

--- a/test/features/collections/presentation/widgets/branch_chip_test.dart
+++ b/test/features/collections/presentation/widgets/branch_chip_test.dart
@@ -137,6 +137,77 @@ void main() {
     verify(() => bloc.add(const PullChanges(root))).called(1);
   });
 
+  testWidgets('PUSH dispatches PushChanges when a remote exists', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      host(
+        const GitSyncState(
+          status: GitSyncStatus.ready,
+          branch: BranchStatus(
+            isRepo: true,
+            current: 'main',
+            branches: ['main'],
+            hasRemote: true,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('branch_chip')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('branch_menu_push')));
+    await tester.pumpAndSettle();
+
+    verify(() => bloc.add(const PushChanges(root))).called(1);
+  });
+
+  testWidgets(
+    'PUSH with no remote opens the ADD REMOTE prompt; confirming dispatches '
+    'PushChanges with addRemoteUrl',
+    (tester) async {
+      await tester.pumpWidget(
+        host(
+          const GitSyncState(
+            status: GitSyncStatus.ready,
+            branch: BranchStatus(
+              isRepo: true,
+              current: 'main',
+              branches: ['main'],
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const ValueKey('branch_chip')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('branch_menu_push')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('ADD REMOTE'), findsWidgets);
+      expect(find.byKey(const ValueKey('name_prompt_field')), findsOneWidget);
+
+      await tester.enterText(
+        find.byKey(const ValueKey('name_prompt_field')),
+        'https://example.invalid/x/y.git',
+      );
+      await tester.pump();
+      await tester.tap(find.widgetWithText(TextButton, 'ADD REMOTE'));
+      await tester.pumpAndSettle();
+
+      verify(
+        () => bloc.add(
+          const PushChanges(
+            root,
+            addRemoteUrl: 'https://example.invalid/x/y.git',
+          ),
+        ),
+      ).called(1);
+    },
+  );
+
   testWidgets('FETCH dispatches FetchRemote', (tester) async {
     await tester.pumpWidget(
       host(

--- a/test/features/collections/presentation/widgets/branch_chip_test.dart
+++ b/test/features/collections/presentation/widgets/branch_chip_test.dart
@@ -28,6 +28,13 @@ void main() {
   late _MockGitSyncBloc bloc;
   late _MockSettingsBloc settings;
 
+  setUpAll(() {
+    // Needed for `captureAny()` on `bloc.add(...)` in the PULL-no-remote
+    // test below — mocktail requires a registered fallback for any type
+    // used with `any`/`captureAny`.
+    registerFallbackValue(const LoadBranchStatus(root));
+  });
+
   setUp(() {
     bloc = _MockGitSyncBloc();
     settings = _MockSettingsBloc();
@@ -208,6 +215,54 @@ void main() {
     },
   );
 
+  testWidgets(
+    'PULL with no remote opens the ADD REMOTE prompt; confirming dispatches '
+    'PullChanges with addRemoteUrl',
+    (tester) async {
+      await tester.pumpWidget(
+        host(
+          const GitSyncState(
+            status: GitSyncStatus.ready,
+            branch: BranchStatus(
+              isRepo: true,
+              current: 'main',
+              branches: ['main'],
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const ValueKey('branch_chip')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('branch_menu_pull')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('ADD REMOTE'), findsWidgets);
+      expect(find.byKey(const ValueKey('name_prompt_field')), findsOneWidget);
+
+      await tester.enterText(
+        find.byKey(const ValueKey('name_prompt_field')),
+        'https://example.invalid/x/y.git',
+      );
+      await tester.pump();
+      await tester.tap(find.widgetWithText(TextButton, 'ADD REMOTE'));
+      await tester.pumpAndSettle();
+
+      final captured = verify(
+        () => bloc.add(captureAny(that: isA<PullChanges>())),
+      ).captured;
+      expect(captured, hasLength(1));
+      final event = captured.single as PullChanges;
+      expect(event.root, root);
+      expect(event.addRemoteUrl, 'https://example.invalid/x/y.git');
+      // Identity fields are threaded through from SettingsBloc, exactly as
+      // the hasRemote-true PULL path does.
+      expect(event.authorName, settings.state.settings.gitUserName);
+      expect(event.authorEmail, settings.state.settings.gitUserEmail);
+    },
+  );
+
   testWidgets('FETCH dispatches FetchRemote', (tester) async {
     await tester.pumpWidget(
       host(
@@ -231,6 +286,51 @@ void main() {
 
     verify(() => bloc.add(const FetchRemote(root))).called(1);
   });
+
+  testWidgets(
+    'FETCH with no remote opens the ADD REMOTE prompt; confirming dispatches '
+    'FetchRemote with addRemoteUrl',
+    (tester) async {
+      await tester.pumpWidget(
+        host(
+          const GitSyncState(
+            status: GitSyncStatus.ready,
+            branch: BranchStatus(
+              isRepo: true,
+              current: 'main',
+              branches: ['main'],
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const ValueKey('branch_chip')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('branch_menu_fetch')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('ADD REMOTE'), findsWidgets);
+      expect(find.byKey(const ValueKey('name_prompt_field')), findsOneWidget);
+
+      await tester.enterText(
+        find.byKey(const ValueKey('name_prompt_field')),
+        'https://example.invalid/x/y.git',
+      );
+      await tester.pump();
+      await tester.tap(find.widgetWithText(TextButton, 'ADD REMOTE'));
+      await tester.pumpAndSettle();
+
+      verify(
+        () => bloc.add(
+          const FetchRemote(
+            root,
+            addRemoteUrl: 'https://example.invalid/x/y.git',
+          ),
+        ),
+      ).called(1);
+    },
+  );
 
   testWidgets('a dirty-switch error shows the commit/stash prompt', (
     tester,

--- a/test/features/collections/presentation/widgets/branch_sync_listener_test.dart
+++ b/test/features/collections/presentation/widgets/branch_sync_listener_test.dart
@@ -32,6 +32,11 @@ import 'package:getman/features/collections/presentation/widgets/workspace_sync_
 import 'package:getman/features/settings/domain/entities/settings_entity.dart';
 import 'package:getman/features/settings/domain/usecases/settings_usecases.dart';
 import 'package:getman/features/settings/presentation/bloc/settings_bloc.dart';
+import 'package:getman/features/tabs/domain/entities/panel_entity.dart';
+import 'package:getman/features/tabs/domain/entities/request_tab_entity.dart';
+import 'package:getman/features/tabs/presentation/bloc/tabs_bloc.dart';
+import 'package:getman/features/tabs/presentation/bloc/tabs_event.dart';
+import 'package:getman/features/tabs/presentation/bloc/tabs_state.dart';
 import 'package:mocktail/mocktail.dart';
 
 class _MockGitSyncBloc extends MockBloc<GitSyncEvent, GitSyncState>
@@ -39,6 +44,9 @@ class _MockGitSyncBloc extends MockBloc<GitSyncEvent, GitSyncState>
 
 class _MockCollectionsBloc extends MockBloc<CollectionsEvent, CollectionsState>
     implements CollectionsBloc {}
+
+class _MockTabsBloc extends MockBloc<TabsEvent, TabsState>
+    implements TabsBloc {}
 
 class _MockDataSource extends Mock implements WorkspaceCollectionsDataSource {}
 
@@ -88,6 +96,11 @@ void main() {
     bool withMirroring = false,
   }) {
     const listener = BranchSyncListener(child: SizedBox());
+    // BranchSyncListener reads TabsBloc to refresh open tabs after a reload;
+    // an empty panels state makes that a no-op for these collection-focused
+    // tests (the tab-refresh logic is unit-tested separately below).
+    final tabs = _MockTabsBloc();
+    when(() => tabs.state).thenReturn(const TabsState());
     return MaterialApp(
       home: RepositoryProvider<WorkspaceSyncService>.value(
         value: sync,
@@ -96,6 +109,7 @@ void main() {
             BlocProvider<GitSyncBloc>.value(value: gitSync),
             BlocProvider<CollectionsBloc>.value(value: collections),
             BlocProvider<SettingsBloc>.value(value: settings),
+            BlocProvider<TabsBloc>.value(value: tabs),
           ],
           child: withMirroring
               // The real mirroring listener sits above in main.dart — this is
@@ -341,5 +355,91 @@ void main() {
       reason: "the old branch's forest was mirrored onto the new branch",
     );
     expect(collections.state.collections.single.name, 'From disk');
+  });
+
+  group('tabsToRefreshAfterReload', () {
+    HttpRequestConfigEntity cfg(String id, {String url = 'a'}) =>
+        HttpRequestConfigEntity(id: id, url: url);
+    HttpRequestTabEntity tab(
+      String tabId,
+      HttpRequestConfigEntity config, {
+      String? nodeId,
+    }) => HttpRequestTabEntity(
+      config: config,
+      tabId: tabId,
+      collectionNodeId: nodeId,
+    );
+    List<PanelEntity> panels(List<HttpRequestTabEntity> tabs) => [
+      PanelEntity(id: 'p1', name: 'Panel 1', tabs: tabs, activeTabId: ''),
+    ];
+
+    test('refreshes a clean linked tab whose request changed upstream', () {
+      final result = tabsToRefreshAfterReload(
+        panels([tab('t1', cfg('c1', url: 'old'), nodeId: 'n1')]),
+        {'n1': cfg('c1', url: 'old')},
+        {'n1': cfg('c1', url: 'new')},
+      );
+      expect(result, hasLength(1));
+      expect(result.single.tabId, 't1');
+      expect(result.single.config.url, 'new');
+    });
+
+    test('leaves a tab with unsaved edits untouched (never clobbers)', () {
+      final result = tabsToRefreshAfterReload(
+        panels([tab('t1', cfg('c1', url: 'mine'), nodeId: 'n1')]),
+        {'n1': cfg('c1', url: 'old')},
+        {'n1': cfg('c1', url: 'new')},
+      );
+      expect(result, isEmpty);
+    });
+
+    test('ignores an unlinked tab (no collectionNodeId)', () {
+      final result = tabsToRefreshAfterReload(
+        panels([tab('t1', cfg('c1', url: 'old'))]),
+        {'n1': cfg('c1', url: 'old')},
+        {'n1': cfg('c1', url: 'new')},
+      );
+      expect(result, isEmpty);
+    });
+
+    test('leaves a tab whose node was deleted upstream', () {
+      final result = tabsToRefreshAfterReload(
+        panels([tab('t1', cfg('c1', url: 'old'), nodeId: 'n1')]),
+        {'n1': cfg('c1', url: 'old')},
+        const {},
+      );
+      expect(result, isEmpty);
+    });
+
+    test('does not touch a clean tab whose request did not change', () {
+      final result = tabsToRefreshAfterReload(
+        panels([tab('t1', cfg('c1', url: 'same'), nodeId: 'n1')]),
+        {'n1': cfg('c1', url: 'same')},
+        {'n1': cfg('c1', url: 'same')},
+      );
+      expect(result, isEmpty);
+    });
+
+    test('reconciles tabs across every panel, not just the active one', () {
+      final result = tabsToRefreshAfterReload(
+        [
+          PanelEntity(
+            id: 'p1',
+            name: 'Panel 1',
+            tabs: [tab('t1', cfg('c1', url: 'old'), nodeId: 'n1')],
+            activeTabId: 't1',
+          ),
+          PanelEntity(
+            id: 'p2',
+            name: 'Panel 2',
+            tabs: [tab('t2', cfg('c2', url: 'x'), nodeId: 'n2')],
+            activeTabId: 't2',
+          ),
+        ],
+        {'n1': cfg('c1', url: 'old'), 'n2': cfg('c2', url: 'x')},
+        {'n1': cfg('c1', url: 'new'), 'n2': cfg('c2', url: 'y')},
+      );
+      expect(result.map((t) => t.tabId), containsAll(['t1', 't2']));
+    });
   });
 }

--- a/test/features/collections/presentation/widgets/conflict_resolution_dialog_test.dart
+++ b/test/features/collections/presentation/widgets/conflict_resolution_dialog_test.dart
@@ -334,6 +334,101 @@ void main() {
     expect(find.byKey(const ValueKey('conflict_cancel')), findsNothing);
   });
 
+  testWidgets(
+    'CANCEL does not show the "Conflicts resolved." snackbar when the '
+    'abort resolves to done',
+    (tester) async {
+      final controller = StreamController<ConflictState>();
+      whenListen(
+        conflictBloc,
+        controller.stream,
+        initialState: const ConflictState(status: ConflictStatus.ready),
+      );
+
+      await openDialog(tester);
+      await tester.tap(find.byKey(const ValueKey('conflict_cancel')));
+      // Deliberately don't settle: the dialog's exit transition is still
+      // running (still mounted), mirroring the real race where AbortRebase
+      // resolves to `done` before the pop animation finishes.
+      controller.add(const ConflictState(status: ConflictStatus.done));
+      await tester.pump();
+      await tester.pumpAndSettle();
+
+      verify(() => conflictBloc.add(const AbortRebase(root))).called(1);
+      expect(find.text('Conflicts resolved.'), findsNothing);
+      verifyNever(() => gitBloc.add(const LoadBranchStatus(root)));
+      await controller.close();
+    },
+  );
+
+  testWidgets(
+    'reusing a row position across a batch transition (body conflict then '
+    'a non-body conflict) does not crash on TAKE INCOMING',
+    (tester) async {
+      const batch1 = [
+        FileConflict(
+          path: 'r1.req.json',
+          kind: ConflictKind.request,
+          node: NodeMergeResult(
+            merged: _node,
+            conflicts: [
+              FieldConflict(
+                field: 'body',
+                kind: FieldConflictKind.scalar,
+                incoming: '{"a":1}',
+                yours: '{"a":2}',
+              ),
+            ],
+          ),
+        ),
+      ];
+      const batch2 = [
+        FileConflict(
+          path: 'r1.req.json',
+          kind: ConflictKind.request,
+          node: NodeMergeResult(
+            merged: _node,
+            conflicts: [
+              FieldConflict(
+                field: 'url',
+                kind: FieldConflictKind.scalar,
+                incoming: 'https://a.example',
+                yours: 'https://b.example',
+              ),
+            ],
+          ),
+        ),
+      ];
+      final controller = StreamController<ConflictState>();
+      whenListen(
+        conflictBloc,
+        controller.stream,
+        initialState: const ConflictState(
+          status: ConflictStatus.ready,
+          conflicts: batch1,
+        ),
+      );
+
+      await openDialog(tester);
+      controller.add(
+        const ConflictState(
+          status: ConflictStatus.ready,
+          conflicts: batch2,
+          batch: 1,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(
+        find.byKey(const ValueKey('take_incoming_r1.req.json_url')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      await controller.close();
+    },
+  );
+
   testWidgets('a done status closes the dialog and refreshes branch status', (
     tester,
   ) async {

--- a/test/features/collections/presentation/widgets/conflict_resolution_dialog_test.dart
+++ b/test/features/collections/presentation/widgets/conflict_resolution_dialog_test.dart
@@ -203,44 +203,87 @@ void main() {
     },
   );
 
-  testWidgets(
-    'a coarse deleteModify conflict shows the labelled choices and sets '
-    'wholeFile',
-    (tester) async {
-      const conflicts = [
-        FileConflict(
-          path: 'r2.req.json',
-          kind: ConflictKind.deleteModify,
-        ),
-      ];
-      when(() => conflictBloc.state).thenReturn(
-        const ConflictState(
-          status: ConflictStatus.ready,
-          conflicts: conflicts,
-        ),
-      );
+  // FIX C1: the coarse deleteModify tile used to hardcode "Accept the
+  // deletion" to the incoming button and "Keep your edited request" to the
+  // yours button — correct only when upstream deleted (Case A). When YOU
+  // deleted (Case B: stage 3 absent, deletedSide=yours), that hardcoding
+  // put "Accept the deletion" on the button that actually resolves to
+  // wholeFile: incoming (the PRESENT stage — writes the file back) and
+  // "Keep your edited request" on the button that resolves to wholeFile:
+  // yours (the ABSENT stage — deletes it): exactly inverted. These four
+  // cases (both labels x both orientations) pin the fix by tapping on the
+  // button *text*, not a positional key, so a regression back to hardcoded
+  // labels fails loudly.
+  for (final side in [FileSide.incoming, FileSide.yours]) {
+    final otherSide = side == FileSide.incoming
+        ? FileSide.yours
+        : FileSide.incoming;
+    final orientation = side == FileSide.incoming
+        ? 'Case A (upstream deleted)'
+        : 'Case B (you deleted)';
 
-      await openDialog(tester);
+    testWidgets(
+      '$orientation: tapping "Accept the deletion" resolves to the '
+      'deleting side ($side)',
+      (tester) async {
+        final conflicts = [
+          FileConflict(
+            path: 'r2.req.json',
+            kind: ConflictKind.deleteModify,
+            deletedSide: side,
+          ),
+        ];
+        when(() => conflictBloc.state).thenReturn(
+          ConflictState(status: ConflictStatus.ready, conflicts: conflicts),
+        );
 
-      expect(find.text('Accept the deletion'), findsOneWidget);
-      expect(find.text('Keep your edited request'), findsOneWidget);
+        await openDialog(tester);
+        await tester.tap(find.text('Accept the deletion'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.byKey(const ValueKey('conflict_resolve')));
+        await tester.pumpAndSettle();
 
-      await tester.tap(
-        find.byKey(const ValueKey('keep_yours_r2.req.json')),
-      );
-      await tester.pumpAndSettle();
-      await tester.tap(find.byKey(const ValueKey('conflict_resolve')));
-      await tester.pumpAndSettle();
+        verify(
+          () => conflictBloc.add(
+            ResolveAndContinue(root, [
+              FileResolution(path: 'r2.req.json', wholeFile: side),
+            ]),
+          ),
+        ).called(1);
+      },
+    );
 
-      verify(
-        () => conflictBloc.add(
-          const ResolveAndContinue(root, [
-            FileResolution(path: 'r2.req.json', wholeFile: FileSide.yours),
-          ]),
-        ),
-      ).called(1);
-    },
-  );
+    testWidgets(
+      '$orientation: tapping "Keep the edited request" resolves to the '
+      'surviving side ($otherSide)',
+      (tester) async {
+        final conflicts = [
+          FileConflict(
+            path: 'r2.req.json',
+            kind: ConflictKind.deleteModify,
+            deletedSide: side,
+          ),
+        ];
+        when(() => conflictBloc.state).thenReturn(
+          ConflictState(status: ConflictStatus.ready, conflicts: conflicts),
+        );
+
+        await openDialog(tester);
+        await tester.tap(find.text('Keep the edited request'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.byKey(const ValueKey('conflict_resolve')));
+        await tester.pumpAndSettle();
+
+        verify(
+          () => conflictBloc.add(
+            ResolveAndContinue(root, [
+              FileResolution(path: 'r2.req.json', wholeFile: otherSide),
+            ]),
+          ),
+        ).called(1);
+      },
+    );
+  }
 
   testWidgets('RESOLVE is disabled until every conflict has a pick', (
     tester,
@@ -319,24 +362,14 @@ void main() {
     ).called(1);
   });
 
-  testWidgets('CANCEL dispatches AbortRebase and closes the dialog', (
-    tester,
-  ) async {
-    when(
-      () => conflictBloc.state,
-    ).thenReturn(const ConflictState(status: ConflictStatus.ready));
-
-    await openDialog(tester);
-    await tester.tap(find.byKey(const ValueKey('conflict_cancel')));
-    await tester.pumpAndSettle();
-
-    verify(() => conflictBloc.add(const AbortRebase(root))).called(1);
-    expect(find.byKey(const ValueKey('conflict_cancel')), findsNothing);
-  });
-
+  // FIX M1: CANCEL used to pop immediately, so an AbortRebase failure would
+  // surface on a dead (deactivated) context with the rebase still in
+  // progress and no UI to retry from. Now _cancel dispatches AbortRebase and
+  // waits — the dialog only pops once the abort actually resolves to `done`,
+  // and stays open (with the GIT ERROR dialog on top) if the abort fails.
   testWidgets(
-    'CANCEL does not show the "Conflicts resolved." snackbar when the '
-    'abort resolves to done',
+    'CANCEL dispatches AbortRebase but keeps the dialog open until the '
+    'abort resolves',
     (tester) async {
       final controller = StreamController<ConflictState>();
       whenListen(
@@ -347,16 +380,76 @@ void main() {
 
       await openDialog(tester);
       await tester.tap(find.byKey(const ValueKey('conflict_cancel')));
-      // Deliberately don't settle: the dialog's exit transition is still
-      // running (still mounted), mirroring the real race where AbortRebase
-      // resolves to `done` before the pop animation finishes.
+      await tester.pump();
+
+      verify(() => conflictBloc.add(const AbortRebase(root))).called(1);
+      // Still open: the abort hasn't resolved yet.
+      expect(find.byKey(const ValueKey('conflict_cancel')), findsOneWidget);
+
+      controller.add(const ConflictState(status: ConflictStatus.done));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const ValueKey('conflict_cancel')), findsNothing);
+      await controller.close();
+    },
+  );
+
+  testWidgets(
+    'CANCEL does not show the "Conflicts resolved." snackbar or reload the '
+    'tree when the abort resolves to done',
+    (tester) async {
+      final controller = StreamController<ConflictState>();
+      whenListen(
+        conflictBloc,
+        controller.stream,
+        initialState: const ConflictState(status: ConflictStatus.ready),
+      );
+
+      await openDialog(tester);
+      await tester.tap(find.byKey(const ValueKey('conflict_cancel')));
+      await tester.pump();
       controller.add(const ConflictState(status: ConflictStatus.done));
       await tester.pump();
       await tester.pumpAndSettle();
 
       verify(() => conflictBloc.add(const AbortRebase(root))).called(1);
       expect(find.text('Conflicts resolved.'), findsNothing);
+      verifyNever(() => gitBloc.add(const ConflictsResolved(root)));
       verifyNever(() => gitBloc.add(const LoadBranchStatus(root)));
+      await controller.close();
+    },
+  );
+
+  testWidgets(
+    'an AbortRebase failure surfaces the GIT ERROR dialog and leaves the '
+    'resolver open for a retry',
+    (tester) async {
+      final controller = StreamController<ConflictState>();
+      whenListen(
+        conflictBloc,
+        controller.stream,
+        initialState: const ConflictState(status: ConflictStatus.ready),
+      );
+
+      await openDialog(tester);
+      await tester.tap(find.byKey(const ValueKey('conflict_cancel')));
+      await tester.pump();
+      controller.add(
+        const ConflictState(
+          status: ConflictStatus.error,
+          errorMessage: 'abort failed',
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const ValueKey('conflict_error_dialog')),
+        findsOneWidget,
+      );
+      // The resolver itself is still mounted underneath — the user can
+      // dismiss the error and retry CANCEL (or resolve normally) instead of
+      // being left with a wedged rebase and no UI.
+      expect(find.byKey(const ValueKey('conflict_cancel')), findsOneWidget);
       await controller.close();
     },
   );
@@ -429,24 +522,29 @@ void main() {
     },
   );
 
-  testWidgets('a done status closes the dialog and refreshes branch status', (
-    tester,
-  ) async {
-    final controller = StreamController<ConflictState>();
-    whenListen(
-      conflictBloc,
-      controller.stream,
-      initialState: const ConflictState(status: ConflictStatus.ready),
-    );
+  testWidgets(
+    'a done status (non-abort) closes the dialog, shows the resolved '
+    'snackbar, and dispatches ConflictsResolved — FIX C2: this must reload '
+    'the tree, not just refresh branch status',
+    (tester) async {
+      final controller = StreamController<ConflictState>();
+      whenListen(
+        conflictBloc,
+        controller.stream,
+        initialState: const ConflictState(status: ConflictStatus.ready),
+      );
 
-    await openDialog(tester);
-    controller.add(const ConflictState(status: ConflictStatus.done));
-    await tester.pumpAndSettle();
+      await openDialog(tester);
+      controller.add(const ConflictState(status: ConflictStatus.done));
+      await tester.pumpAndSettle();
 
-    expect(find.byKey(const ValueKey('conflict_cancel')), findsNothing);
-    verify(() => gitBloc.add(const LoadBranchStatus(root))).called(1);
-    await controller.close();
-  });
+      expect(find.byKey(const ValueKey('conflict_cancel')), findsNothing);
+      expect(find.text('Conflicts resolved.'), findsOneWidget);
+      verify(() => gitBloc.add(const ConflictsResolved(root))).called(1);
+      verifyNever(() => gitBloc.add(const LoadBranchStatus(root)));
+      await controller.close();
+    },
+  );
 
   testWidgets('an error status surfaces the GIT ERROR dialog', (
     tester,

--- a/test/features/collections/presentation/widgets/conflict_resolution_dialog_test.dart
+++ b/test/features/collections/presentation/widgets/conflict_resolution_dialog_test.dart
@@ -15,6 +15,9 @@ import 'package:getman/features/collections/presentation/bloc/git_sync_bloc.dart
 import 'package:getman/features/collections/presentation/bloc/git_sync_event.dart';
 import 'package:getman/features/collections/presentation/bloc/git_sync_state.dart';
 import 'package:getman/features/collections/presentation/widgets/conflict_resolution_dialog.dart';
+import 'package:getman/features/settings/domain/entities/settings_entity.dart';
+import 'package:getman/features/settings/presentation/bloc/settings_bloc.dart';
+import 'package:getman/features/settings/presentation/bloc/settings_state.dart';
 import 'package:mocktail/mocktail.dart';
 
 class _MockConflictBloc extends MockBloc<ConflictEvent, ConflictState>
@@ -22,6 +25,8 @@ class _MockConflictBloc extends MockBloc<ConflictEvent, ConflictState>
 
 class _MockGitSyncBloc extends MockBloc<GitSyncEvent, GitSyncState>
     implements GitSyncBloc {}
+
+class _MockSettingsBloc extends Mock implements SettingsBloc {}
 
 class _FakeConflictEvent extends Fake implements ConflictEvent {}
 
@@ -43,11 +48,17 @@ void main() {
 
   late _MockConflictBloc conflictBloc;
   late _MockGitSyncBloc gitBloc;
+  late _MockSettingsBloc settingsBloc;
 
   setUp(() {
     conflictBloc = _MockConflictBloc();
     gitBloc = _MockGitSyncBloc();
     when(() => gitBloc.state).thenReturn(const GitSyncState());
+    settingsBloc = _MockSettingsBloc();
+    when(
+      () => settingsBloc.state,
+    ).thenReturn(const SettingsState(settings: SettingsEntity()));
+    when(() => settingsBloc.stream).thenAnswer((_) => const Stream.empty());
   });
 
   Widget host() {
@@ -58,6 +69,7 @@ void main() {
           providers: [
             BlocProvider<ConflictBloc>.value(value: conflictBloc),
             BlocProvider<GitSyncBloc>.value(value: gitBloc),
+            BlocProvider<SettingsBloc>.value(value: settingsBloc),
           ],
           child: Builder(
             builder: (context) => TextButton(

--- a/test/features/collections/presentation/widgets/conflict_resolution_dialog_test.dart
+++ b/test/features/collections/presentation/widgets/conflict_resolution_dialog_test.dart
@@ -1,0 +1,376 @@
+import 'dart:async';
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/core/theme/themes/brutalist/brutalist_theme.dart';
+import 'package:getman/features/collections/domain/entities/collection_node_entity.dart';
+import 'package:getman/features/collections/domain/entities/file_conflict.dart';
+import 'package:getman/features/collections/domain/logic/three_way_merge.dart';
+import 'package:getman/features/collections/presentation/bloc/conflict_bloc.dart';
+import 'package:getman/features/collections/presentation/bloc/conflict_event.dart';
+import 'package:getman/features/collections/presentation/bloc/conflict_state.dart';
+import 'package:getman/features/collections/presentation/bloc/git_sync_bloc.dart';
+import 'package:getman/features/collections/presentation/bloc/git_sync_event.dart';
+import 'package:getman/features/collections/presentation/bloc/git_sync_state.dart';
+import 'package:getman/features/collections/presentation/widgets/conflict_resolution_dialog.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockConflictBloc extends MockBloc<ConflictEvent, ConflictState>
+    implements ConflictBloc {}
+
+class _MockGitSyncBloc extends MockBloc<GitSyncEvent, GitSyncState>
+    implements GitSyncBloc {}
+
+class _FakeConflictEvent extends Fake implements ConflictEvent {}
+
+class _FakeGitSyncEvent extends Fake implements GitSyncEvent {}
+
+const _node = CollectionNodeEntity(
+  id: 'r1',
+  name: 'Get thing',
+  isFolder: false,
+);
+
+void main() {
+  const root = '/ws';
+
+  setUpAll(() {
+    registerFallbackValue(_FakeConflictEvent());
+    registerFallbackValue(_FakeGitSyncEvent());
+  });
+
+  late _MockConflictBloc conflictBloc;
+  late _MockGitSyncBloc gitBloc;
+
+  setUp(() {
+    conflictBloc = _MockConflictBloc();
+    gitBloc = _MockGitSyncBloc();
+    when(() => gitBloc.state).thenReturn(const GitSyncState());
+  });
+
+  Widget host() {
+    return MaterialApp(
+      theme: brutalistTheme(Brightness.light),
+      home: Scaffold(
+        body: MultiBlocProvider(
+          providers: [
+            BlocProvider<ConflictBloc>.value(value: conflictBloc),
+            BlocProvider<GitSyncBloc>.value(value: gitBloc),
+          ],
+          child: Builder(
+            builder: (context) => TextButton(
+              onPressed: () =>
+                  ConflictResolutionDialog.show(context, root: root),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> openDialog(WidgetTester tester) async {
+    await tester.pumpWidget(host());
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('a field-level scalar conflict renders the two side buttons', (
+    tester,
+  ) async {
+    const conflicts = [
+      FileConflict(
+        path: 'r1.req.json',
+        kind: ConflictKind.request,
+        node: NodeMergeResult(
+          merged: _node,
+          conflicts: [
+            FieldConflict(
+              field: 'url',
+              kind: FieldConflictKind.scalar,
+              incoming: 'https://a.example',
+              yours: 'https://b.example',
+            ),
+          ],
+        ),
+      ),
+    ];
+    when(() => conflictBloc.state).thenReturn(
+      const ConflictState(status: ConflictStatus.ready, conflicts: conflicts),
+    );
+
+    await openDialog(tester);
+
+    expect(find.text('TAKE INCOMING'), findsOneWidget);
+    expect(find.text('KEEP YOURS'), findsOneWidget);
+    verify(() => conflictBloc.add(const LoadConflicts(root))).called(1);
+  });
+
+  testWidgets(
+    'picking Keep Yours then RESOLVE & CONTINUE sends the yours value',
+    (tester) async {
+      const conflicts = [
+        FileConflict(
+          path: 'r1.req.json',
+          kind: ConflictKind.request,
+          node: NodeMergeResult(
+            merged: _node,
+            conflicts: [
+              FieldConflict(
+                field: 'url',
+                kind: FieldConflictKind.scalar,
+                incoming: 'https://a.example',
+                yours: 'https://b.example',
+              ),
+            ],
+          ),
+        ),
+      ];
+      when(() => conflictBloc.state).thenReturn(
+        const ConflictState(
+          status: ConflictStatus.ready,
+          conflicts: conflicts,
+        ),
+      );
+
+      await openDialog(tester);
+      await tester.tap(
+        find.byKey(const ValueKey('keep_yours_r1.req.json_url')),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('conflict_resolve')));
+      await tester.pumpAndSettle();
+
+      verify(
+        () => conflictBloc.add(
+          const ResolveAndContinue(root, [
+            FileResolution(
+              path: 'r1.req.json',
+              fieldChoices: {'url': 'https://b.example'},
+            ),
+          ]),
+        ),
+      ).called(1);
+    },
+  );
+
+  testWidgets(
+    "an opaque authentication conflict's pick is the literal marker, not a "
+    'value',
+    (tester) async {
+      const conflicts = [
+        FileConflict(
+          path: 'r1.req.json',
+          kind: ConflictKind.request,
+          node: NodeMergeResult(
+            merged: _node,
+            conflicts: [
+              FieldConflict(
+                field: 'authentication',
+                kind: FieldConflictKind.opaque,
+              ),
+            ],
+          ),
+        ),
+      ];
+      when(() => conflictBloc.state).thenReturn(
+        const ConflictState(
+          status: ConflictStatus.ready,
+          conflicts: conflicts,
+        ),
+      );
+
+      await openDialog(tester);
+      await tester.tap(
+        find.byKey(const ValueKey('keep_yours_r1.req.json_authentication')),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('conflict_resolve')));
+      await tester.pumpAndSettle();
+
+      verify(
+        () => conflictBloc.add(
+          const ResolveAndContinue(root, [
+            FileResolution(
+              path: 'r1.req.json',
+              fieldChoices: {'authentication': 'yours'},
+            ),
+          ]),
+        ),
+      ).called(1);
+    },
+  );
+
+  testWidgets(
+    'a coarse deleteModify conflict shows the labelled choices and sets '
+    'wholeFile',
+    (tester) async {
+      const conflicts = [
+        FileConflict(
+          path: 'r2.req.json',
+          kind: ConflictKind.deleteModify,
+        ),
+      ];
+      when(() => conflictBloc.state).thenReturn(
+        const ConflictState(
+          status: ConflictStatus.ready,
+          conflicts: conflicts,
+        ),
+      );
+
+      await openDialog(tester);
+
+      expect(find.text('Accept the deletion'), findsOneWidget);
+      expect(find.text('Keep your edited request'), findsOneWidget);
+
+      await tester.tap(
+        find.byKey(const ValueKey('keep_yours_r2.req.json')),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('conflict_resolve')));
+      await tester.pumpAndSettle();
+
+      verify(
+        () => conflictBloc.add(
+          const ResolveAndContinue(root, [
+            FileResolution(path: 'r2.req.json', wholeFile: FileSide.yours),
+          ]),
+        ),
+      ).called(1);
+    },
+  );
+
+  testWidgets('RESOLVE is disabled until every conflict has a pick', (
+    tester,
+  ) async {
+    const conflicts = [
+      FileConflict(
+        path: 'r1.req.json',
+        kind: ConflictKind.request,
+        node: NodeMergeResult(
+          merged: _node,
+          conflicts: [
+            FieldConflict(
+              field: 'url',
+              kind: FieldConflictKind.scalar,
+              incoming: 'a',
+              yours: 'b',
+            ),
+          ],
+        ),
+      ),
+      FileConflict(path: 'r2.req.json', kind: ConflictKind.deleteModify),
+    ];
+    when(() => conflictBloc.state).thenReturn(
+      const ConflictState(status: ConflictStatus.ready, conflicts: conflicts),
+    );
+
+    await openDialog(tester);
+
+    FilledButton resolveButton() => tester.widget<FilledButton>(
+      find.byKey(const ValueKey('conflict_resolve')),
+    );
+    expect(resolveButton().onPressed, isNull);
+
+    await tester.tap(
+      find.byKey(const ValueKey('keep_yours_r1.req.json_url')),
+    );
+    await tester.pumpAndSettle();
+    expect(resolveButton().onPressed, isNull); // r2 still unpicked
+
+    await tester.tap(find.byKey(const ValueKey('keep_yours_r2.req.json')));
+    await tester.pumpAndSettle();
+    expect(resolveButton().onPressed, isNotNull);
+  });
+
+  testWidgets('an auto-merged file needs no pick and does not block RESOLVE', (
+    tester,
+  ) async {
+    const conflicts = [
+      FileConflict(
+        path: 'r1.req.json',
+        kind: ConflictKind.request,
+        node: NodeMergeResult(merged: _node, conflicts: []),
+      ),
+    ];
+    when(() => conflictBloc.state).thenReturn(
+      const ConflictState(status: ConflictStatus.ready, conflicts: conflicts),
+    );
+
+    await openDialog(tester);
+
+    expect(find.text('Auto-merged.'), findsOneWidget);
+    final resolveButton = tester.widget<FilledButton>(
+      find.byKey(const ValueKey('conflict_resolve')),
+    );
+    expect(resolveButton.onPressed, isNotNull);
+
+    await tester.tap(find.byKey(const ValueKey('conflict_resolve')));
+    await tester.pumpAndSettle();
+
+    verify(
+      () => conflictBloc.add(
+        const ResolveAndContinue(root, [
+          FileResolution(path: 'r1.req.json'),
+        ]),
+      ),
+    ).called(1);
+  });
+
+  testWidgets('CANCEL dispatches AbortRebase and closes the dialog', (
+    tester,
+  ) async {
+    when(
+      () => conflictBloc.state,
+    ).thenReturn(const ConflictState(status: ConflictStatus.ready));
+
+    await openDialog(tester);
+    await tester.tap(find.byKey(const ValueKey('conflict_cancel')));
+    await tester.pumpAndSettle();
+
+    verify(() => conflictBloc.add(const AbortRebase(root))).called(1);
+    expect(find.byKey(const ValueKey('conflict_cancel')), findsNothing);
+  });
+
+  testWidgets('a done status closes the dialog and refreshes branch status', (
+    tester,
+  ) async {
+    final controller = StreamController<ConflictState>();
+    whenListen(
+      conflictBloc,
+      controller.stream,
+      initialState: const ConflictState(status: ConflictStatus.ready),
+    );
+
+    await openDialog(tester);
+    controller.add(const ConflictState(status: ConflictStatus.done));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('conflict_cancel')), findsNothing);
+    verify(() => gitBloc.add(const LoadBranchStatus(root))).called(1);
+    await controller.close();
+  });
+
+  testWidgets('an error status surfaces the GIT ERROR dialog', (
+    tester,
+  ) async {
+    final controller = StreamController<ConflictState>();
+    whenListen(
+      conflictBloc,
+      controller.stream,
+      initialState: const ConflictState(status: ConflictStatus.ready),
+    );
+
+    await openDialog(tester);
+    controller.add(
+      const ConflictState(status: ConflictStatus.error, errorMessage: 'boom'),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('conflict_error_dialog')), findsOneWidget);
+    expect(find.text('boom'), findsOneWidget);
+    await controller.close();
+  });
+}

--- a/test/features/collections/presentation/widgets/pull_requests_dialog_test.dart
+++ b/test/features/collections/presentation/widgets/pull_requests_dialog_test.dart
@@ -1,0 +1,328 @@
+import 'dart:async';
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/core/theme/themes/brutalist/brutalist_theme.dart';
+import 'package:getman/features/collections/domain/entities/branch_status.dart';
+import 'package:getman/features/collections/domain/entities/pull_request.dart';
+import 'package:getman/features/collections/presentation/bloc/git_sync_bloc.dart';
+import 'package:getman/features/collections/presentation/bloc/git_sync_event.dart';
+import 'package:getman/features/collections/presentation/bloc/git_sync_state.dart';
+import 'package:getman/features/collections/presentation/bloc/pull_requests_bloc.dart';
+import 'package:getman/features/collections/presentation/bloc/pull_requests_event.dart';
+import 'package:getman/features/collections/presentation/bloc/pull_requests_state.dart';
+import 'package:getman/features/collections/presentation/widgets/pull_requests_dialog.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockPrBloc extends MockBloc<PullRequestsEvent, PullRequestsState>
+    implements PullRequestsBloc {}
+
+class _MockGitBloc extends MockBloc<GitSyncEvent, GitSyncState>
+    implements GitSyncBloc {}
+
+class _FakePrEvent extends Fake implements PullRequestsEvent {}
+
+const _pr = PullRequestEntity(
+  number: 77,
+  title: 'feat: y',
+  state: PrState.open,
+  url: 'https://github.com/o/r/pull/77',
+  isDraft: false,
+  checks: PrChecks.passing,
+);
+
+void main() {
+  const root = '/ws';
+
+  setUpAll(() => registerFallbackValue(_FakePrEvent()));
+
+  _MockGitBloc defaultGit() {
+    final git = _MockGitBloc();
+    when(() => git.state).thenReturn(const GitSyncState());
+    return git;
+  }
+
+  Widget host(_MockPrBloc prBloc, {_MockGitBloc? gitBloc}) {
+    // Use the caller's pre-stubbed git bloc as-is (stubbing here would clobber
+    // the branches a test set up); synthesize a default only when none given.
+    final git = gitBloc ?? defaultGit();
+    return MaterialApp(
+      theme: brutalistTheme(Brightness.light),
+      home: Scaffold(
+        body: MultiBlocProvider(
+          providers: [
+            BlocProvider<PullRequestsBloc>.value(value: prBloc),
+            BlocProvider<GitSyncBloc>.value(value: git),
+          ],
+          child: Builder(
+            builder: (context) => TextButton(
+              onPressed: () => PullRequestsDialog.show(context, root: root),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('notInstalled shows the install prompt', (tester) async {
+    final bloc = _MockPrBloc();
+    when(() => bloc.state).thenReturn(
+      const PullRequestsState(
+        status: PrStatus.ready,
+        availability: GhAvailability.notInstalled,
+      ),
+    );
+    await tester.pumpWidget(host(bloc));
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('gh'), findsWidgets);
+    expect(find.text('INSTALL GH'), findsOneWidget);
+  });
+
+  testWidgets('notAuthenticated shows the gh auth hint', (tester) async {
+    final bloc = _MockPrBloc();
+    when(() => bloc.state).thenReturn(
+      const PullRequestsState(
+        status: PrStatus.ready,
+        availability: GhAvailability.notAuthenticated,
+      ),
+    );
+    await tester.pumpWidget(host(bloc));
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('gh auth login'), findsOneWidget);
+  });
+
+  testWidgets('a ready list renders a PR row and the create button', (
+    tester,
+  ) async {
+    final bloc = _MockPrBloc();
+    when(() => bloc.state).thenReturn(
+      const PullRequestsState(
+        status: PrStatus.ready,
+        prs: [
+          PullRequestEntity(
+            number: 42,
+            title: 'feat: thing',
+            state: PrState.open,
+            url: 'https://github.com/o/r/pull/42',
+            isDraft: false,
+            checks: PrChecks.passing,
+          ),
+        ],
+      ),
+    );
+    await tester.pumpWidget(host(bloc));
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('42'), findsWidgets);
+    expect(find.text('feat: thing'), findsOneWidget);
+    expect(find.text('CREATE PULL REQUEST…'), findsOneWidget);
+  });
+
+  testWidgets('empty ready list shows the empty message', (tester) async {
+    final bloc = _MockPrBloc();
+    when(() => bloc.state).thenReturn(
+      const PullRequestsState(
+        status: PrStatus.ready,
+      ),
+    );
+    await tester.pumpWidget(host(bloc));
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('No open pull requests.'), findsOneWidget);
+  });
+
+  testWidgets('opening the dialog dispatches LoadPullRequests', (tester) async {
+    final bloc = _MockPrBloc();
+    when(() => bloc.state).thenReturn(
+      const PullRequestsState(
+        status: PrStatus.ready,
+      ),
+    );
+    await tester.pumpWidget(host(bloc));
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    verify(() => bloc.add(const LoadPullRequests(root))).called(1);
+  });
+
+  testWidgets('the create form dispatches CreatePullRequest', (tester) async {
+    final bloc = _MockPrBloc();
+    final git = _MockGitBloc();
+    when(() => git.state).thenReturn(
+      const GitSyncState(
+        branch: BranchStatus(
+          isRepo: true,
+          current: 'feat/x',
+          branches: ['feat/x', 'main'],
+        ),
+      ),
+    );
+    when(() => bloc.state).thenReturn(
+      const PullRequestsState(
+        status: PrStatus.ready,
+      ),
+    );
+    await tester.pumpWidget(host(bloc, gitBloc: git));
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('CREATE PULL REQUEST…'));
+    await tester.pumpAndSettle();
+
+    // Base is prefilled from the known branches ('main'); enter a title so the
+    // submit enables.
+    await tester.enterText(
+      find.byKey(const ValueKey('pr_form_title')),
+      'my pr',
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('pr_form_submit')));
+    await tester.pumpAndSettle();
+
+    verify(
+      () => bloc.add(
+        const CreatePullRequest(
+          root,
+          base: 'main',
+          title: 'my pr',
+          body: '',
+          draft: false,
+        ),
+      ),
+    ).called(1);
+  });
+
+  testWidgets('the draft toggle sends draft:true with the body', (
+    tester,
+  ) async {
+    final bloc = _MockPrBloc();
+    final git = _MockGitBloc();
+    when(() => git.state).thenReturn(
+      const GitSyncState(
+        branch: BranchStatus(isRepo: true, current: 'x', branches: ['main']),
+      ),
+    );
+    when(() => bloc.state).thenReturn(
+      const PullRequestsState(status: PrStatus.ready),
+    );
+    await tester.pumpWidget(host(bloc, gitBloc: git));
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('CREATE PULL REQUEST…'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byKey(const ValueKey('pr_form_title')), 't');
+    await tester.enterText(find.byKey(const ValueKey('pr_form_body')), 'desc');
+    await tester.tap(find.byKey(const ValueKey('pr_form_draft')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('pr_form_submit')));
+    await tester.pumpAndSettle();
+
+    verify(
+      () => bloc.add(
+        const CreatePullRequest(
+          root,
+          base: 'main',
+          title: 't',
+          body: 'desc',
+          draft: true,
+        ),
+      ),
+    ).called(1);
+  });
+
+  testWidgets('a created PR nudges the chip once — not again on refresh', (
+    tester,
+  ) async {
+    final bloc = _MockPrBloc();
+    final git = _MockGitBloc();
+    when(() => git.state).thenReturn(const GitSyncState());
+    // Emit into a controller AFTER the dialog subscribes, so no state is lost.
+    final controller = StreamController<PullRequestsState>();
+    whenListen(
+      bloc,
+      controller.stream,
+      initialState: const PullRequestsState(status: PrStatus.ready),
+    );
+    await tester.pumpWidget(host(bloc, gitBloc: git));
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    // First: the create resolves (lastCreated set). Then: a plain refresh with
+    // the SAME lastCreated (list now carries the PR). The nudge must fire once.
+    controller.add(
+      const PullRequestsState(
+        status: PrStatus.ready,
+        lastCreated: PullRequestRef(number: 77, url: 'u/pull/77'),
+      ),
+    );
+    await tester.pump();
+    controller.add(
+      const PullRequestsState(
+        status: PrStatus.ready,
+        prs: [_pr],
+        lastCreated: PullRequestRef(number: 77, url: 'u/pull/77'),
+      ),
+    );
+    await tester.pump();
+
+    verify(() => git.add(const LoadBranchStatus(root))).called(1);
+    await controller.close();
+  });
+
+  testWidgets('an error state shows the GIT ERROR dialog', (tester) async {
+    final bloc = _MockPrBloc();
+    final controller = StreamController<PullRequestsState>();
+    whenListen(
+      bloc,
+      controller.stream,
+      initialState: const PullRequestsState(status: PrStatus.ready),
+    );
+    await tester.pumpWidget(host(bloc));
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    controller.add(
+      const PullRequestsState(status: PrStatus.error, errorMessage: 'boom'),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('pr_error_dialog')), findsOneWidget);
+    expect(find.text('boom'), findsOneWidget);
+    await controller.close();
+  });
+
+  testWidgets('a busy state disables the actions and shows a spinner', (
+    tester,
+  ) async {
+    final bloc = _MockPrBloc();
+    when(() => bloc.state).thenReturn(
+      const PullRequestsState(status: PrStatus.creating),
+    );
+    await tester.pumpWidget(host(bloc));
+    await tester.tap(find.text('open'));
+    // A spinner animates forever — pump past the dialog-open transition only,
+    // never pumpAndSettle (it would time out on the CircularProgressIndicator).
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    final refresh = tester.widget<OutlinedButton>(
+      find.byKey(const ValueKey('pr_refresh')),
+    );
+    final create = tester.widget<FilledButton>(
+      find.byKey(const ValueKey('pr_create')),
+    );
+    expect(refresh.onPressed, isNull);
+    expect(create.onPressed, isNull);
+  });
+}

--- a/test/features/collections/presentation/widgets/pull_requests_dialog_test.dart
+++ b/test/features/collections/presentation/widgets/pull_requests_dialog_test.dart
@@ -201,6 +201,45 @@ void main() {
     ).called(1);
   });
 
+  testWidgets('the create form prefers state.defaultBase over the heuristic', (
+    tester,
+  ) async {
+    final bloc = _MockPrBloc();
+    final git = _MockGitBloc();
+    // Branches contain 'main' — the heuristic would pick it — but the repo's
+    // real default base is 'develop', which must win.
+    when(() => git.state).thenReturn(
+      const GitSyncState(
+        branch: BranchStatus(isRepo: true, current: 'x', branches: ['main']),
+      ),
+    );
+    when(() => bloc.state).thenReturn(
+      const PullRequestsState(status: PrStatus.ready, defaultBase: 'develop'),
+    );
+    await tester.pumpWidget(host(bloc, gitBloc: git));
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('CREATE PULL REQUEST…'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byKey(const ValueKey('pr_form_title')), 't');
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('pr_form_submit')));
+    await tester.pumpAndSettle();
+
+    verify(
+      () => bloc.add(
+        const CreatePullRequest(
+          root,
+          base: 'develop',
+          title: 't',
+          body: '',
+          draft: false,
+        ),
+      ),
+    ).called(1);
+  });
+
   testWidgets('the draft toggle sends draft:true with the body', (
     tester,
   ) async {

--- a/test/features/collections/presentation/widgets/review_changes_dialog_test.dart
+++ b/test/features/collections/presentation/widgets/review_changes_dialog_test.dart
@@ -34,6 +34,13 @@ void main() {
   late _MockSettingsBloc settingsBloc;
   late _MockGitSyncBloc gitSyncBloc;
 
+  setUpAll(() {
+    // Needed for `any()` on `gitSyncBloc.add(...)` in the busy-push test
+    // below — mocktail requires a registered fallback for any type used
+    // with `any`/`captureAny`.
+    registerFallbackValue(const LoadBranchStatus(''));
+  });
+
   const entry = ReviewEntry(
     path: 'a.req.json',
     nodeKind: NodeKind.request,
@@ -313,6 +320,38 @@ void main() {
           ),
         ),
       ).called(1);
+    },
+  );
+
+  testWidgets(
+    'pressing PUSH while git is busy shows a snack bar and does not '
+    'dispatch or pop',
+    (tester) async {
+      when(() => gitSyncBloc.state).thenReturn(
+        const GitSyncState(
+          status: GitSyncStatus.busy,
+          branch: BranchStatus(
+            isRepo: true,
+            current: 'main',
+            branches: ['main'],
+            hasRemote: true,
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(
+        hostAsRoute(const ReviewState(status: ReviewStatus.ready)),
+      );
+      await tester.tap(find.text('open review'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const ValueKey('review_push_button')));
+      await tester.pumpAndSettle();
+
+      verifyNever(() => gitSyncBloc.add(any()));
+      expect(find.text('Git is busy — try again in a moment.'), findsOneWidget);
+      // The dialog route was NOT popped.
+      expect(find.byKey(const ValueKey('review_push_button')), findsOneWidget);
     },
   );
 

--- a/test/features/collections/presentation/widgets/review_changes_dialog_test.dart
+++ b/test/features/collections/presentation/widgets/review_changes_dialog_test.dart
@@ -4,9 +4,13 @@ import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:getman/core/theme/theme_registry.dart';
+import 'package:getman/core/theme/themes/brutalist/brutalist_theme.dart';
+import 'package:getman/features/collections/domain/entities/branch_status.dart';
 import 'package:getman/features/collections/domain/entities/review_entry.dart';
 import 'package:getman/features/collections/domain/logic/semantic_diff.dart';
+import 'package:getman/features/collections/presentation/bloc/git_sync_bloc.dart';
+import 'package:getman/features/collections/presentation/bloc/git_sync_event.dart';
+import 'package:getman/features/collections/presentation/bloc/git_sync_state.dart';
 import 'package:getman/features/collections/presentation/bloc/review_bloc.dart';
 import 'package:getman/features/collections/presentation/bloc/review_event.dart';
 import 'package:getman/features/collections/presentation/bloc/review_state.dart';
@@ -22,9 +26,13 @@ class _MockReviewBloc extends MockBloc<ReviewEvent, ReviewState>
 
 class _MockSettingsBloc extends Mock implements SettingsBloc {}
 
+class _MockGitSyncBloc extends MockBloc<GitSyncEvent, GitSyncState>
+    implements GitSyncBloc {}
+
 void main() {
   late _MockReviewBloc bloc;
   late _MockSettingsBloc settingsBloc;
+  late _MockGitSyncBloc gitSyncBloc;
 
   const entry = ReviewEntry(
     path: 'a.req.json',
@@ -45,20 +53,34 @@ void main() {
   setUp(() {
     bloc = _MockReviewBloc();
     settingsBloc = _MockSettingsBloc();
+    gitSyncBloc = _MockGitSyncBloc();
     when(
       () => settingsBloc.state,
     ).thenReturn(const SettingsState(settings: SettingsEntity()));
     when(() => settingsBloc.stream).thenAnswer((_) => const Stream.empty());
+    when(() => gitSyncBloc.state).thenReturn(
+      const GitSyncState(
+        status: GitSyncStatus.ready,
+        branch: BranchStatus(
+          isRepo: true,
+          current: 'main',
+          branches: ['main'],
+          hasRemote: true,
+        ),
+      ),
+    );
+    when(() => gitSyncBloc.stream).thenAnswer((_) => const Stream.empty());
   });
 
   Widget host(ReviewState state) {
     when(() => bloc.state).thenReturn(state);
     return MaterialApp(
-      theme: resolveTheme('classic')(Brightness.light),
+      theme: brutalistTheme(Brightness.light),
       home: MultiBlocProvider(
         providers: [
           BlocProvider<ReviewBloc>.value(value: bloc),
           BlocProvider<SettingsBloc>.value(value: settingsBloc),
+          BlocProvider<GitSyncBloc>.value(value: gitSyncBloc),
         ],
         child: const Scaffold(body: ReviewChangesBody(root: '/ws')),
       ),
@@ -182,6 +204,117 @@ void main() {
     );
     expect(find.textContaining('Initialize git'), findsOneWidget);
   });
+
+  testWidgets('the PUSH button is present when the workspace is a repo', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      host(const ReviewState(status: ReviewStatus.ready)),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('review_push_button')), findsOneWidget);
+  });
+
+  // Pushed via a real route (unlike `host()`, which renders the body
+  // directly as `home:`) so `Navigator.of(context).maybePop()` inside the
+  // PUSH handler has something real to pop — mirrors how
+  // `ReviewChangesDialog.show` actually opens this body.
+  Widget hostAsRoute(ReviewState state) {
+    when(() => bloc.state).thenReturn(state);
+    // The providers wrap `MaterialApp` itself (not just `home:`), matching
+    // main.dart's root MultiBlocProvider — a route pushed via `Navigator.push`
+    // lands in the same Overlay as `home`, a *sibling* of it in the element
+    // tree, not a descendant, so providers scoped only to `home:` would not
+    // be reachable from the pushed route.
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider<ReviewBloc>.value(value: bloc),
+        BlocProvider<SettingsBloc>.value(value: settingsBloc),
+        BlocProvider<GitSyncBloc>.value(value: gitSyncBloc),
+      ],
+      child: MaterialApp(
+        theme: brutalistTheme(Brightness.light),
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: Center(
+              child: TextButton(
+                onPressed: () => Navigator.of(context).push(
+                  MaterialPageRoute<void>(
+                    builder: (_) =>
+                        const Scaffold(body: ReviewChangesBody(root: '/ws')),
+                  ),
+                ),
+                child: const Text('open review'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets(
+    'pressing PUSH with a remote present dispatches PushChanges and pops',
+    (tester) async {
+      await tester.pumpWidget(
+        hostAsRoute(const ReviewState(status: ReviewStatus.ready)),
+      );
+      await tester.tap(find.text('open review'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const ValueKey('review_push_button')));
+      await tester.pumpAndSettle();
+
+      verify(() => gitSyncBloc.add(const PushChanges('/ws'))).called(1);
+      // The dialog route itself was popped.
+      expect(find.byKey(const ValueKey('review_push_button')), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'pressing PUSH with no remote prompts for a URL before pushing',
+    (tester) async {
+      when(() => gitSyncBloc.state).thenReturn(
+        const GitSyncState(
+          status: GitSyncStatus.ready,
+          branch: BranchStatus(
+            isRepo: true,
+            current: 'main',
+            branches: ['main'],
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(
+        host(const ReviewState(status: ReviewStatus.ready)),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const ValueKey('review_push_button')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('ADD REMOTE'), findsWidgets);
+      expect(find.byKey(const ValueKey('name_prompt_field')), findsOneWidget);
+
+      await tester.enterText(
+        find.byKey(const ValueKey('name_prompt_field')),
+        'https://example.invalid/x/y.git',
+      );
+      await tester.pump();
+      await tester.tap(find.widgetWithText(TextButton, 'ADD REMOTE'));
+      await tester.pumpAndSettle();
+
+      verify(
+        () => gitSyncBloc.add(
+          const PushChanges(
+            '/ws',
+            addRemoteUrl: 'https://example.invalid/x/y.git',
+          ),
+        ),
+      ).called(1);
+    },
+  );
 
   testWidgets('surfaces the error message after a failed commit', (
     tester,

--- a/test/features/collections/presentation/widgets/review_changes_dialog_test.dart
+++ b/test/features/collections/presentation/widgets/review_changes_dialog_test.dart
@@ -238,6 +238,9 @@ void main() {
         find.byKey(const ValueKey('git_identity_email_field')),
         'ada@example.com',
       );
+      // SAVE is gated on both fields being non-empty (FIX 1) — pump so the
+      // rebuild from the second field's onChanged lands before the tap.
+      await tester.pump();
       await tester.tap(find.byKey(const ValueKey('git_identity_save')));
       await tester.pumpAndSettle();
 
@@ -260,6 +263,67 @@ void main() {
           ),
         ),
       ).called(1);
+
+      await controller.close();
+    },
+  );
+
+  testWidgets(
+    'the identity prompt SAVE button is disabled while the email (or name) '
+    'field is blank',
+    (tester) async {
+      final controller = StreamController<ReviewState>();
+      const readyState = ReviewState(
+        status: ReviewStatus.ready,
+        entries: [entry],
+        selectedPath: 'a.req.json',
+      );
+      whenListen(bloc, controller.stream, initialState: readyState);
+
+      await tester.pumpWidget(host(readyState));
+      await tester.pumpAndSettle();
+
+      controller.add(
+        const ReviewState(
+          status: ReviewStatus.needsIdentity,
+          entries: [entry],
+          selectedPath: 'a.req.json',
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const ValueKey('git_identity_dialog')), findsOneWidget);
+
+      FilledButton saveButton() => tester.widget<FilledButton>(
+        find.byKey(const ValueKey('git_identity_save')),
+      );
+
+      // Both fields blank → disabled.
+      expect(saveButton().onPressed, isNull);
+
+      // Name only → still disabled (email blank).
+      await tester.enterText(
+        find.byKey(const ValueKey('git_identity_name_field')),
+        'Ada Lovelace',
+      );
+      await tester.pump();
+      expect(saveButton().onPressed, isNull);
+
+      // Both filled → enabled.
+      await tester.enterText(
+        find.byKey(const ValueKey('git_identity_email_field')),
+        'ada@example.com',
+      );
+      await tester.pump();
+      expect(saveButton().onPressed, isNotNull);
+
+      // Email cleared back to blank (whitespace-only) → disabled again.
+      await tester.enterText(
+        find.byKey(const ValueKey('git_identity_email_field')),
+        '   ',
+      );
+      await tester.pump();
+      expect(saveButton().onPressed, isNull);
 
       await controller.close();
     },

--- a/test/features/collections/presentation/widgets/review_changes_dialog_test.dart
+++ b/test/features/collections/presentation/widgets/review_changes_dialog_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -9,13 +11,20 @@ import 'package:getman/features/collections/presentation/bloc/review_bloc.dart';
 import 'package:getman/features/collections/presentation/bloc/review_event.dart';
 import 'package:getman/features/collections/presentation/bloc/review_state.dart';
 import 'package:getman/features/collections/presentation/widgets/review_changes_dialog.dart';
+import 'package:getman/features/settings/domain/entities/settings_entity.dart';
+import 'package:getman/features/settings/presentation/bloc/settings_bloc.dart';
+import 'package:getman/features/settings/presentation/bloc/settings_event.dart';
+import 'package:getman/features/settings/presentation/bloc/settings_state.dart';
 import 'package:mocktail/mocktail.dart';
 
 class _MockReviewBloc extends MockBloc<ReviewEvent, ReviewState>
     implements ReviewBloc {}
 
+class _MockSettingsBloc extends Mock implements SettingsBloc {}
+
 void main() {
   late _MockReviewBloc bloc;
+  late _MockSettingsBloc settingsBloc;
 
   const entry = ReviewEntry(
     path: 'a.req.json',
@@ -33,14 +42,24 @@ void main() {
     ]),
   );
 
-  setUp(() => bloc = _MockReviewBloc());
+  setUp(() {
+    bloc = _MockReviewBloc();
+    settingsBloc = _MockSettingsBloc();
+    when(
+      () => settingsBloc.state,
+    ).thenReturn(const SettingsState(settings: SettingsEntity()));
+    when(() => settingsBloc.stream).thenAnswer((_) => const Stream.empty());
+  });
 
   Widget host(ReviewState state) {
     when(() => bloc.state).thenReturn(state);
     return MaterialApp(
       theme: resolveTheme('classic')(Brightness.light),
-      home: BlocProvider<ReviewBloc>.value(
-        value: bloc,
+      home: MultiBlocProvider(
+        providers: [
+          BlocProvider<ReviewBloc>.value(value: bloc),
+          BlocProvider<SettingsBloc>.value(value: settingsBloc),
+        ],
         child: const Scaffold(body: ReviewChangesBody(root: '/ws')),
       ),
     );
@@ -181,4 +200,68 @@ void main() {
     expect(find.text('boom'), findsOneWidget);
     expect(tester.takeException(), isNull);
   });
+
+  testWidgets(
+    'a commit failing with needsIdentity opens the identity prompt; SAVE '
+    'dispatches UpdateGitIdentity then re-dispatches Commit',
+    (tester) async {
+      final controller = StreamController<ReviewState>();
+      const readyState = ReviewState(
+        status: ReviewStatus.ready,
+        entries: [entry],
+        selectedPath: 'a.req.json',
+      );
+      whenListen(bloc, controller.stream, initialState: readyState);
+
+      await tester.pumpWidget(host(readyState));
+      await tester.pumpAndSettle();
+
+      // No prompt yet.
+      expect(find.byKey(const ValueKey('git_identity_dialog')), findsNothing);
+
+      controller.add(
+        const ReviewState(
+          status: ReviewStatus.needsIdentity,
+          entries: [entry],
+          selectedPath: 'a.req.json',
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const ValueKey('git_identity_dialog')), findsOneWidget);
+
+      await tester.enterText(
+        find.byKey(const ValueKey('git_identity_name_field')),
+        'Ada Lovelace',
+      );
+      await tester.enterText(
+        find.byKey(const ValueKey('git_identity_email_field')),
+        'ada@example.com',
+      );
+      await tester.tap(find.byKey(const ValueKey('git_identity_save')));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const ValueKey('git_identity_dialog')), findsNothing);
+      verify(
+        () => settingsBloc.add(
+          const UpdateGitIdentity(
+            name: 'Ada Lovelace',
+            email: 'ada@example.com',
+          ),
+        ),
+      ).called(1);
+      verify(
+        () => bloc.add(
+          const Commit(
+            '/ws',
+            '',
+            authorName: 'Ada Lovelace',
+            authorEmail: 'ada@example.com',
+          ),
+        ),
+      ).called(1);
+
+      await controller.close();
+    },
+  );
 }

--- a/test/features/settings/data/models/settings_model_test.dart
+++ b/test/features/settings/data/models/settings_model_test.dart
@@ -239,4 +239,73 @@ void main() {
       expect(const SettingsEntity().skippedUpdateVersion, isNull);
     });
   });
+
+  group('SettingsModel gitUserName + gitUserEmail', () {
+    test('default is null', () {
+      expect(const SettingsEntity().gitUserName, isNull);
+      expect(const SettingsEntity().gitUserEmail, isNull);
+      expect(SettingsModel().gitUserName, isNull);
+      expect(SettingsModel().gitUserEmail, isNull);
+    });
+
+    test('json roundtrip preserves both fields', () {
+      final model = SettingsModel(
+        gitUserName: 'Ada Lovelace',
+        gitUserEmail: 'ada@example.com',
+      );
+      final back = SettingsModel.fromJson(model.toJson());
+      expect(back.gitUserName, 'Ada Lovelace');
+      expect(back.gitUserEmail, 'ada@example.com');
+    });
+
+    test('entity roundtrip preserves both fields', () {
+      const entity = SettingsEntity(
+        gitUserName: 'Ada Lovelace',
+        gitUserEmail: 'ada@example.com',
+      );
+      final back = SettingsModel.fromEntity(entity).toEntity();
+      expect(back.gitUserName, 'Ada Lovelace');
+      expect(back.gitUserEmail, 'ada@example.com');
+    });
+
+    test('legacy json without the fields defaults both to null', () {
+      final back = SettingsModel.fromJson({'historyLimit': 50});
+      expect(back.gitUserName, isNull);
+      expect(back.gitUserEmail, isNull);
+    });
+
+    test('SettingsEntity.copyWith can clear both to null explicitly', () {
+      const entity = SettingsEntity(
+        gitUserName: 'Ada Lovelace',
+        gitUserEmail: 'ada@example.com',
+      );
+      final cleared = entity.copyWith(gitUserName: null, gitUserEmail: null);
+      expect(cleared.gitUserName, isNull);
+      expect(cleared.gitUserEmail, isNull);
+    });
+
+    test('SettingsEntity.copyWith without arg preserves previous values', () {
+      const entity = SettingsEntity(
+        gitUserName: 'Ada Lovelace',
+        gitUserEmail: 'ada@example.com',
+      );
+      final preserved = entity.copyWith(themeId: 'other');
+      expect(preserved.gitUserName, 'Ada Lovelace');
+      expect(preserved.gitUserEmail, 'ada@example.com');
+    });
+
+    test('SettingsModel.copyWith can clear both via the sentinel', () {
+      final model = SettingsModel(
+        gitUserName: 'Ada Lovelace',
+        gitUserEmail: 'ada@example.com',
+      );
+      final cleared = model.copyWith(gitUserName: null, gitUserEmail: null);
+      expect(cleared.gitUserName, isNull);
+      expect(cleared.gitUserEmail, isNull);
+      // Omitting keeps them.
+      final kept = model.copyWith(historyLimit: 5);
+      expect(kept.gitUserName, 'Ada Lovelace');
+      expect(kept.gitUserEmail, 'ada@example.com');
+    });
+  });
 }

--- a/test/features/settings/presentation/bloc/settings_bloc_test.dart
+++ b/test/features/settings/presentation/bloc/settings_bloc_test.dart
@@ -85,6 +85,21 @@ void main() {
     expect(bloc.state.settings.clientCertPassphrase, isNull);
   });
 
+  test('UpdateGitIdentity sets the pair, then clears it', () async {
+    bloc.add(
+      const UpdateGitIdentity(name: 'Ada Lovelace', email: 'ada@example.com'),
+    );
+    await bloc.stream.firstWhere((s) => s.settings.gitUserName != null);
+    expect(bloc.state.settings.gitUserName, 'Ada Lovelace');
+    expect(bloc.state.settings.gitUserEmail, 'ada@example.com');
+    verify(() => save.call(any())).called(1);
+
+    bloc.add(const UpdateGitIdentity());
+    await bloc.stream.firstWhere((s) => s.settings.gitUserName == null);
+    expect(bloc.state.settings.gitUserName, isNull);
+    expect(bloc.state.settings.gitUserEmail, isNull);
+  });
+
   test('UpdateProxyUrl sets and clears the proxy', () async {
     bloc.add(const UpdateProxyUrl('127.0.0.1:8888'));
     await bloc.stream.firstWhere(


### PR DESCRIPTION
## Spec C — GitHub Pull Request integration

Third spec in the git-native-collaboration roadmap (A = review & commit / #50, B = branch & sync / #51). Create GitHub pull requests and see the repo's open PRs — with state and CI checks — from inside Getman, **without the app ever storing a credential**.

Targets `feat/git-branch-sync` (Spec B), since it builds on that branch's `BranchService.push`.

### What it does

Reached from the branch chip's new **PULL REQUESTS…** menu item. The panel renders one of three views:

- **gh not installed** → an **INSTALL GH** prompt linking to `cli.github.com`.
- **gh not authenticated** → a `gh auth login` hint + **REFRESH**.
- **Available** → the list of open PRs (title, `#number`, `DRAFT` tag, a checks glyph — passing / failing / pending / none), each tappable to open in the browser, plus **REFRESH** and **CREATE PULL REQUEST…**.

Creating a PR pushes the branch first (setting upstream on the first push), then runs `gh pr create` — so a never-pushed branch opens a PR in one step. A base picker (prefilled with the repo's real default branch), title, optional body, and a **Create as draft** toggle. On success it confirms `PR #n opened.`, refreshes the list, and nudges the branch chip's ahead/behind counts.

### How it's built

Same three-layer architecture as Specs A/B:

- **Core** (`lib/core/git/`) — `GhService` shells out to the `gh` CLI via `Process.run` (no shell, stdin closed → never hangs / never prompts). The single `dart:io` boundary is `gh_service_io.dart`; web gets a stub. Parsing lives in the pure `gh_output_parser.dart`.
- **Domain** — `PullRequestEntity` + enums + the abstract `PullRequestService`.
- **Data** — `GhPullRequestService` composes `GhService` with Spec B's `BranchService` (reusing the flush-guarded push).
- **Presentation** — `PullRequestsBloc` (on the abstraction, droppable-while-busy) + `PullRequestsDialog`.

### Guarantees

- **No credentials stored**; git config is never edited. Auth rides entirely on the user's existing `gh` login.
- **Non-interactive**: `gh` never blocks on stdin (push-then-create avoids the one prompt path).
- **Web-safe**: `dart:io` + `gh` confined to `*_io.dart`; desktop-only, web-stubbed.
- Only **open** PRs are listed; reviewing / approving / merging in-app is out of scope for v1.

### Testing

Each layer has unit/bloc/widget coverage — parser edge cases and check-rollup precedence, push-then-create ordering (Completer-gated, non-vacuous), the droppable-while-busy guard, `lastCreated` single-consume, and the three dialog views + create form. Full done-bar green: `flutter analyze`, `custom_lint`, `bloc_lint`, the lint fixtures self-test, `dart format`, and 1949 tests.

The wiki's Version Control page gains a **Pull requests** section.
