### PR TITLE
ci: add Qodo PR-Agent workflow (Gemini backend)

### DIFF
--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -1,0 +1,39 @@
+name: PR Agent
+
+# Qodo PR-Agent — AI-assisted PR review, backed by Google Gemini (not OpenAI).
+# On a new/updated PR it posts an automatic review; description and improve are
+# left OFF by default and stay available on demand via PR comments:
+#   /review   /describe   /improve   /ask <question>
+#
+# Setup (one-time): add a repository secret GEMINI_API_KEY from
+# https://aistudio.google.com/  — no OpenAI key is required.
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  pr_agent:
+    # Skip Dependabot PRs (its token can't read the secret) and draft PRs.
+    if: >-
+      github.actor != 'dependabot[bot]' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+    runs-on: ubuntu-latest
+    steps:
+      - name: PR Agent
+        uses: qodo-ai/pr-agent@8e4d32e5497defd43c023a404f73560c62728961 # v0.39.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GOOGLE_AI_STUDIO.GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          config.model: "gemini/gemini-2.5-flash"
+          config.fallback_models: '["gemini/gemini-2.0-flash"]'
+          # Auto-run review only; describe/improve stay on-demand via comments.
+          github_action_config.auto_review: "true"
+          github_action_config.auto_describe: "false"
+          github_action_config.auto_improve: "false"

--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -2,11 +2,12 @@ name: PR Agent
 
 # Qodo PR-Agent — AI-assisted PR review, backed by Google Gemini (not OpenAI).
 #
-# Gated: the auto-review runs ONLY once every other check on the PR head commit
-# has finished AND all of them are green (CI, CodeQL, GitGuardian, etc.). The
-# job triggers on the PR event, then polls the Checks API + legacy commit
-# statuses until nothing is pending, and skips the review if anything failed.
-# This avoids spending a Gemini review on a PR that is still red.
+# Two ways it runs:
+#   1. Automatic review when a PR is opened/reopened/marked ready — but GATED:
+#      it waits until every other check on the head commit has finished and all
+#      are green (CI, CodeQL, GitGuardian, …), and skips if anything failed.
+#   2. On demand: comment  /review  (also /describe, /improve, /ask <q>) on a
+#      PR. Manual commands are NOT gated — an explicit request runs immediately.
 #
 # Note: this posts an analysis *comment* only — it does NOT submit an approving
 # ("+1") GitHub review, and cannot satisfy a required-reviewer branch rule.
@@ -16,6 +17,8 @@ name: PR Agent
 on:
   pull_request:
     types: [opened, reopened, ready_for_review]
+  issue_comment:
+    types: [created]
 
 permissions:
   contents: read
@@ -24,19 +27,19 @@ permissions:
   pull-requests: write
   issues: write
 
-# A newer event for the same PR supersedes an in-flight wait.
-concurrency:
-  group: pr-agent-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
-
 jobs:
-  pr-agent:
+  # ── Automatic review on PR open, gated on all other checks being green ──────
+  auto-review:
     name: PR Agent (auto-review)
-    # Skip Dependabot PRs (its token can't read the secret) and drafts.
     if: >-
+      github.event_name == 'pull_request' &&
       github.actor != 'dependabot[bot]' &&
       github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    # A newer PR event supersedes an in-flight wait for the same PR.
+    concurrency:
+      group: pr-agent-auto-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     steps:
       - name: Wait for all other checks to pass
         id: gate
@@ -104,3 +107,29 @@ jobs:
           github_action_config.auto_review: "true"
           github_action_config.auto_describe: "false"
           github_action_config.auto_improve: "false"
+
+  # ── On-demand commands (/review, /describe, /improve, /ask) — NOT gated ─────
+  command:
+    name: PR Agent (command)
+    # Only PR comments that start with a PR-Agent command, from a human.
+    if: >-
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      github.event.comment.user.type != 'Bot' &&
+      (startsWith(github.event.comment.body, '/review') ||
+       startsWith(github.event.comment.body, '/describe') ||
+       startsWith(github.event.comment.body, '/improve') ||
+       startsWith(github.event.comment.body, '/ask'))
+    runs-on: ubuntu-latest
+    # Serialize repeated commands on the same PR; don't cancel one mid-run.
+    concurrency:
+      group: pr-agent-cmd-${{ github.event.issue.number }}
+      cancel-in-progress: false
+    steps:
+      - name: PR Agent
+        uses: qodo-ai/pr-agent@8e4d32e5497defd43c023a404f73560c62728961 # v0.39.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GOOGLE_AI_STUDIO.GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          config.model: "gemini/gemini-2.5-flash"
+          config.fallback_models: '["gemini/gemini-2.0-flash"]'

--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -1,32 +1,99 @@
 name: PR Agent
 
 # Qodo PR-Agent — AI-assisted PR review, backed by Google Gemini (not OpenAI).
-# On a new/updated PR it posts an automatic review; description and improve are
-# left OFF by default and stay available on demand via PR comments:
-#   /review   /describe   /improve   /ask <question>
+#
+# Gated: the auto-review runs ONLY once every other check on the PR head commit
+# has finished AND all of them are green (CI, CodeQL, GitGuardian, etc.). The
+# job triggers on the PR event, then polls the Checks API + legacy commit
+# statuses until nothing is pending, and skips the review if anything failed.
+# This avoids spending a Gemini review on a PR that is still red.
+#
+# Note: this posts an analysis *comment* only — it does NOT submit an approving
+# ("+1") GitHub review, and cannot satisfy a required-reviewer branch rule.
 #
 # Setup (one-time): add a repository secret GEMINI_API_KEY from
 # https://aistudio.google.com/  — no OpenAI key is required.
 on:
   pull_request:
     types: [opened, reopened, ready_for_review]
-  issue_comment:
-    types: [created]
 
 permissions:
   contents: read
+  checks: read
+  statuses: read
   pull-requests: write
   issues: write
 
+# A newer event for the same PR supersedes an in-flight wait.
+concurrency:
+  group: pr-agent-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
-  pr_agent:
-    # Skip Dependabot PRs (its token can't read the secret) and draft PRs.
+  pr-agent:
+    name: PR Agent (auto-review)
+    # Skip Dependabot PRs (its token can't read the secret) and drafts.
     if: >-
       github.actor != 'dependabot[bot]' &&
-      (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+      github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
+      - name: Wait for all other checks to pass
+        id: gate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+          # This job's own check-run name — excluded so we never wait on ourselves.
+          SELF_CHECK: PR Agent (auto-review)
+        run: |
+          set -euo pipefail
+          deadline=$(( $(date +%s) + 1800 ))    # wait up to 30 min for slow checks
+          warmup_until=$(( $(date +%s) + 120 ))  # tolerate "no checks yet" only briefly
+
+          while :; do
+            now=$(date +%s)
+
+            runs=$(gh api "repos/$REPO/commits/$SHA/check-runs?per_page=100" \
+              --jq '[.check_runs[] | select(.name != env.SELF_CHECK)]')
+            statuses=$(gh api "repos/$REPO/commits/$SHA/status?per_page=100" \
+              --jq '[.statuses[] | select(.context != env.SELF_CHECK)]')
+
+            total=$(( $(jq 'length' <<<"$runs") + $(jq 'length' <<<"$statuses") ))
+            pending=$(( \
+              $(jq '[.[] | select(.status != "completed")] | length' <<<"$runs") + \
+              $(jq '[.[] | select(.state == "pending")] | length' <<<"$statuses") ))
+            failed=$(( \
+              $(jq '[.[] | select(.status == "completed" and (.conclusion | IN("success","neutral","skipped") | not))] | length' <<<"$runs") + \
+              $(jq '[.[] | select(.state == "failure" or .state == "error")] | length' <<<"$statuses") ))
+
+            if [ "$total" -eq 0 ]; then
+              if [ "$now" -lt "$warmup_until" ]; then
+                echo "No checks reported yet — warming up…"; sleep 15; continue
+              fi
+              echo "No other checks on $SHA — nothing to gate on; proceeding."
+              echo "passed=true" >> "$GITHUB_OUTPUT"; exit 0
+            fi
+
+            if [ "$pending" -gt 0 ]; then
+              if [ "$now" -ge "$deadline" ]; then
+                echo "Timed out after 30 min with $pending check(s) still pending — skipping review."
+                echo "passed=false" >> "$GITHUB_OUTPUT"; exit 0
+              fi
+              echo "$pending check(s) still running — waiting…"; sleep 20; continue
+            fi
+
+            if [ "$failed" -gt 0 ]; then
+              echo "$failed check(s) failed — skipping PR-Agent review."
+              echo "passed=false" >> "$GITHUB_OUTPUT"; exit 0
+            fi
+
+            echo "All $total check(s) passed — running PR-Agent."
+            echo "passed=true" >> "$GITHUB_OUTPUT"; exit 0
+          done
+
       - name: PR Agent
+        if: steps.gate.outputs.passed == 'true'
         uses: qodo-ai/pr-agent@8e4d32e5497defd43c023a404f73560c62728961 # v0.39.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Adds `.github/workflows/pr_agent.yml` — [Qodo PR-Agent](https://github.com/qodo-ai/pr-agent) with **Google Gemini** as the LLM backend (not OpenAI). It posts an analysis **review comment** (summary, score/effort, possible issues, security notes).

> Comment only — it does **not** submit an approving ("+1") review and cannot satisfy a required-reviewer branch rule.

## Two ways it runs

1. **Automatic** on PR open/reopen/ready — **gated**: waits until every other check on the head commit has finished and all are green (CI, CodeQL, GitGuardian, …), and skips if anything failed. Avoids spending a Gemini review on a red PR.
2. **On demand** — comment `/review` (also `/describe`, `/improve`, `/ask <q>`) on a PR. Manual commands are **not** gated: an explicit request runs immediately, red CI or not.

Why a wait-gate instead of `workflow_run`: PR-Agent's action only understands `pull_request`/`issue_comment` events (verified in its source), so `workflow_run` can't resolve the PR — and `workflow_run: ["CI"]` would ignore CodeQL/GitGuardian anyway.

## Config

- Auto path: `auto_review` on, `auto_describe`/`auto_improve` off.
- Model `gemini/gemini-2.5-flash`, fallback `gemini/gemini-2.0-flash`.
- Action pinned to `v0.39.0` by commit SHA (matches the repo's supply-chain hardening).
- Dependabot PRs and drafts skipped; auto gate waits up to 30 min then skips. Command job restricted to human PR comments starting with a known command.

## Required before it works

Add one **repository secret**: `GEMINI_API_KEY` from [Google AI Studio](https://aistudio.google.com/). No OpenAI key needed. Until then the review step fails at the Gemini call (the gate still runs).

## Notes

- Pure CI tooling — no app code, no wiki impact.