### PR TITLE
ci: raise PR-Agent token limit for Gemini's large context

### DIFF
--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -103,6 +103,9 @@ jobs:
           GOOGLE_AI_STUDIO.GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           config.model: "gemini/gemini-2.5-flash"
           config.fallback_models: '["gemini/gemini-2.0-flash"]'
+          # Gemini 2.5 has a ~1M-token context; lift PR-Agent's 32k default so a
+          # large PR diff is reviewed in full instead of pruned to a few files.
+          config.max_model_tokens: "500000"
           # Auto-run review only; describe/improve stay on-demand via comments.
           github_action_config.auto_review: "true"
           github_action_config.auto_describe: "false"
@@ -133,3 +136,6 @@ jobs:
           GOOGLE_AI_STUDIO.GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           config.model: "gemini/gemini-2.5-flash"
           config.fallback_models: '["gemini/gemini-2.0-flash"]'
+          # Gemini 2.5 has a ~1M-token context; lift PR-Agent's 32k default so a
+          # large PR diff is reviewed in full instead of pruned to a few files.
+          config.max_model_tokens: "500000"


### PR DESCRIPTION
## Why

On PR #50, `/review` completed successfully but produced a **partial** review. The run log shows the cause:

```
Tokens: 240667, total tokens over limit: 32000, pruning diff.
... Additional added/modified files (insufficient token budget to process): ...
```

PR-Agent defaults `config.max_model_tokens` to **32,000** — an OpenAI-era cap — and prunes any diff beyond it. That throws away almost all of a large PR and wastes **Gemini 2.5 Flash's ~1M-token context window**.

## Change

Set `config.max_model_tokens: "500000"` on both the auto-review and the `/review` command jobs. This:

- Reviews the full diff for large PRs (PR #50's ~240k tokens fits comfortably).
- Stays **below** Gemini's real ~1M window, so a truly enormous PR still prunes gracefully instead of erroring.
- Bounds cost — Flash is cheap, but this caps how much any single review can send.

## Validating after merge

`config.max_model_tokens` (like `issue_comment` triggers) only takes effect from the **master** copy of the workflow, so this must merge first. Then re-run `/review` on PR #50 — PR-Agent uses a persistent comment, so it updates the existing review in place rather than posting a second one.