### PR TITLE
feat: Windows/Linux download-and-close update flow

### DIFF
--- a/docs/CODEMAP.md
+++ b/docs/CODEMAP.md
@@ -194,7 +194,7 @@ widgets + screens). Shared cross-feature code lives under `lib/core/`. See
 | `lib/features/updates/domain/entities` | `release_info.dart` (`ReleaseInfo` + `UpdatePlatform`). |
 | `lib/features/updates/domain/repositories` | `update_repository.dart` (abstract). |
 | `lib/features/updates/presentation` | Web-safety gate + logic: `update_gate.dart` (conditional export), `update_gate_io.dart`, `update_gate_stub.dart`, `update_decision.dart`, `update_controller.dart`, `update_phase.dart`. |
-| `lib/features/updates/presentation/widgets` | `update_dialog.dart`, `update_settings_section.dart`. |
+| `lib/features/updates/presentation/widgets` | `update_dialog.dart`, `update_download_dialog.dart` (blocking in-app download progress), `update_settings_section.dart`. |
 
 ---
 
@@ -348,4 +348,4 @@ features; follow them to trace an end-to-end behavior.
 2. `lib/features/updates/data/datasources/github_release_data_source.dart` — fetches the latest GitHub release.
 3. `lib/features/updates/presentation/update_decision.dart` — `isNewerVersion` + `shouldPromptForUpdate`.
 4. `lib/features/updates/presentation/update_controller.dart` — drives dialog state (a `ChangeNotifier`).
-5. `lib/features/updates/presentation/widgets/update_dialog.dart` — Update now / Skip this version / Later (UPDATE NOW opens the browser).
+5. `lib/features/updates/presentation/widgets/update_dialog.dart` — Update now / Skip this version / Later (UPDATE NOW: macOS opens the browser; Windows/Linux confirm, download in-app, launch the installer, and quit).

--- a/docs/architecture/settings-history-updates.md
+++ b/docs/architecture/settings-history-updates.md
@@ -18,14 +18,44 @@
 
 ## Auto-update (GitHub-release)
 
-On startup (when `checkForUpdatesOnStartup` is `true`) one `releases/latest` check via `GithubReleaseDataSource`; if a newer version is found, `UpdateDialog` prompts Update now / Skip this version / Later. Logic lives in `update_decision.dart` (`isNewerVersion` + `shouldPromptForUpdate`); `UpdateController` (a `ChangeNotifier`) drives dialog state and is provided via `ChangeNotifierProvider` above `MaterialApp`. A GENERAL-tab toggle + "CHECK FOR UPDATES" button are in `UpdateSettingsSection`. Per-platform installers: `.dmg` (macOS), Inno Setup `.exe` (Windows), `AppImage` (Linux). On macOS, "UPDATE NOW" opens the asset URL in the browser (an in-app download tripped Gatekeeper on the unsigned build).
+On startup (when `checkForUpdatesOnStartup` is `true`) one `releases/latest`
+check via `GithubReleaseDataSource`; if a newer version is found, `UpdateDialog`
+prompts Update now / Skip this version / Later. Logic lives in
+`update_decision.dart` (`isNewerVersion` + `shouldPromptForUpdate`);
+`UpdateController` (a `ChangeNotifier`) drives dialog state and is provided via
+`ChangeNotifierProvider` above `MaterialApp`. A GENERAL-tab toggle + "CHECK FOR
+UPDATES" button are in `UpdateSettingsSection`. Per-platform installers: `.dmg`
+(macOS), Inno Setup `.exe` (Windows), `AppImage` (Linux).
+
+UPDATE NOW is platform-split via `UpdateController.installsInApp` (set once by
+the io gate at startup):
+
+- **macOS** (`installsInApp == false`): opens the asset URL in the browser —
+  an in-app download by the sandboxed, unsigned app carries a strict
+  `com.apple.quarantine` flag that Gatekeeper reports as "damaged", and the
+  sandbox can't clear it (the v1.4.1 fix; do not re-enable without
+  signing/notarization).
+- **Windows/Linux** (`installsInApp == true`): a `ConfirmDialog`
+  ("CLOSE AND UPDATE?") warns that Getman will close; on confirm, `updat`
+  downloads the installer to the user's Downloads folder behind the blocking
+  `UpdateDownloadDialog`, then `finishInAppUpdate` runs **launch installer →
+  flush tabs (`TabsBloc.close()`, cancels the 10 s debounce) → `exit(0)`**.
+  Launch comes first deliberately: a failed launch must leave the app fully
+  usable, and an early flush would have closed the TabsBloc. Linux gets a
+  `chmod +x` before the AppImage starts. A failed download pops the dialog and
+  snackbars; a failed launch surfaces the downloaded path. `updat`'s own
+  `openOnDownload`/`closeOnInstall` stay **off** — its `closeOnInstall` calls
+  `exit(0)` without flushing tabs.
 
 ### Web-safety gate
 
 The platform gate keeps web builds clean via a conditional export:
 
 - `update_gate.dart` — conditional export.
-- `update_gate_io.dart` — native only; the **sole importer of `updat`, `dart:io`, and `package_info_plus`**. (It does **not** import `path_provider` — that package is imported only by `html_open_external_io.dart` and `media_temp_file_io.dart` under the response media viewers.)
+- `update_gate_io.dart` — native only; the **sole importer of `updat`,
+  `dart:io`, `package_info_plus`, and `path_provider`** (the latter for
+  `getDownloadsDirectory` in the in-app download flow; the response media
+  viewers' `*_io.dart` files also import it).
 - `update_gate_stub.dart` — web no-op.
 
 This split is machine-enforced by the `platform_io_outside_io_files` custom lint (imports of `dart:io`/`updat`/`package_info_plus`/`path_provider` are forbidden outside `*_io.dart` files).

--- a/docs/architecture/settings-history-updates.md
+++ b/docs/architecture/settings-history-updates.md
@@ -54,10 +54,11 @@ the io gate at startup):
 The platform gate keeps web builds clean via a conditional export:
 
 - `update_gate.dart` — conditional export.
-- `update_gate_io.dart` — native only; the **sole importer of `updat`,
-  `dart:io`, `package_info_plus`, and `path_provider`** (the latter for
-  `getDownloadsDirectory` in the in-app download flow; the response media
-  viewers' `*_io.dart` files also import it).
+- `update_gate_io.dart` — native only; the **sole importer of `updat` and
+  `package_info_plus`**, and one of the io-gated `*_io.dart` importers of
+  `dart:io`/`path_provider` (the latter for `getDownloadsDirectory` in the
+  in-app download flow; the response media viewers' `*_io.dart` files also
+  import it).
 - `update_gate_stub.dart` — web no-op.
 
 This split is machine-enforced by the `platform_io_outside_io_files` custom lint (imports of `dart:io`/`updat`/`package_info_plus`/`path_provider` are forbidden outside `*_io.dart` files).

--- a/docs/architecture/settings-history-updates.md
+++ b/docs/architecture/settings-history-updates.md
@@ -45,7 +45,9 @@ the io gate at startup):
   `chmod +x` before the AppImage starts. A failed download pops the dialog and
   snackbars; a failed launch surfaces the downloaded path. `updat`'s own
   `openOnDownload`/`closeOnInstall` stay **off** — its `closeOnInstall` calls
-  `exit(0)` without flushing tabs.
+  `exit(0)` without flushing tabs. A 10-minute download-stall watchdog guards
+  `updat`'s single unbounded `http.get`: on fire the dialog closes and a
+  snackbar explains the timeout, with the app staying open.
 
 ### Web-safety gate
 

--- a/docs/superpowers/plans/2026-07-21-update-download-and-close.md
+++ b/docs/superpowers/plans/2026-07-21-update-download-and-close.md
@@ -1,0 +1,1065 @@
+# Update Download-and-Close Flow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** On Windows/Linux, UPDATE NOW confirms "close and update", downloads the installer in-app to the Downloads folder behind a blocking progress dialog, then auto-launches the installer and quits Getman. macOS keeps the browser hand-off.
+
+**Architecture:** Reuse `updat`'s download machinery (already a dependency), orchestrated by `update_gate_io.dart` with `openOnDownload`/`closeOnInstall` OFF so we control the terminal sequence (launch installer → flush tabs → `exit(0)`). The web-safe `UpdateController` gains an `installsInApp` flag so the platform-agnostic `UpdateDialog` can branch without importing `dart:io`.
+
+**Tech Stack:** Flutter (pinned via `.fvmrc` — always `fvm flutter` / `fvm dart`), `updat` 1.4.0, `path_provider`, `flutter_bloc`, mocktail.
+
+**Spec:** `docs/superpowers/specs/2026-07-21-update-download-and-close-design.md`
+
+## Global Constraints
+
+- **Always `fvm flutter …` / `fvm dart …`** — never plain `flutter`/`dart`.
+- **`package:getman/…` imports everywhere** — no relative imports.
+- Every new/edited `lib/` file keeps an accurate opening `//` header (`file_header_required` lint).
+- Theme adherence: sizes/paddings/font sizes via `context.appLayout` etc. — never hardcoded.
+- `discarded_futures` is a warning-level lint: wrap fire-and-forget futures in `unawaited(…)` (`dart:async`).
+- Snackbars only via `showAppSnackBar(context, …)`; confirmations only via `ConfirmDialog.show(…)`.
+- `print`/`debugPrint` rules: non-bloc layers use `debugPrint`; BLoCs use `dart:developer` `log`.
+- `dart:io`/`updat`/`package_info_plus`/`path_provider` imports allowed ONLY in `*_io.dart` files (`platform_io_outside_io_files` lint). All gate work stays in `update_gate_io.dart`.
+- UI copy is load-bearing for the wiki task — use these labels verbatim: `CLOSE AND UPDATE?`, `DOWNLOAD AND CLOSE`, `CANCEL`, `DOWNLOADING UPDATE…`, `UPDATE NOW`.
+- Run feature tests with: `fvm flutter test test/features/updates -r compact`.
+- Commit messages end with:
+  ```
+  Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+  Claude-Session: https://claude.ai/code/session_013mhumtQgzotqiYH9g5CVyS
+  ```
+
+---
+
+### Task 1: `installsInApp` flag on `UpdateController`
+
+**Files:**
+- Modify: `lib/features/updates/presentation/update_controller.dart`
+- Test: `test/features/updates/presentation/update_controller_test.dart`
+
+**Interfaces:**
+- Produces: `UpdateController.installsInApp` — a plain `bool` field, default `false`, no `notifyListeners` (set once by the io gate at startup, before any dialog exists). Tasks 2 and 5 read/write it.
+
+- [ ] **Step 1: Write the failing test**
+
+Append inside `main()` in `test/features/updates/presentation/update_controller_test.dart` (the file already has a `setUp` creating `controller`):
+
+```dart
+  test('installsInApp defaults to false (browser hand-off is the default)', () {
+    expect(controller.installsInApp, isFalse);
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `fvm flutter test test/features/updates/presentation/update_controller_test.dart -r compact`
+Expected: FAIL — compile error, `installsInApp` isn't defined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `lib/features/updates/presentation/update_controller.dart`, add after the `cachedRelease` field:
+
+```dart
+  /// True when this platform installs updates in-app (Windows/Linux: download
+  /// to the Downloads folder, then auto-launch + quit) rather than handing
+  /// the download to the browser (macOS, web). Set once by the io gate at
+  /// startup — a plain field, no [notifyListeners] needed.
+  bool installsInApp = false;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `fvm flutter test test/features/updates/presentation/update_controller_test.dart -r compact`
+Expected: PASS (all tests in file).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/updates/presentation/update_controller.dart test/features/updates/presentation/update_controller_test.dart
+git commit -m "feat: add UpdateController.installsInApp platform flag"
+```
+
+---
+
+### Task 2: UpdateDialog confirm-close flow + platform-aware note text
+
+**Files:**
+- Modify: `lib/features/updates/presentation/widgets/update_dialog.dart`
+- Test: `test/features/updates/presentation/widgets/update_dialog_test.dart`
+
+**Interfaces:**
+- Consumes: `UpdateController.installsInApp` (Task 1), `ConfirmDialog.show` from `package:getman/core/ui/widgets/confirm_dialog.dart` (existing atom — signature: `show(context, {required String title, required String message, required VoidCallback onConfirm, String confirmLabel, String cancelLabel, bool destructive})`; it pops itself BEFORE running `onConfirm`).
+- Produces: UPDATE NOW behavior — when `installsInApp` is true, tapping UPDATE NOW shows the ConfirmDialog *on top of* the still-open update dialog; CANCEL keeps the update dialog; DOWNLOAD AND CLOSE pops the update dialog then calls `controller.startUpdate`. When false, behavior is unchanged (startUpdate + pop immediately).
+
+- [ ] **Step 1: Write the failing tests**
+
+In `test/features/updates/presentation/widgets/update_dialog_test.dart`, first extract a host-widget helper (the existing "UPDATE NOW invokes startUpdate" test builds this inline — refactor it to use the helper too):
+
+```dart
+Widget _host(UpdateController controller) {
+  return MaterialApp(
+    theme: brutalistTheme(Brightness.light),
+    home: ChangeNotifierProvider<UpdateController>.value(
+      value: controller,
+      child: Scaffold(
+        body: Builder(
+          builder: (context) => Center(
+            child: ElevatedButton(
+              onPressed: () => showDialog<void>(
+                context: context,
+                builder: (_) => ChangeNotifierProvider<UpdateController>.value(
+                  value: controller,
+                  child: const UpdateDialog(
+                    latestVersion: '1.1.0',
+                    currentVersion: '1.0.0',
+                    changelog: null,
+                  ),
+                ),
+              ),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+```
+
+Then add these tests inside `main()`:
+
+```dart
+  testWidgets('in-app flow: UPDATE NOW asks for confirmation first', (t) async {
+    final controller = UpdateController(_FakeUpdateRepository())
+      ..installsInApp = true;
+    var started = false;
+    controller.startUpdate = () async => started = true;
+
+    await t.pumpWidget(_host(controller));
+    await t.tap(find.text('open'));
+    await t.pumpAndSettle();
+
+    await t.tap(find.byKey(const ValueKey('update_now_button')));
+    await t.pumpAndSettle();
+
+    expect(find.text('CLOSE AND UPDATE?'), findsOneWidget);
+    expect(find.text('DOWNLOAD AND CLOSE'), findsOneWidget);
+    // Update dialog still open behind the confirm box; nothing started.
+    expect(find.byKey(const ValueKey('update_now_button')), findsOneWidget);
+    expect(started, isFalse);
+  });
+
+  testWidgets('in-app flow: CANCEL keeps the update dialog, starts nothing', (
+    t,
+  ) async {
+    final controller = UpdateController(_FakeUpdateRepository())
+      ..installsInApp = true;
+    var started = false;
+    controller.startUpdate = () async => started = true;
+
+    await t.pumpWidget(_host(controller));
+    await t.tap(find.text('open'));
+    await t.pumpAndSettle();
+    await t.tap(find.byKey(const ValueKey('update_now_button')));
+    await t.pumpAndSettle();
+
+    await t.tap(find.text('CANCEL'));
+    await t.pumpAndSettle();
+
+    expect(find.text('CLOSE AND UPDATE?'), findsNothing);
+    expect(find.byKey(const ValueKey('update_now_button')), findsOneWidget);
+    expect(started, isFalse);
+  });
+
+  testWidgets(
+    'in-app flow: DOWNLOAD AND CLOSE starts the update and closes the dialog',
+    (t) async {
+      final controller = UpdateController(_FakeUpdateRepository())
+        ..installsInApp = true;
+      var started = false;
+      controller.startUpdate = () async => started = true;
+
+      await t.pumpWidget(_host(controller));
+      await t.tap(find.text('open'));
+      await t.pumpAndSettle();
+      await t.tap(find.byKey(const ValueKey('update_now_button')));
+      await t.pumpAndSettle();
+
+      await t.tap(find.text('DOWNLOAD AND CLOSE'));
+      await t.pumpAndSettle();
+
+      expect(started, isTrue);
+      expect(find.byKey(const ValueKey('update_now_button')), findsNothing);
+      expect(find.text('CLOSE AND UPDATE?'), findsNothing);
+    },
+  );
+
+  testWidgets('note text is platform-aware', (t) async {
+    final inApp = UpdateController(_FakeUpdateRepository())
+      ..installsInApp = true;
+    await t.pumpWidget(_host(inApp));
+    await t.tap(find.text('open'));
+    await t.pumpAndSettle();
+    expect(find.textContaining('Downloads folder'), findsOneWidget);
+    expect(find.textContaining('browser'), findsNothing);
+  });
+```
+
+- [ ] **Step 2: Run tests to verify the new ones fail**
+
+Run: `fvm flutter test test/features/updates/presentation/widgets/update_dialog_test.dart -r compact`
+Expected: the 4 new tests FAIL (no 'CLOSE AND UPDATE?' appears; note text still says browser); the 2 existing tests still PASS.
+
+- [ ] **Step 3: Implement**
+
+In `lib/features/updates/presentation/widgets/update_dialog.dart`:
+
+a) Replace the file header (lines 1–3) with:
+
+```dart
+// Update-available dialog (SKIP THIS VERSION / LATER / UPDATE NOW). UPDATE
+// NOW branches on UpdateController.installsInApp: Windows/Linux confirm
+// "close and update" then download in-app; macOS hands off to the browser.
+```
+
+b) Add the import `package:getman/core/ui/widgets/confirm_dialog.dart` (keep imports alphabetized — `directives_ordering`).
+
+c) Update the class doc's action sentence to:
+
+```dart
+/// Themed dialog shown when an update is available. Shows the version line,
+/// optional changelog, a note about how the download works, and three actions:
+/// SKIP THIS VERSION, LATER, and UPDATE NOW. When
+/// [UpdateController.installsInApp] is true (Windows/Linux) UPDATE NOW first
+/// confirms via [ConfirmDialog] that Getman may close, then starts the in-app
+/// download (see `update_gate_io.dart`); otherwise it opens the release
+/// download in the user's browser and closes the dialog.
+```
+
+d) In `build`, read the flag once and pass it down:
+
+```dart
+  @override
+  Widget build(BuildContext context) {
+    final layout = context.appLayout;
+    final controller = _controller(context);
+    final installsInApp = controller?.installsInApp ?? false;
+
+    return ResponsiveDialogScaffold(
+      title: const Text('UPDATE AVAILABLE'),
+      content: _DialogBody(
+        latestVersion: latestVersion,
+        currentVersion: currentVersion,
+        changelog: changelog,
+        layout: layout,
+        installsInApp: installsInApp,
+      ),
+```
+
+e) Replace the UPDATE NOW button's `onPressed`:
+
+```dart
+        TextButton(
+          key: const ValueKey('update_now_button'),
+          onPressed: () {
+            if (installsInApp) {
+              unawaited(
+                ConfirmDialog.show(
+                  context,
+                  title: 'CLOSE AND UPDATE?',
+                  message:
+                      'Getman will download the update to your Downloads '
+                      'folder and then close itself so the installer can '
+                      'run. Continue?',
+                  confirmLabel: 'DOWNLOAD AND CLOSE',
+                  destructive: false,
+                  // ConfirmDialog pops itself before onConfirm, so `context`
+                  // (the still-mounted update dialog) is safe to pop here.
+                  onConfirm: () {
+                    Navigator.pop(context);
+                    unawaited(controller?.startUpdate?.call());
+                  },
+                ),
+              );
+            } else {
+              unawaited(controller?.startUpdate?.call());
+              Navigator.pop(context);
+            }
+          },
+          style: TextButton.styleFrom(
+            foregroundColor: Theme.of(context).colorScheme.primary,
+          ),
+          child: const Text('UPDATE NOW'),
+        ),
+```
+
+f) `_DialogBody`: add the field + constructor param `required this.installsInApp,` / `final bool installsInApp;`, and replace the final note `Text` with:
+
+```dart
+        Text(
+          installsInApp
+              ? 'UPDATE NOW downloads the installer to your Downloads folder '
+                    'and closes Getman so the installer can run. Getman is '
+                    'not code-signed, so your OS may warn before running it.'
+              : 'UPDATE NOW opens the download in your browser. Getman is '
+                    'not code-signed, so your OS may warn on first launch — '
+                    'allow it via right-click → Open (macOS) or More info → '
+                    'Run anyway (Windows).',
+          style: TextStyle(fontSize: layout.fontSizeSmall),
+        ),
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `fvm flutter test test/features/updates/presentation/widgets/update_dialog_test.dart -r compact`
+Expected: ALL PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/updates/presentation/widgets/update_dialog.dart test/features/updates/presentation/widgets/update_dialog_test.dart
+git commit -m "feat: confirm close-and-update before in-app download in UpdateDialog"
+```
+
+---
+
+### Task 3: Blocking download-progress dialog
+
+**Files:**
+- Create: `lib/features/updates/presentation/widgets/update_download_dialog.dart`
+- Test: `test/features/updates/presentation/widgets/update_download_dialog_test.dart`
+
+**Interfaces:**
+- Produces: `UpdateDownloadDialog` with `static Future<void> show(BuildContext context)` — non-dismissible modal; Task 5's gate calls `show` when the download starts and pops it (via the navigator) on failure.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/features/updates/presentation/widgets/update_download_dialog_test.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/core/theme/themes/brutalist/brutalist_theme.dart';
+import 'package:getman/features/updates/presentation/widgets/update_download_dialog.dart';
+
+void main() {
+  Widget host() {
+    return MaterialApp(
+      theme: brutalistTheme(Brightness.light),
+      home: Scaffold(
+        body: Builder(
+          builder: (context) => Center(
+            child: ElevatedButton(
+              onPressed: () => UpdateDownloadDialog.show(context),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('shows the blocking download dialog with a spinner', (t) async {
+    await t.pumpWidget(host());
+    await t.tap(find.text('open'));
+    await t.pump();
+
+    expect(find.text('DOWNLOADING UPDATE…'), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+  });
+
+  testWidgets('cannot be dismissed by barrier tap or Escape', (t) async {
+    await t.pumpWidget(host());
+    await t.tap(find.text('open'));
+    await t.pump();
+
+    // Barrier tap (top-left corner is outside the dialog card).
+    await t.tapAt(const Offset(5, 5));
+    await t.pump();
+    expect(find.text('DOWNLOADING UPDATE…'), findsOneWidget);
+
+    // Escape key.
+    await t.sendKeyEvent(LogicalKeyboardKey.escape);
+    await t.pump();
+    expect(find.text('DOWNLOADING UPDATE…'), findsOneWidget);
+  });
+}
+```
+
+Note: use `t.pump()` (not `pumpAndSettle`) — the indeterminate spinner animates forever, so `pumpAndSettle` would time out.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `fvm flutter test test/features/updates/presentation/widgets/update_download_dialog_test.dart -r compact`
+Expected: FAIL — compile error, file doesn't exist.
+
+- [ ] **Step 3: Implement**
+
+Create `lib/features/updates/presentation/widgets/update_download_dialog.dart`:
+
+```dart
+// Blocking "DOWNLOADING UPDATE…" progress dialog for the Windows/Linux
+// in-app update flow; deliberately non-dismissible — the user already
+// confirmed Getman will close when the download finishes.
+
+import 'package:flutter/material.dart';
+import 'package:getman/core/theme/app_theme.dart';
+import 'package:getman/core/ui/widgets/responsive_dialog.dart';
+
+/// Modal indeterminate-progress dialog shown while the update installer
+/// downloads. No actions and no dismissal ([PopScope] blocks Escape/back and
+/// the barrier is non-dismissible): the update gate pops it on download
+/// failure, and on success the app quits with it still up. Indeterminate
+/// because `updat` downloads with a single `http.get` — no progress stream.
+class UpdateDownloadDialog extends StatelessWidget {
+  const UpdateDownloadDialog({super.key});
+
+  /// Shows the dialog; the returned future completes when the update gate
+  /// pops it (download failure) — on success the app exits first.
+  static Future<void> show(BuildContext context) {
+    return showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => const UpdateDownloadDialog(),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final layout = context.appLayout;
+    return PopScope(
+      canPop: false,
+      child: ResponsiveDialogScaffold(
+        title: const Text('DOWNLOADING UPDATE…'),
+        content: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const CircularProgressIndicator(),
+            SizedBox(width: layout.tabSpacing),
+            Flexible(
+              child: Text(
+                'Getman will close and run the installer when the download '
+                'finishes.',
+                style: TextStyle(fontSize: layout.fontSizeNormal),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `fvm flutter test test/features/updates/presentation/widgets/update_download_dialog_test.dart -r compact`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/updates/presentation/widgets/update_download_dialog.dart test/features/updates/presentation/widgets/update_download_dialog_test.dart
+git commit -m "feat: add blocking UpdateDownloadDialog for the in-app update flow"
+```
+
+---
+
+### Task 4: Terminal sequence — `finishInAppUpdate` + `launchDownloadedInstaller`
+
+**Files:**
+- Modify: `lib/features/updates/presentation/update_gate_io.dart` (top-level additions only — no widget changes yet)
+- Test: `test/features/updates/presentation/update_gate_io_test.dart`
+
+**Interfaces:**
+- Produces (Task 5 consumes both):
+  - `enum UpdateFinishResult { quitting, launchFailed }`
+  - `Future<UpdateFinishResult> finishInAppUpdate({required Future<void> Function() launchInstaller, required Future<void> Function() flushTabs, required void Function() quit})`
+  - `Future<void> launchDownloadedInstaller(File installer)`
+
+**Ordering rationale (this is a deliberate spec amendment, documented in Task 6):** launch comes FIRST. Flushing first would `close()` the TabsBloc; if the launch then failed, the app would stay open with dead tab persistence. A failed launch must leave the app fully intact.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `test/features/updates/presentation/update_gate_io_test.dart` (inside `main()`, after the existing tests):
+
+```dart
+  group('finishInAppUpdate', () {
+    test('launches, then flushes tabs, then quits — in that order', () async {
+      final calls = <String>[];
+      final result = await finishInAppUpdate(
+        launchInstaller: () async => calls.add('launch'),
+        flushTabs: () async => calls.add('flush'),
+        quit: () => calls.add('quit'),
+      );
+      expect(result, UpdateFinishResult.quitting);
+      expect(calls, ['launch', 'flush', 'quit']);
+    });
+
+    test('a failed launch keeps the app alive: no flush, no quit', () async {
+      final calls = <String>[];
+      final result = await finishInAppUpdate(
+        launchInstaller: () async => throw Exception('no such file'),
+        flushTabs: () async => calls.add('flush'),
+        quit: () => calls.add('quit'),
+      );
+      expect(result, UpdateFinishResult.launchFailed);
+      expect(calls, isEmpty);
+    });
+
+    test('a failed tab flush still quits (best-effort flush)', () async {
+      var quitCalled = false;
+      final result = await finishInAppUpdate(
+        launchInstaller: () async {},
+        flushTabs: () async => throw Exception('hive is gone'),
+        quit: () => quitCalled = true,
+      );
+      expect(result, UpdateFinishResult.quitting);
+      expect(quitCalled, isTrue);
+    });
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `fvm flutter test test/features/updates/presentation/update_gate_io_test.dart -r compact`
+Expected: FAIL — compile error, `finishInAppUpdate` / `UpdateFinishResult` undefined.
+
+- [ ] **Step 3: Implement**
+
+Add at the BOTTOM of `lib/features/updates/presentation/update_gate_io.dart` (after the `_UpdateGateState` class). Also add `import 'package:flutter/foundation.dart' show visibleForTesting;` — NO: `visibleForTesting` comes from `package:meta` via flutter's `material.dart` which is already imported, so no new import is needed.
+
+```dart
+/// Outcome of [finishInAppUpdate]: tells the gate (and tests) apart "the app
+/// is about to exit" from "installer launch failed, keep the app alive".
+enum UpdateFinishResult { quitting, launchFailed }
+
+/// Terminal sequence of the in-app update: launch the downloaded installer,
+/// best-effort flush unsaved tabs, then quit.
+///
+/// Launch comes FIRST deliberately — flushing first would `close()` the
+/// TabsBloc, and if the launch then failed the app would sit open with dead
+/// tab persistence. A failed launch here leaves the app fully intact; a
+/// failed flush never blocks the quit (losing <10 s of tab edits beats
+/// stranding the update with the installer already running).
+@visibleForTesting
+Future<UpdateFinishResult> finishInAppUpdate({
+  required Future<void> Function() launchInstaller,
+  required Future<void> Function() flushTabs,
+  required void Function() quit,
+}) async {
+  try {
+    await launchInstaller();
+  } on Object {
+    return UpdateFinishResult.launchFailed;
+  }
+  try {
+    await flushTabs();
+  } on Object {
+    // Best-effort only — see doc above.
+  }
+  quit();
+  return UpdateFinishResult.quitting;
+}
+
+/// Launches the downloaded installer. Windows: start the Inno Setup `.exe`
+/// detached. Linux: `chmod +x` first, then start the AppImage detached — a
+/// fresh download has no execute bit, so a plain file-open would not run it.
+/// Throws on failure so [finishInAppUpdate] can keep the app alive.
+@visibleForTesting
+Future<void> launchDownloadedInstaller(File installer) async {
+  if (Platform.isLinux) {
+    final chmod = await Process.run('chmod', ['+x', installer.path]);
+    if (chmod.exitCode != 0) {
+      throw ProcessException(
+        'chmod',
+        ['+x', installer.path],
+        chmod.stderr.toString(),
+        chmod.exitCode,
+      );
+    }
+  }
+  await Process.start(
+    installer.path,
+    const <String>[],
+    mode: ProcessStartMode.detached,
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `fvm flutter test test/features/updates/presentation/update_gate_io_test.dart -r compact`
+Expected: ALL PASS (existing 3 + new 3).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/updates/presentation/update_gate_io.dart test/features/updates/presentation/update_gate_io_test.dart
+git commit -m "feat: add launch-flush-quit terminal sequence for in-app updates"
+```
+
+---
+
+### Task 5: Gate wiring — platform flag, download orchestration, status routing
+
+**Files:**
+- Modify: `lib/features/updates/presentation/update_gate_io.dart`
+- Test: `test/features/updates/presentation/update_gate_io_test.dart`
+
+**Interfaces:**
+- Consumes: `UpdateController.installsInApp` (Task 1), `UpdateDownloadDialog.show` (Task 3), `finishInAppUpdate` / `launchDownloadedInstaller` / `UpdateFinishResult` (Task 4), `TabsBloc` from `package:getman/features/tabs/presentation/bloc/tabs_bloc.dart` (provided app-wide in `main.dart`; its `close()` cancels the 10 s debounce and flushes dirty tabs).
+- Produces: `UpdateGate` constructor test seams `debugInstallsInApp` (`bool?`), `debugInstallerLauncher` (`Future<void> Function(File)?`), `debugQuit` (`void Function()?`).
+
+- [ ] **Step 1: Write the failing widget test**
+
+Append to `test/features/updates/presentation/update_gate_io_test.dart` inside `main()`:
+
+```dart
+  testWidgets(
+    'in-app flow: confirm shows the blocking dialog; a failed download pops '
+    'it, shows the error snackbar, and never quits',
+    (tester) async {
+      final controller = UpdateController(
+        _ReleaseRepo(
+          const ReleaseInfo(
+            version: '99.0.0',
+            changelog: null,
+            assetUrl: 'https://example.com/getman-99.0.0.exe',
+          ),
+        ),
+      );
+      final bloc = buildSettingsBloc();
+      var quitCalled = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: brutalistTheme(Brightness.light),
+          home: ChangeNotifierProvider<UpdateController>.value(
+            value: controller,
+            child: BlocProvider.value(
+              value: bloc,
+              child: Scaffold(
+                body: UpdateGate(
+                  debugInstallsInApp: true,
+                  debugQuit: () => quitCalled = true,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Startup check found 99.0.0 → update dialog prompted.
+      await tester.tap(find.byKey(const ValueKey('update_now_button')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('DOWNLOAD AND CLOSE'));
+      await tester.pump();
+
+      // The blocking dialog is up while updat downloads.
+      expect(find.text('DOWNLOADING UPDATE…'), findsOneWidget);
+
+      // flutter_test's HttpClient 400s every request, so the download fails:
+      // dialog popped, snackbar shown, app still alive.
+      await tester.pumpAndSettle();
+      expect(find.text('DOWNLOADING UPDATE…'), findsNothing);
+      expect(find.text("Couldn't download the update."), findsOneWidget);
+      expect(quitCalled, isFalse);
+    },
+  );
+```
+
+Timing note for the implementer: the single `pump()` after DOWNLOAD AND CLOSE should render the dialog because `_startInAppDownload` pushes it synchronously in the confirm handler chain. If the download error lands in the same frame on your machine, replace the intermediate assertion with a comment and keep the post-`pumpAndSettle` assertions — those are the load-bearing ones.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `fvm flutter test test/features/updates/presentation/update_gate_io_test.dart -r compact`
+Expected: the new test FAILS (no `debugInstallsInApp` param → compile error).
+
+- [ ] **Step 3: Implement the gate changes**
+
+All in `lib/features/updates/presentation/update_gate_io.dart`:
+
+a) Replace the file header (lines 1–8) with:
+
+```dart
+// Native-only auto-update gate: the SOLE importer of dart:io, package:updat,
+// package_info_plus, and path_provider (the web-safety gate — see
+// update_gate.dart's conditional export to update_gate_stub.dart on web).
+// Two flows: macOS hands the download to the browser (a file downloaded by
+// this sandboxed, unsigned app carries a strict com.apple.quarantine flag
+// that Gatekeeper reports as "damaged", and the sandbox forbids clearing it);
+// Windows/Linux download in-app via updat to the Downloads folder, then
+// launch the installer and quit (finishInAppUpdate). See class doc below.
+```
+
+b) Add imports (alphabetized within the existing block):
+
+```dart
+import 'package:getman/features/tabs/presentation/bloc/tabs_bloc.dart';
+import 'package:getman/features/updates/presentation/widgets/update_download_dialog.dart';
+import 'package:path_provider/path_provider.dart';
+```
+
+c) Update the class doc and add the seams:
+
+```dart
+/// Invisible widget mounted in `MainScreen`. Hosts one `UpdatWidget` for the
+/// GitHub version *check* (and, on Windows/Linux, the in-app download),
+/// bridges its callbacks into [UpdateController], and shows the themed
+/// [UpdateDialog] / snackbars per the prompt decision.
+///
+/// macOS: the download is handed to the user's browser (see
+/// `_openDownloadInBrowser`) — never performed in-process. Windows/Linux:
+/// updat downloads the installer (blocking [UpdateDownloadDialog]), then
+/// [finishInAppUpdate] launches it, flushes tabs, and quits.
+class UpdateGate extends StatefulWidget {
+  const UpdateGate({
+    super.key,
+    this.debugInstallsInApp,
+    this.debugInstallerLauncher,
+    this.debugQuit,
+  });
+
+  /// Test seams — widget tests run on a macOS host, so the Windows/Linux
+  /// in-app flow is unreachable without overrides. All null in production.
+  @visibleForTesting
+  final bool? debugInstallsInApp;
+
+  @visibleForTesting
+  final Future<void> Function(File installer)? debugInstallerLauncher;
+
+  @visibleForTesting
+  final void Function()? debugQuit;
+
+  @override
+  State<UpdateGate> createState() => _UpdateGateState();
+}
+```
+
+d) In `_UpdateGateState`, add fields + a getter after `_currentVersion`:
+
+```dart
+  /// The installer download target, remembered by [_downloadLocationFor] so
+  /// the finish/error paths can launch it or name it in messages.
+  File? _installerFile;
+
+  /// True from the user's "download and close" confirmation until the
+  /// download resolves. Routes `_onStatus`'s readyToInstall/error into the
+  /// in-app flow (a failed version *check* also emits `error` — this flag
+  /// tells the two apart).
+  bool _inAppDownloadInFlight = false;
+
+  /// Whether the blocking [UpdateDownloadDialog] is on screen, so the error
+  /// path pops exactly it and nothing else.
+  bool _downloadDialogOpen = false;
+
+  /// updat's real in-process downloader, captured from the chip builder.
+  void Function()? _updatStartUpdate;
+
+  bool get _installsInApp =>
+      widget.debugInstallsInApp ?? (Platform.isWindows || Platform.isLinux);
+```
+
+e) In `initState`, publish the flag to the web-safe controller (before `_loadVersion`):
+
+```dart
+  @override
+  void initState() {
+    super.initState();
+    if (_supported) {
+      context.read<UpdateController>().installsInApp = _installsInApp;
+      unawaited(_loadVersion());
+    }
+  }
+```
+
+f) In the `UpdatWidget` construction: pass the download location hook, and fix the stale `getBinaryUrl` comment:
+
+```dart
+      // Used by updat's in-app downloader on Windows/Linux. On macOS the
+      // browser hand-off means it's never invoked.
+      getBinaryUrl: (_) async => controller.cachedRelease?.assetUrl ?? '',
+      getDownloadFileLocation: _downloadLocationFor,
+```
+
+g) In the chip builder, capture updat's downloader and branch `startUpdate` per platform (replace the existing `controller..triggerCheck…` cascade; keep the existing comment about assignment order):
+
+```dart
+            _updatStartUpdate = startUpdate;
+            controller
+              ..triggerCheck = checkForUpdate
+              ..dismiss = dismissUpdate
+              ..startUpdate = () {
+                return _installsInApp
+                    ? _startInAppDownload()
+                    : _openDownloadInBrowser(controller);
+              };
+```
+
+h) Add the orchestration methods to `_UpdateGateState` (after `_openDownloadInBrowser`):
+
+```dart
+  /// Computes (and remembers) where the installer download lands: the user's
+  /// Downloads folder, falling back to the system temp dir when the platform
+  /// reports none (some headless Linux setups; plugin-less tests). Must never
+  /// throw — updat calls it OUTSIDE its own try/catch, so an exception here
+  /// would strand the status at `downloading` with the dialog up forever.
+  Future<File> _downloadLocationFor(String? latestVersion) async {
+    final url = context.read<UpdateController>().cachedRelease?.assetUrl ?? '';
+    Directory? downloads;
+    try {
+      downloads = await getDownloadsDirectory();
+    } on Object {
+      downloads = null;
+    }
+    final dir = downloads ?? Directory.systemTemp;
+    final ext = url.contains('.') ? url.split('.').last : 'bin';
+    final file = File(
+      '${dir.path}${Platform.pathSeparator}$_appName-$latestVersion.$ext',
+    );
+    _installerFile = file;
+    return file;
+  }
+
+  /// Confirmed in-app flow: block the UI with [UpdateDownloadDialog] and hand
+  /// off to updat's downloader. Resolution arrives via [_onStatus]
+  /// (readyToInstall → [_finishInAppUpdate]; error → pop + snackbar).
+  Future<void> _startInAppDownload() async {
+    _inAppDownloadInFlight = true;
+    _downloadDialogOpen = true;
+    unawaited(
+      UpdateDownloadDialog.show(
+        context,
+      ).whenComplete(() => _downloadDialogOpen = false),
+    );
+    _updatStartUpdate?.call();
+  }
+
+  void _popDownloadDialogIfOpen() {
+    if (!_downloadDialogOpen) return;
+    _downloadDialogOpen = false;
+    Navigator.of(context, rootNavigator: true).pop();
+  }
+
+  /// Download finished: run the terminal sequence (launch installer → flush
+  /// tabs → quit). Only the launch-failure outcome returns control here —
+  /// the app must then stay fully usable, with the installer path surfaced.
+  Future<void> _finishInAppUpdate() async {
+    final installer = _installerFile;
+    if (installer == null) return;
+    TabsBloc? tabs;
+    try {
+      tabs = context.read<TabsBloc>();
+    } on Object {
+      tabs = null; // Tests may mount the gate without a TabsBloc.
+    }
+    final launcher = widget.debugInstallerLauncher ?? launchDownloadedInstaller;
+    final result = await finishInAppUpdate(
+      launchInstaller: () => launcher(installer),
+      flushTabs: () async => tabs?.close(),
+      quit: widget.debugQuit ?? _exitApp,
+    );
+    if (!mounted || result != UpdateFinishResult.launchFailed) return;
+    _popDownloadDialogIfOpen();
+    showAppSnackBar(
+      context,
+      'Update downloaded to ${installer.path}, but it could not be opened — '
+      'run it manually.',
+    );
+  }
+
+  static Never _exitApp() => exit(0);
+```
+
+i) In `_onStatus`, replace the final "never occur" comment + fall-through group so `readyToInstall` and the in-app `error` are handled:
+
+```dart
+        case UpdatePhase.error:
+          if (_inAppDownloadInFlight) {
+            // The in-app download failed (not a version check): unblock the
+            // UI and keep the app running.
+            _inAppDownloadInFlight = false;
+            _popDownloadDialogIfOpen();
+            showAppSnackBar(context, "Couldn't download the update.");
+          } else if (controller.manualInFlight) {
+            // A failed *check* only matters to surface when the user
+            // explicitly pressed "Check for updates"; background checks stay
+            // quiet.
+            controller.manualInFlight = false;
+            showAppSnackBar(context, "Couldn't check for updates.");
+          }
+        case UpdatePhase.readyToInstall:
+          if (_inAppDownloadInFlight) {
+            _inAppDownloadInFlight = false;
+            unawaited(_finishInAppUpdate());
+          }
+        // downloading is surfaced by the blocking dialog _startInAppDownload
+        // already pushed; the rest need no side effects.
+        case UpdatePhase.idle:
+        case UpdatePhase.checking:
+        case UpdatePhase.downloading:
+        case UpdatePhase.dismissed:
+          break;
+```
+
+(The existing `available` / `upToDate` cases stay exactly as they are.)
+
+- [ ] **Step 4: Run the whole updates feature suite**
+
+Run: `fvm flutter test test/features/updates -r compact`
+Expected: ALL PASS — including the untouched C1/C2/regression tests (macOS host → `_installsInApp` false → browser path unchanged) and Task 2/3/4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/updates/presentation/update_gate_io.dart test/features/updates/presentation/update_gate_io_test.dart
+git commit -m "feat: in-app download-and-close update flow on Windows/Linux"
+```
+
+---
+
+### Task 6: Documentation sync (architecture doc, spec amendment, CODEMAP)
+
+**Files:**
+- Modify: `docs/architecture/settings-history-updates.md`
+- Modify: `docs/superpowers/specs/2026-07-21-update-download-and-close-design.md`
+- Modify: `docs/CODEMAP.md`
+
+- [ ] **Step 1: Rewrite the auto-update section of `docs/architecture/settings-history-updates.md`**
+
+Replace the paragraph under `## Auto-update (GitHub-release)` (keep the `### Web-safety gate` and `### Auto-update fields` subsections, but update the gate note as shown):
+
+```markdown
+On startup (when `checkForUpdatesOnStartup` is `true`) one `releases/latest`
+check via `GithubReleaseDataSource`; if a newer version is found, `UpdateDialog`
+prompts Update now / Skip this version / Later. Logic lives in
+`update_decision.dart` (`isNewerVersion` + `shouldPromptForUpdate`);
+`UpdateController` (a `ChangeNotifier`) drives dialog state and is provided via
+`ChangeNotifierProvider` above `MaterialApp`. A GENERAL-tab toggle + "CHECK FOR
+UPDATES" button are in `UpdateSettingsSection`. Per-platform installers: `.dmg`
+(macOS), Inno Setup `.exe` (Windows), `AppImage` (Linux).
+
+UPDATE NOW is platform-split via `UpdateController.installsInApp` (set once by
+the io gate at startup):
+
+- **macOS** (`installsInApp == false`): opens the asset URL in the browser —
+  an in-app download by the sandboxed, unsigned app carries a strict
+  `com.apple.quarantine` flag that Gatekeeper reports as "damaged", and the
+  sandbox can't clear it (the v1.4.1 fix; do not re-enable without
+  signing/notarization).
+- **Windows/Linux** (`installsInApp == true`): a `ConfirmDialog`
+  ("CLOSE AND UPDATE?") warns that Getman will close; on confirm, `updat`
+  downloads the installer to the user's Downloads folder behind the blocking
+  `UpdateDownloadDialog`, then `finishInAppUpdate` runs **launch installer →
+  flush tabs (`TabsBloc.close()`, cancels the 10 s debounce) → `exit(0)`**.
+  Launch comes first deliberately: a failed launch must leave the app fully
+  usable, and an early flush would have closed the TabsBloc. Linux gets a
+  `chmod +x` before the AppImage starts. A failed download pops the dialog and
+  snackbars; a failed launch surfaces the downloaded path. `updat`'s own
+  `openOnDownload`/`closeOnInstall` stay **off** — its `closeOnInstall` calls
+  `exit(0)` without flushing tabs.
+```
+
+And in the `### Web-safety gate` subsection, update the `update_gate_io.dart` bullet's parenthetical — it currently says the file does **not** import `path_provider`; it now does (for `getDownloadsDirectory`):
+
+```markdown
+- `update_gate_io.dart` — native only; the **sole importer of `updat`,
+  `dart:io`, `package_info_plus`, and `path_provider`** (the latter for
+  `getDownloadsDirectory` in the in-app download flow; the response media
+  viewers' `*_io.dart` files also import it).
+```
+
+- [ ] **Step 2: Amend the spec's ordering**
+
+In `docs/superpowers/specs/2026-07-21-update-download-and-close-design.md`, the "On success, in order" list says flush → launch → exit. Replace that numbered list with:
+
+```markdown
+4. On success, in order (*amended during planning — launch moved first: a
+   failed launch must leave the app fully usable, and flushing first would
+   have `close()`d the TabsBloc, killing tab persistence*):
+   1. Launch the installer:
+      - **Windows:** start the downloaded `.exe` detached.
+      - **Linux:** `chmod +x` the AppImage, then start it detached
+        (a plain file-open does not execute a fresh AppImage).
+   2. Flush unsaved tabs — `TabsBloc.close()` (cancels the 10 s debounce and
+      writes dirty tabs; best-effort — a failed flush never blocks the quit).
+   3. `exit(0)`.
+```
+
+- [ ] **Step 3: Update CODEMAP**
+
+In `docs/CODEMAP.md`:
+- Line ~197 (`lib/features/updates/presentation/widgets` row): add `update_download_dialog.dart` → new cell text: `` `update_dialog.dart`, `update_download_dialog.dart` (blocking in-app download progress), `update_settings_section.dart`. ``
+- Line ~351 (Auto-update flow step 5): replace the parenthetical `(UPDATE NOW opens the browser)` with `(UPDATE NOW: macOS opens the browser; Windows/Linux confirm, download in-app, launch the installer, and quit)`.
+
+- [ ] **Step 4: Run the docs coverage test**
+
+Run: `fvm flutter test test/docs -r compact` — if that path doesn't exist, find it with `grep -rln 'CODEMAP' test/ | head` and run the matching test file.
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/architecture/settings-history-updates.md docs/superpowers/specs/2026-07-21-update-download-and-close-design.md docs/CODEMAP.md
+git commit -m "docs: document the Windows/Linux download-and-close update flow"
+```
+
+---
+
+### Task 7: Full verification bar
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run all four static-analysis passes + format + full test suite**
+
+```bash
+fvm flutter analyze
+fvm dart run custom_lint
+( cd tools/getman_lints/example && fvm dart run custom_lint )
+fvm dart run bloc_tools:bloc lint lib
+fvm dart format lib test tools
+fvm flutter test
+```
+
+Expected: analyze `No issues found!`; custom_lint `No issues found!` (both); bloc lint `0 issues`; format `0 changed`; tests 100% green. Fix anything that surfaces (likely candidates: import ordering, `discarded_futures` on a missed future, line length from the long strings) and re-run until all clean.
+
+- [ ] **Step 2: Commit any fixes**
+
+```bash
+git add -A && git commit -m "chore: verification-bar fixes for the update flow"
+```
+
+(Skip the commit if the tree is already clean.)
+
+---
+
+### Task 8: Wiki sync (mandate)
+
+**Files:** external repo `https://github.com/thiagomiranda3/Getman.wiki.git` (branch `master`).
+
+- [ ] **Step 1: Clone the wiki into the scratchpad and find the Auto-Update page**
+
+```bash
+git clone https://github.com/thiagomiranda3/Getman.wiki.git "$SCRATCHPAD/wiki"
+ls "$SCRATCHPAD/wiki" | grep -i -e update -e auto
+```
+
+(`$SCRATCHPAD` = the session scratchpad directory. The page is likely `Auto-Update.md`; check `_Sidebar.md` if unsure.)
+
+- [ ] **Step 2: Update the page**
+
+Rewrite the "what UPDATE NOW does" portion to describe both flows, using verbatim UI labels. Content to convey (adapt to the page's existing voice/structure — read it first):
+
+- **Windows / Linux:** clicking **UPDATE NOW** opens a confirmation box titled **CLOSE AND UPDATE?** explaining Getman will download the update to your Downloads folder and then close itself so the installer can run. **CANCEL** returns to the update dialog. **DOWNLOAD AND CLOSE** downloads the installer (`getman-<version>.exe` / `.AppImage`) behind a **DOWNLOADING UPDATE…** progress dialog; when it finishes, the installer opens automatically and Getman closes itself. If the download fails, Getman stays open and shows an error. Getman is not code-signed, so your OS may warn before running the installer.
+- **macOS:** unchanged — **UPDATE NOW** opens the download in your browser (Getman can't safely download it in-app while unsigned); allow the app on first launch via right-click → Open.
+
+- [ ] **Step 3: Commit and push the wiki**
+
+```bash
+cd "$SCRATCHPAD/wiki"
+git add -A && git commit -m "docs: document the Windows/Linux download-and-close update flow" && git push origin master
+```
+
+Expected: push succeeds (gh/keyring auth is already set up for `thiagomiranda3`).

--- a/docs/superpowers/specs/2026-07-21-update-download-and-close-design.md
+++ b/docs/superpowers/specs/2026-07-21-update-download-and-close-design.md
@@ -1,0 +1,103 @@
+# Update download-and-close flow — design
+
+**Date:** 2026-07-21
+**Status:** Approved
+**Feature:** In-app installer download with confirm-close, auto-open, and auto-quit (Windows/Linux)
+
+## Problem
+
+Today UPDATE NOW hands the release download to the user's browser on every
+platform. The user then has to notice the download finishing, find the file,
+quit Getman, and run the installer by hand. On Windows and Linux none of that
+indirection is necessary — the `updat` package already in the app can download
+the installer and launch it. (On macOS the browser hand-off is load-bearing:
+a file downloaded by the sandboxed, unsigned app carries a strict
+`com.apple.quarantine` flag that Gatekeeper escalates to "damaged", and the
+sandbox cannot clear it — the exact bug fixed in v1.4.1. macOS behavior does
+not change.)
+
+## Decisions made during brainstorming
+
+- **macOS keeps the browser hand-off** (no in-app download, no auto-quit).
+- **Blocking indeterminate progress dialog** during the download — the user
+  just agreed to close the app, so blocking is honest and nothing new is lost.
+  No percentage is available (`updat` downloads via a single `http.get`).
+- **Approach A**: reuse `updat`'s download/launch machinery, orchestrated by
+  our code, rather than a custom `dio` downloader (B) or browser-everywhere (C).
+
+## UX flow
+
+### Windows / Linux
+
+1. Update dialog (unchanged) → user clicks **UPDATE NOW**.
+2. `ConfirmDialog.show` appears **on top of** the update dialog:
+   - Title: `CLOSE AND UPDATE?`
+   - Message: "Getman will download the update to your Downloads folder and
+     then close itself so the installer can run. Continue?"
+   - **Cancel** → confirm box closes, update dialog is still open, nothing
+     downloaded.
+   - **Confirm** → update dialog closes and the download starts.
+3. A non-dismissible themed **DOWNLOADING UPDATE…** dialog (indeterminate
+   spinner) blocks the UI. `updat` downloads the installer to the user's
+   **Downloads folder** as `getman-<version>.exe` / `getman-<version>.AppImage`.
+4. On success, in order:
+   1. Flush unsaved tabs — `TabsBloc.close()` (cancels the 10 s debounce and
+      writes dirty tabs; see docs/architecture/persistence-hive.md).
+   2. Launch the installer:
+      - **Windows:** shell-open the downloaded `.exe` (updat's
+        `launchInstaller`, a `file://` open).
+      - **Linux:** `chmod +x` the AppImage, then `Process.start` it detached
+        (a plain file-open does not execute a fresh AppImage).
+   3. `exit(0)`.
+
+### macOS
+
+Unchanged: UPDATE NOW opens the asset URL in the browser. One fix that falls
+out: the update dialog's note text currently claims "UPDATE NOW opens the
+download in your browser" on *all* platforms — it becomes platform-aware
+(Windows/Linux: "UPDATE NOW downloads the installer to your Downloads folder
+and closes Getman to run it.").
+
+## Code changes
+
+| File | Change |
+|---|---|
+| `update_controller.dart` (web-safe) | New `installsInApp` flag (default `false`), set by the gate on Windows/Linux. This is how the platform-agnostic dialog picks its flow without importing `dart:io` (`platform_io_outside_io_files` stays happy). |
+| `update_dialog.dart` | UPDATE NOW checks `installsInApp` → shows the ConfirmDialog first (cancel keeps the update dialog open); browser path untouched. Note text becomes flag-aware. |
+| `update_gate_io.dart` | Keeps `openOnDownload: false` and `closeOnInstall: false` and orchestrates itself: captures updat's real `startUpdate`, supplies `getDownloadFileLocation` (so the installer path is known for launch/chmod/error messages), tracks an `_inAppDownloadInFlight` flag so `_onStatus` routes `downloading` → show progress dialog, `readyToInstall` → flush-launch-exit, `error` → pop progress dialog + error snackbar (app stays open). |
+| `widgets/update_download_dialog.dart` (new) | The blocking progress dialog (`PopScope(canPop: false)`, themed, indeterminate spinner). |
+| Quit seam | The `exit(0)` call sits behind an injectable hook so tests can assert "would have exited" without killing the test runner. |
+
+`updat`'s `closeOnInstall` is deliberately **not** used: it calls `exit(0)`
+immediately after launching the installer, which would skip the tab flush.
+
+## Error handling
+
+- **Download fails** → progress dialog closes, `showAppSnackBar` "Couldn't
+  download the update.", app stays open (a re-check from Settings re-prompts).
+- **Installer launch fails after a good download** → snackbar including the
+  downloaded file path so the user can run it manually; **no exit**.
+- **Browser fails on macOS** → unchanged existing fallback message.
+
+## Testing
+
+- Widget tests: UPDATE NOW with `installsInApp` true shows the ConfirmDialog;
+  cancel keeps the update dialog and downloads nothing; confirm pops both and
+  invokes `startUpdate`. Flag false → browser path unchanged. Note text per
+  flag. Progress dialog renders and is not dismissible.
+- Gate orchestration tests via the injectable exit seam: ready-to-install
+  triggers flush → launch → exit in order; error path keeps the app open.
+- Existing macOS-path tests stay green.
+
+## Docs & wiki (sync mandate)
+
+- Wiki Auto-Update page: new confirm box, Windows/Linux in-app download +
+  auto-open + auto-close, macOS unchanged. Verbatim UI labels.
+- `docs/architecture/settings-history-updates.md`: auto-update section
+  rewritten to describe the per-platform split.
+
+## Out of scope
+
+- macOS in-app download (blocked on code-signing/notarization).
+- Download progress percentage or cancellation (would require Approach B).
+- Signing the app.

--- a/docs/superpowers/specs/2026-07-21-update-download-and-close-design.md
+++ b/docs/superpowers/specs/2026-07-21-update-download-and-close-design.md
@@ -65,7 +65,7 @@ and closes Getman to run it.").
 |---|---|
 | `update_controller.dart` (web-safe) | New `installsInApp` flag (default `false`), set by the gate on Windows/Linux. This is how the platform-agnostic dialog picks its flow without importing `dart:io` (`platform_io_outside_io_files` stays happy). |
 | `update_dialog.dart` | UPDATE NOW checks `installsInApp` → shows the ConfirmDialog first (cancel keeps the update dialog open); browser path untouched. Note text becomes flag-aware. |
-| `update_gate_io.dart` | Keeps `openOnDownload: false` and `closeOnInstall: false` and orchestrates itself: captures updat's real `startUpdate`, supplies `getDownloadFileLocation` (so the installer path is known for launch/chmod/error messages), tracks an `_inAppDownloadInFlight` flag so `_onStatus` routes `downloading` → show progress dialog, `readyToInstall` → flush-launch-exit, `error` → pop progress dialog + error snackbar (app stays open). |
+| `update_gate_io.dart` | Keeps `openOnDownload: false` and `closeOnInstall: false` and orchestrates itself: captures updat's real `startUpdate`, supplies `getDownloadFileLocation` (so the installer path is known for launch/chmod/error messages), tracks an `_inAppDownloadInFlight` flag so `_onStatus` routes `downloading` → show progress dialog, `readyToInstall` → launch-flush-exit, `error` → pop progress dialog + error snackbar (app stays open). |
 | `widgets/update_download_dialog.dart` (new) | The blocking progress dialog (`PopScope(canPop: false)`, themed, indeterminate spinner). |
 | Quit seam | The `exit(0)` call sits behind an injectable hook so tests can assert "would have exited" without killing the test runner. |
 
@@ -87,7 +87,7 @@ immediately after launching the installer, which would skip the tab flush.
   invokes `startUpdate`. Flag false → browser path unchanged. Note text per
   flag. Progress dialog renders and is not dismissible.
 - Gate orchestration tests via the injectable exit seam: ready-to-install
-  triggers flush → launch → exit in order; error path keeps the app open.
+  triggers launch → flush → exit in order; error path keeps the app open.
 - Existing macOS-path tests stay green.
 
 ## Docs & wiki (sync mandate)

--- a/docs/superpowers/specs/2026-07-21-update-download-and-close-design.md
+++ b/docs/superpowers/specs/2026-07-21-update-download-and-close-design.md
@@ -40,14 +40,15 @@ not change.)
 3. A non-dismissible themed **DOWNLOADING UPDATE…** dialog (indeterminate
    spinner) blocks the UI. `updat` downloads the installer to the user's
    **Downloads folder** as `getman-<version>.exe` / `getman-<version>.AppImage`.
-4. On success, in order:
-   1. Flush unsaved tabs — `TabsBloc.close()` (cancels the 10 s debounce and
-      writes dirty tabs; see docs/architecture/persistence-hive.md).
-   2. Launch the installer:
-      - **Windows:** shell-open the downloaded `.exe` (updat's
-        `launchInstaller`, a `file://` open).
-      - **Linux:** `chmod +x` the AppImage, then `Process.start` it detached
+4. On success, in order (*amended during planning — launch moved first: a
+   failed launch must leave the app fully usable, and flushing first would
+   have `close()`d the TabsBloc, killing tab persistence*):
+   1. Launch the installer:
+      - **Windows:** start the downloaded `.exe` detached.
+      - **Linux:** `chmod +x` the AppImage, then start it detached
         (a plain file-open does not execute a fresh AppImage).
+   2. Flush unsaved tabs — `TabsBloc.close()` (cancels the 10 s debounce and
+      writes dirty tabs; best-effort — a failed flush never blocks the quit).
    3. `exit(0)`.
 
 ### macOS

--- a/lib/features/updates/presentation/update_controller.dart
+++ b/lib/features/updates/presentation/update_controller.dart
@@ -22,6 +22,12 @@ class UpdateController extends ChangeNotifier {
   bool manualInFlight = false;
   ReleaseInfo? cachedRelease;
 
+  /// True when this platform installs updates in-app (Windows/Linux: download
+  /// to the Downloads folder, then auto-launch + quit) rather than handing
+  /// the download to the browser (macOS, web). Set once by the io gate at
+  /// startup — a plain field, no [notifyListeners] needed.
+  bool installsInApp = false;
+
   // Set by the gate each build (captured from `updat`'s builder callbacks).
   VoidCallback? triggerCheck;
   Future<void> Function()? startUpdate;

--- a/lib/features/updates/presentation/update_gate_io.dart
+++ b/lib/features/updates/presentation/update_gate_io.dart
@@ -1,6 +1,7 @@
-// Native-only auto-update gate: the SOLE importer of dart:io, package:updat,
-// package_info_plus, and path_provider (the web-safety gate — see
-// update_gate.dart's conditional export to update_gate_stub.dart on web).
+// Native-only auto-update gate: the SOLE importer of package:updat and
+// package_info_plus; one of the io-gated (*_io.dart) importers of dart:io and
+// path_provider (the web-safety gate — see update_gate.dart's conditional
+// export to update_gate_stub.dart on web).
 // Two flows: macOS hands the download to the browser (a file downloaded by
 // this sandboxed, unsigned app carries a strict com.apple.quarantine flag
 // that Gatekeeper reports as "damaged", and the sandbox forbids clearing it);
@@ -33,14 +34,16 @@ import 'package:url_launcher/url_launcher.dart';
 ///
 /// macOS: the download is handed to the user's browser (see
 /// `_openDownloadInBrowser`) — never performed in-process. Windows/Linux:
-/// updat downloads the installer (blocking [UpdateDownloadDialog]), then
-/// [finishInAppUpdate] launches it, flushes tabs, and quits.
+/// updat downloads the installer (blocking [UpdateDownloadDialog], guarded by
+/// a download-stall watchdog), then [finishInAppUpdate] launches it, flushes
+/// tabs, and quits.
 class UpdateGate extends StatefulWidget {
   const UpdateGate({
     super.key,
     this.debugInstallsInApp,
     this.debugInstallerLauncher,
     this.debugQuit,
+    this.debugDownloadTimeout,
   });
 
   /// Test seams — widget tests run on a macOS host, so the Windows/Linux
@@ -53,6 +56,11 @@ class UpdateGate extends StatefulWidget {
 
   @visibleForTesting
   final void Function()? debugQuit;
+
+  /// Overrides the download-stall watchdog's duration (production default:
+  /// 10 minutes) so a fire path can be exercised deterministically in tests.
+  @visibleForTesting
+  final Duration? debugDownloadTimeout;
 
   @override
   State<UpdateGate> createState() => _UpdateGateState();
@@ -77,6 +85,13 @@ class _UpdateGateState extends State<UpdateGate> {
 
   /// updat's real in-process downloader, captured from the chip builder.
   void Function()? _updatStartUpdate;
+
+  /// Guards against updat's downloader (a single `http.get` with no timeout)
+  /// stalling mid-transfer and leaving the non-dismissible
+  /// [UpdateDownloadDialog] up forever. Started in [_startInAppDownload];
+  /// cancelled on any terminal resolution (`_onStatus`'s error/readyToInstall
+  /// branches) and in [dispose].
+  Timer? _downloadWatchdog;
 
   bool get _installsInApp =>
       widget.debugInstallsInApp ?? (Platform.isWindows || Platform.isLinux);
@@ -103,6 +118,12 @@ class _UpdateGateState extends State<UpdateGate> {
       context.read<UpdateController>().installsInApp = _installsInApp;
       unawaited(_loadVersion());
     }
+  }
+
+  @override
+  void dispose() {
+    _downloadWatchdog?.cancel();
+    super.dispose();
   }
 
   Future<void> _loadVersion() async {
@@ -261,14 +282,33 @@ class _UpdateGateState extends State<UpdateGate> {
 
   /// Confirmed in-app flow: block the UI with [UpdateDownloadDialog] and hand
   /// off to updat's downloader. Resolution arrives via [_onStatus]
-  /// (readyToInstall → [_finishInAppUpdate]; error → pop + snackbar).
+  /// (readyToInstall → [_finishInAppUpdate]; error → pop + snackbar). A
+  /// watchdog timer guards against the download stalling forever (see
+  /// [_downloadWatchdog]).
   Future<void> _startInAppDownload() async {
+    // Capture always precedes prompts today, so `_updatStartUpdate` should
+    // never be null here — this guard just prevents a permanent blocking
+    // modal if that ever stops being true.
+    if (_updatStartUpdate == null) return;
     _inAppDownloadInFlight = true;
     _downloadDialogOpen = true;
     unawaited(
       UpdateDownloadDialog.show(
         context,
       ).whenComplete(() => _downloadDialogOpen = false),
+    );
+    _downloadWatchdog = Timer(
+      widget.debugDownloadTimeout ?? const Duration(minutes: 10),
+      () {
+        if (!_inAppDownloadInFlight || !mounted) return;
+        _inAppDownloadInFlight = false;
+        _popDownloadDialogIfOpen();
+        showAppSnackBar(context, 'The update download timed out.');
+        // If updat's downloader resolves after this fires, `_onStatus`'s
+        // readyToInstall/error branches see `_inAppDownloadInFlight ==
+        // false` and no-op, so a late completion is a harmless no-op rather
+        // than reopening the dialog or launching a stale installer.
+      },
     );
     _updatStartUpdate?.call();
   }
@@ -330,6 +370,7 @@ class _UpdateGateState extends State<UpdateGate> {
           if (_inAppDownloadInFlight) {
             // The in-app download failed (not a version check): unblock the
             // UI and keep the app running.
+            _downloadWatchdog?.cancel();
             _inAppDownloadInFlight = false;
             _popDownloadDialogIfOpen();
             showAppSnackBar(context, "Couldn't download the update.");
@@ -342,6 +383,7 @@ class _UpdateGateState extends State<UpdateGate> {
           }
         case UpdatePhase.readyToInstall:
           if (_inAppDownloadInFlight) {
+            _downloadWatchdog?.cancel();
             _inAppDownloadInFlight = false;
             unawaited(_finishInAppUpdate());
           }
@@ -424,8 +466,9 @@ Future<UpdateFinishResult> finishInAppUpdate({
   }
   try {
     await flushTabs();
-  } on Object {
+  } on Object catch (e) {
     // Best-effort only — see doc above.
+    debugPrint('Tab flush before update install failed: $e');
   }
   quit();
   return UpdateFinishResult.quitting;

--- a/lib/features/updates/presentation/update_gate_io.dart
+++ b/lib/features/updates/presentation/update_gate_io.dart
@@ -262,3 +262,59 @@ class _UpdateGateState extends State<UpdateGate> {
     UpdatStatus.dismissed => UpdatePhase.dismissed,
   };
 }
+
+/// Outcome of [finishInAppUpdate]: tells the gate (and tests) apart "the app
+/// is about to exit" from "installer launch failed, keep the app alive".
+enum UpdateFinishResult { quitting, launchFailed }
+
+/// Terminal sequence of the in-app update: launch the downloaded installer,
+/// best-effort flush unsaved tabs, then quit.
+///
+/// Launch comes FIRST deliberately — flushing first would `close()` the
+/// TabsBloc, and if the launch then failed the app would sit open with dead
+/// tab persistence. A failed launch here leaves the app fully intact; a
+/// failed flush never blocks the quit (losing <10 s of tab edits beats
+/// stranding the update with the installer already running).
+@visibleForTesting
+Future<UpdateFinishResult> finishInAppUpdate({
+  required Future<void> Function() launchInstaller,
+  required Future<void> Function() flushTabs,
+  required void Function() quit,
+}) async {
+  try {
+    await launchInstaller();
+  } on Object {
+    return UpdateFinishResult.launchFailed;
+  }
+  try {
+    await flushTabs();
+  } on Object {
+    // Best-effort only — see doc above.
+  }
+  quit();
+  return UpdateFinishResult.quitting;
+}
+
+/// Launches the downloaded installer. Windows: start the Inno Setup `.exe`
+/// detached. Linux: `chmod +x` first, then start the AppImage detached — a
+/// fresh download has no execute bit, so a plain file-open would not run it.
+/// Throws on failure so [finishInAppUpdate] can keep the app alive.
+@visibleForTesting
+Future<void> launchDownloadedInstaller(File installer) async {
+  if (Platform.isLinux) {
+    final chmod = await Process.run('chmod', ['+x', installer.path]);
+    if (chmod.exitCode != 0) {
+      throw ProcessException(
+        'chmod',
+        ['+x', installer.path],
+        chmod.stderr.toString(),
+        chmod.exitCode,
+      );
+    }
+  }
+  await Process.start(
+    installer.path,
+    const <String>[],
+    mode: ProcessStartMode.detached,
+  );
+}

--- a/lib/features/updates/presentation/update_gate_io.dart
+++ b/lib/features/updates/presentation/update_gate_io.dart
@@ -1,11 +1,11 @@
 // Native-only auto-update gate: the SOLE importer of dart:io, package:updat,
-// and package_info_plus (the web-safety gate — see update_gate.dart's
-// conditional export to update_gate_stub.dart on web). Uses `updat` purely for
-// the GitHub version *check*; the actual download is always handed off to the
-// user's default browser (_openDownloadInBrowser), never performed in-process
-// — a file downloaded by this sandboxed, unsigned app carries a strict
-// com.apple.quarantine flag that macOS Gatekeeper reports as "damaged", and
-// the sandbox forbids clearing that flag ourselves. See class doc below.
+// package_info_plus, and path_provider (the web-safety gate — see
+// update_gate.dart's conditional export to update_gate_stub.dart on web).
+// Two flows: macOS hands the download to the browser (a file downloaded by
+// this sandboxed, unsigned app carries a strict com.apple.quarantine flag
+// that Gatekeeper reports as "damaged", and the sandbox forbids clearing it);
+// Windows/Linux download in-app via updat to the Downloads folder, then
+// launch the installer and quit (finishInAppUpdate). See class doc below.
 
 import 'dart:async';
 import 'dart:io';
@@ -14,24 +14,45 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:getman/core/ui/widgets/app_snack_bar.dart';
 import 'package:getman/features/settings/presentation/bloc/settings_bloc.dart';
+import 'package:getman/features/tabs/presentation/bloc/tabs_bloc.dart';
 import 'package:getman/features/updates/domain/entities/release_info.dart';
 import 'package:getman/features/updates/presentation/update_controller.dart';
 import 'package:getman/features/updates/presentation/update_decision.dart';
 import 'package:getman/features/updates/presentation/update_phase.dart';
 import 'package:getman/features/updates/presentation/widgets/update_dialog.dart';
+import 'package:getman/features/updates/presentation/widgets/update_download_dialog.dart';
 import 'package:package_info_plus/package_info_plus.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:updat/updat.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-/// Invisible widget mounted in `MainScreen`. Hosts one `UpdatWidget` purely for
-/// the GitHub version *check*, bridges its callbacks into [UpdateController],
-/// and shows the themed [UpdateDialog] / snackbars per the prompt decision.
+/// Invisible widget mounted in `MainScreen`. Hosts one `UpdatWidget` for the
+/// GitHub version *check* (and, on Windows/Linux, the in-app download),
+/// bridges its callbacks into [UpdateController], and shows the themed
+/// [UpdateDialog] / snackbars per the prompt decision.
 ///
-/// Note: the actual download is intentionally handed to the user's browser
-/// (see `_openDownloadInBrowser`), not performed in-process, so this gate
-/// never drives `updat`'s download/install flow.
+/// macOS: the download is handed to the user's browser (see
+/// `_openDownloadInBrowser`) — never performed in-process. Windows/Linux:
+/// updat downloads the installer (blocking [UpdateDownloadDialog]), then
+/// [finishInAppUpdate] launches it, flushes tabs, and quits.
 class UpdateGate extends StatefulWidget {
-  const UpdateGate({super.key});
+  const UpdateGate({
+    super.key,
+    this.debugInstallsInApp,
+    this.debugInstallerLauncher,
+    this.debugQuit,
+  });
+
+  /// Test seams — widget tests run on a macOS host, so the Windows/Linux
+  /// in-app flow is unreachable without overrides. All null in production.
+  @visibleForTesting
+  final bool? debugInstallsInApp;
+
+  @visibleForTesting
+  final Future<void> Function(File installer)? debugInstallerLauncher;
+
+  @visibleForTesting
+  final void Function()? debugQuit;
 
   @override
   State<UpdateGate> createState() => _UpdateGateState();
@@ -39,6 +60,26 @@ class UpdateGate extends StatefulWidget {
 
 class _UpdateGateState extends State<UpdateGate> {
   String? _currentVersion;
+
+  /// The installer download target, remembered by [_downloadLocationFor] so
+  /// the finish/error paths can launch it or name it in messages.
+  File? _installerFile;
+
+  /// True from the user's "download and close" confirmation until the
+  /// download resolves. Routes `_onStatus`'s readyToInstall/error into the
+  /// in-app flow (a failed version *check* also emits `error` — this flag
+  /// tells the two apart).
+  bool _inAppDownloadInFlight = false;
+
+  /// Whether the blocking [UpdateDownloadDialog] is on screen, so the error
+  /// path pops exactly it and nothing else.
+  bool _downloadDialogOpen = false;
+
+  /// updat's real in-process downloader, captured from the chip builder.
+  void Function()? _updatStartUpdate;
+
+  bool get _installsInApp =>
+      widget.debugInstallsInApp ?? (Platform.isWindows || Platform.isLinux);
 
   static const _appName = 'getman';
 
@@ -58,7 +99,10 @@ class _UpdateGateState extends State<UpdateGate> {
   @override
   void initState() {
     super.initState();
-    if (_supported) unawaited(_loadVersion());
+    if (_supported) {
+      context.read<UpdateController>().installsInApp = _installsInApp;
+      unawaited(_loadVersion());
+    }
   }
 
   Future<void> _loadVersion() async {
@@ -80,9 +124,10 @@ class _UpdateGateState extends State<UpdateGate> {
       getLatestVersion: () => _getLatestVersion(controller),
       getChangelog: (latestVer, appVer) async =>
           controller.cachedRelease?.changelog ?? '',
-      // Required by UpdatWidget but never invoked: we hand the download to the
-      // browser rather than calling updat's in-process `startUpdate()`.
+      // Used by updat's in-app downloader on Windows/Linux. On macOS the
+      // browser hand-off means it's never invoked.
       getBinaryUrl: (_) async => controller.cachedRelease?.assetUrl ?? '',
+      getDownloadFileLocation: _downloadLocationFor,
       callback: (status) => _onStatus(context, controller, status),
       updateChipBuilder:
           ({
@@ -97,15 +142,19 @@ class _UpdateGateState extends State<UpdateGate> {
             required dismissUpdate,
           }) {
             // Capture the callbacks synchronously — plain field assignments,
-            // no listener notification. `startUpdate` is repointed at the
-            // browser hand-off instead of updat's downloader. It is assigned
-            // last and with a block body: a trailing `=> expr` in a cascade
-            // would bind the next `..` to the closure's return value.
+            // no listener notification. `startUpdate` branches per platform:
+            // Windows/Linux drive updat's own downloader in-app; macOS keeps
+            // the browser hand-off. It is assigned last and with a block
+            // body: a trailing `=> expr` in a cascade would bind the next
+            // `..` to the closure's return value.
+            _updatStartUpdate = startUpdate;
             controller
               ..triggerCheck = checkForUpdate
               ..dismiss = dismissUpdate
               ..startUpdate = () {
-                return _openDownloadInBrowser(controller);
+                return _installsInApp
+                    ? _startInAppDownload()
+                    : _openDownloadInBrowser(controller);
               };
 
             // Defer the notifying updateFromGate call out of build, mirroring
@@ -183,6 +232,82 @@ class _UpdateGateState extends State<UpdateGate> {
     );
   }
 
+  /// Computes (and remembers) where the installer download lands: the user's
+  /// Downloads folder, falling back to the system temp dir when the platform
+  /// reports none (some headless Linux setups; plugin-less tests — a widget
+  /// test has no macOS/Windows/Linux platform channel wired up at all, so the
+  /// call never replies rather than resolving null, hence the timeout below).
+  /// Must never throw — updat calls it OUTSIDE its own try/catch, so an
+  /// exception here would strand the status at `downloading` with the dialog
+  /// up forever; the same goes for a hang, hence the bounded wait.
+  Future<File> _downloadLocationFor(String? latestVersion) async {
+    final url = context.read<UpdateController>().cachedRelease?.assetUrl ?? '';
+    Directory? downloads;
+    try {
+      downloads = await getDownloadsDirectory().timeout(
+        const Duration(seconds: 3),
+      );
+    } on Object {
+      downloads = null;
+    }
+    final dir = downloads ?? Directory.systemTemp;
+    final ext = url.contains('.') ? url.split('.').last : 'bin';
+    final file = File(
+      '${dir.path}${Platform.pathSeparator}$_appName-$latestVersion.$ext',
+    );
+    _installerFile = file;
+    return file;
+  }
+
+  /// Confirmed in-app flow: block the UI with [UpdateDownloadDialog] and hand
+  /// off to updat's downloader. Resolution arrives via [_onStatus]
+  /// (readyToInstall → [_finishInAppUpdate]; error → pop + snackbar).
+  Future<void> _startInAppDownload() async {
+    _inAppDownloadInFlight = true;
+    _downloadDialogOpen = true;
+    unawaited(
+      UpdateDownloadDialog.show(
+        context,
+      ).whenComplete(() => _downloadDialogOpen = false),
+    );
+    _updatStartUpdate?.call();
+  }
+
+  void _popDownloadDialogIfOpen() {
+    if (!_downloadDialogOpen) return;
+    _downloadDialogOpen = false;
+    Navigator.of(context, rootNavigator: true).pop();
+  }
+
+  /// Download finished: run the terminal sequence (launch installer → flush
+  /// tabs → quit). Only the launch-failure outcome returns control here —
+  /// the app must then stay fully usable, with the installer path surfaced.
+  Future<void> _finishInAppUpdate() async {
+    final installer = _installerFile;
+    if (installer == null) return;
+    TabsBloc? tabs;
+    try {
+      tabs = context.read<TabsBloc>();
+    } on Object {
+      tabs = null; // Tests may mount the gate without a TabsBloc.
+    }
+    final launcher = widget.debugInstallerLauncher ?? launchDownloadedInstaller;
+    final result = await finishInAppUpdate(
+      launchInstaller: () => launcher(installer),
+      flushTabs: () async => tabs?.close(),
+      quit: widget.debugQuit ?? _exitApp,
+    );
+    if (!mounted || result != UpdateFinishResult.launchFailed) return;
+    _popDownloadDialogIfOpen();
+    showAppSnackBar(
+      context,
+      'Update downloaded to ${installer.path}, but it could not be opened — '
+      'run it manually.',
+    );
+  }
+
+  static Never _exitApp() => exit(0);
+
   void _onStatus(
     BuildContext context,
     UpdateController controller,
@@ -202,18 +327,29 @@ class _UpdateGateState extends State<UpdateGate> {
             showAppSnackBar(context, "You're on the latest version.");
           }
         case UpdatePhase.error:
-          // A failed *check* only matters to surface when the user explicitly
-          // pressed "Check for updates"; background checks stay quiet.
-          if (controller.manualInFlight) {
+          if (_inAppDownloadInFlight) {
+            // The in-app download failed (not a version check): unblock the
+            // UI and keep the app running.
+            _inAppDownloadInFlight = false;
+            _popDownloadDialogIfOpen();
+            showAppSnackBar(context, "Couldn't download the update.");
+          } else if (controller.manualInFlight) {
+            // A failed *check* only matters to surface when the user
+            // explicitly pressed "Check for updates"; background checks stay
+            // quiet.
             controller.manualInFlight = false;
             showAppSnackBar(context, "Couldn't check for updates.");
           }
-        // The download/install phases never occur now that the browser handles
-        // the download, but the switch over UpdatStatus must stay exhaustive.
+        case UpdatePhase.readyToInstall:
+          if (_inAppDownloadInFlight) {
+            _inAppDownloadInFlight = false;
+            unawaited(_finishInAppUpdate());
+          }
+        // downloading is surfaced by the blocking dialog _startInAppDownload
+        // already pushed; the rest need no side effects.
         case UpdatePhase.idle:
         case UpdatePhase.checking:
         case UpdatePhase.downloading:
-        case UpdatePhase.readyToInstall:
         case UpdatePhase.dismissed:
           break;
       }

--- a/lib/features/updates/presentation/widgets/update_dialog.dart
+++ b/lib/features/updates/presentation/widgets/update_dialog.dart
@@ -1,12 +1,13 @@
-// Update-available dialog (SKIP THIS VERSION / LATER / UPDATE NOW); see class
-// doc below. UPDATE NOW hands the download off to the browser, never
-// downloads in-process.
+// Update-available dialog (SKIP THIS VERSION / LATER / UPDATE NOW). UPDATE
+// NOW branches on UpdateController.installsInApp: Windows/Linux confirm
+// "close and update" then download in-app; macOS hands off to the browser.
 
 import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:getman/core/theme/app_theme.dart';
+import 'package:getman/core/ui/widgets/confirm_dialog.dart';
 import 'package:getman/core/ui/widgets/responsive_dialog.dart';
 import 'package:getman/features/settings/presentation/bloc/settings_bloc.dart';
 import 'package:getman/features/settings/presentation/bloc/settings_event.dart';
@@ -15,9 +16,11 @@ import 'package:provider/provider.dart';
 
 /// Themed dialog shown when an update is available. Shows the version line,
 /// optional changelog, a note about how the download works, and three actions:
-/// SKIP THIS VERSION, LATER, and UPDATE NOW. UPDATE NOW opens the release
-/// download in the user's browser (see `update_gate_io._openDownloadInBrowser`)
-/// and closes the dialog.
+/// SKIP THIS VERSION, LATER, and UPDATE NOW. When
+/// [UpdateController.installsInApp] is true (Windows/Linux) UPDATE NOW first
+/// confirms via [ConfirmDialog] that Getman may close, then starts the in-app
+/// download (see `update_gate_io.dart`); otherwise it opens the release
+/// download in the user's browser and closes the dialog.
 ///
 /// Normally opened via [UpdateDialog.show], which injects [UpdateController]
 /// via [ChangeNotifierProvider] and [SettingsBloc] via [BlocProvider]. The
@@ -74,6 +77,7 @@ class UpdateDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     final layout = context.appLayout;
     final controller = _controller(context);
+    final installsInApp = controller?.installsInApp ?? false;
 
     return ResponsiveDialogScaffold(
       title: const Text('UPDATE AVAILABLE'),
@@ -82,6 +86,7 @@ class UpdateDialog extends StatelessWidget {
         currentVersion: currentVersion,
         changelog: changelog,
         layout: layout,
+        installsInApp: installsInApp,
       ),
       actions: [
         TextButton(
@@ -105,8 +110,29 @@ class UpdateDialog extends StatelessWidget {
         TextButton(
           key: const ValueKey('update_now_button'),
           onPressed: () {
-            unawaited(controller?.startUpdate?.call());
-            Navigator.pop(context);
+            if (installsInApp) {
+              unawaited(
+                ConfirmDialog.show(
+                  context,
+                  title: 'CLOSE AND UPDATE?',
+                  message:
+                      'Getman will download the update to your Downloads '
+                      'folder and then close itself so the installer can '
+                      'run. Continue?',
+                  confirmLabel: 'DOWNLOAD AND CLOSE',
+                  destructive: false,
+                  // ConfirmDialog pops itself before onConfirm, so `context`
+                  // (the still-mounted update dialog) is safe to pop here.
+                  onConfirm: () {
+                    Navigator.pop(context);
+                    unawaited(controller?.startUpdate?.call());
+                  },
+                ),
+              );
+            } else {
+              unawaited(controller?.startUpdate?.call());
+              Navigator.pop(context);
+            }
           },
           style: TextButton.styleFrom(
             foregroundColor: Theme.of(context).colorScheme.primary,
@@ -125,12 +151,14 @@ class _DialogBody extends StatelessWidget {
     required this.currentVersion,
     required this.changelog,
     required this.layout,
+    required this.installsInApp,
   });
 
   final String latestVersion;
   final String currentVersion;
   final String? changelog;
   final AppLayout layout;
+  final bool installsInApp;
 
   @override
   Widget build(BuildContext context) {
@@ -155,9 +183,14 @@ class _DialogBody extends StatelessWidget {
           ),
         SizedBox(height: layout.tabSpacing),
         Text(
-          'UPDATE NOW opens the download in your browser. Getman is not '
-          'code-signed, so your OS may warn on first launch — allow it via '
-          'right-click → Open (macOS) or More info → Run anyway (Windows).',
+          installsInApp
+              ? 'UPDATE NOW downloads the installer to your Downloads folder '
+                    'and closes Getman so the installer can run. Getman is '
+                    'not code-signed, so your OS may warn before running it.'
+              : 'UPDATE NOW opens the download in your browser. Getman is '
+                    'not code-signed, so your OS may warn on first launch — '
+                    'allow it via right-click → Open (macOS) or More info → '
+                    'Run anyway (Windows).',
           style: TextStyle(fontSize: layout.fontSizeSmall),
         ),
       ],

--- a/lib/features/updates/presentation/widgets/update_download_dialog.dart
+++ b/lib/features/updates/presentation/widgets/update_download_dialog.dart
@@ -1,0 +1,51 @@
+// Blocking "DOWNLOADING UPDATE…" progress dialog for the Windows/Linux
+// in-app update flow; deliberately non-dismissible — the user already
+// confirmed Getman will close when the download finishes.
+
+import 'package:flutter/material.dart';
+import 'package:getman/core/theme/app_theme.dart';
+import 'package:getman/core/ui/widgets/responsive_dialog.dart';
+
+/// Modal indeterminate-progress dialog shown while the update installer
+/// downloads. No actions and no dismissal ([PopScope] blocks Escape/back and
+/// the barrier is non-dismissible): the update gate pops it on download
+/// failure, and on success the app quits with it still up. Indeterminate
+/// because `updat` downloads with a single `http.get` — no progress stream.
+class UpdateDownloadDialog extends StatelessWidget {
+  const UpdateDownloadDialog({super.key});
+
+  /// Shows the dialog; the returned future completes when the update gate
+  /// pops it (download failure) — on success the app exits first.
+  static Future<void> show(BuildContext context) {
+    return showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => const UpdateDownloadDialog(),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final layout = context.appLayout;
+    return PopScope(
+      canPop: false,
+      child: ResponsiveDialogScaffold(
+        title: const Text('DOWNLOADING UPDATE…'),
+        content: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const CircularProgressIndicator(),
+            SizedBox(width: layout.tabSpacing),
+            Flexible(
+              child: Text(
+                'Getman will close and run the installer when the download '
+                'finishes.',
+                style: TextStyle(fontSize: layout.fontSizeNormal),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/core/git/git_identity_io_test.dart
+++ b/test/core/git/git_identity_io_test.dart
@@ -15,9 +15,14 @@ import 'package:getman/core/git/git_service.dart';
 /// Deliberately does **not** run `git config user.name/user.email` in
 /// [setUp] (unlike `git_service_io_test.dart`'s shared fixture) — the whole
 /// point is a repo with no identity of its own. The service is built with
-/// `GIT_CONFIG_GLOBAL` pointed at an empty file (+ `GIT_CONFIG_NOSYSTEM`) so
-/// the developer machine's real `~/.gitconfig` identity can't leak in and
-/// make the missing-identity commits silently succeed.
+/// `GIT_CONFIG_GLOBAL` pointed at an isolated file (+ `GIT_CONFIG_NOSYSTEM`)
+/// so the developer machine's real `~/.gitconfig` identity can't leak in and
+/// make the missing-identity commits silently succeed. That file sets
+/// `user.useConfigOnly = true`, which disables git's own fallback of
+/// guessing an identity from the OS account/hostname (real on a normal
+/// desktop account — `git commit` there just warns and succeeds instead of
+/// failing) — without it this test is flaky/environment-dependent instead of
+/// deterministic.
 void main() {
   late GitService git;
   late Directory tmp;
@@ -26,10 +31,11 @@ void main() {
 
   setUp(() async {
     tmp = await Directory.systemTemp.createTemp('getman_git_identity_test');
-    final emptyGlobalConfig = File('${tmp.path}/empty-gitconfig')..createSync();
+    final isolatedGlobalConfig = File('${tmp.path}/empty-gitconfig')
+      ..writeAsStringSync('[user]\n\tuseConfigOnly = true\n');
     git = createGitService(
       environmentOverrides: {
-        'GIT_CONFIG_GLOBAL': emptyGlobalConfig.path,
+        'GIT_CONFIG_GLOBAL': isolatedGlobalConfig.path,
         'GIT_CONFIG_NOSYSTEM': '1',
       },
     );

--- a/test/features/updates/presentation/update_controller_test.dart
+++ b/test/features/updates/presentation/update_controller_test.dart
@@ -58,4 +58,8 @@ void main() {
       expect(controller.phase, UpdatePhase.available);
     },
   );
+
+  test('installsInApp defaults to false (browser hand-off is the default)', () {
+    expect(controller.installsInApp, isFalse);
+  });
 }

--- a/test/features/updates/presentation/update_gate_io_test.dart
+++ b/test/features/updates/presentation/update_gate_io_test.dart
@@ -146,4 +146,39 @@ void main() {
       expect(controller.manualInFlight, isFalse);
     },
   );
+
+  group('finishInAppUpdate', () {
+    test('launches, then flushes tabs, then quits — in that order', () async {
+      final calls = <String>[];
+      final result = await finishInAppUpdate(
+        launchInstaller: () async => calls.add('launch'),
+        flushTabs: () async => calls.add('flush'),
+        quit: () => calls.add('quit'),
+      );
+      expect(result, UpdateFinishResult.quitting);
+      expect(calls, ['launch', 'flush', 'quit']);
+    });
+
+    test('a failed launch keeps the app alive: no flush, no quit', () async {
+      final calls = <String>[];
+      final result = await finishInAppUpdate(
+        launchInstaller: () async => throw Exception('no such file'),
+        flushTabs: () async => calls.add('flush'),
+        quit: () => calls.add('quit'),
+      );
+      expect(result, UpdateFinishResult.launchFailed);
+      expect(calls, isEmpty);
+    });
+
+    test('a failed tab flush still quits (best-effort flush)', () async {
+      var quitCalled = false;
+      final result = await finishInAppUpdate(
+        launchInstaller: () async {},
+        flushTabs: () async => throw Exception('hive is gone'),
+        quit: () => quitCalled = true,
+      );
+      expect(result, UpdateFinishResult.quitting);
+      expect(quitCalled, isTrue);
+    });
+  });
 }

--- a/test/features/updates/presentation/update_gate_io_test.dart
+++ b/test/features/updates/presentation/update_gate_io_test.dart
@@ -181,4 +181,57 @@ void main() {
       expect(quitCalled, isTrue);
     });
   });
+
+  testWidgets(
+    'in-app flow: confirm shows the blocking dialog; a failed download pops '
+    'it, shows the error snackbar, and never quits',
+    (tester) async {
+      final controller = UpdateController(
+        _ReleaseRepo(
+          const ReleaseInfo(
+            version: '99.0.0',
+            changelog: null,
+            assetUrl: 'https://example.com/getman-99.0.0.exe',
+          ),
+        ),
+      );
+      final bloc = buildSettingsBloc();
+      var quitCalled = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: brutalistTheme(Brightness.light),
+          home: ChangeNotifierProvider<UpdateController>.value(
+            value: controller,
+            child: BlocProvider.value(
+              value: bloc,
+              child: Scaffold(
+                body: UpdateGate(
+                  debugInstallsInApp: true,
+                  debugQuit: () => quitCalled = true,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Startup check found 99.0.0 → update dialog prompted.
+      await tester.tap(find.byKey(const ValueKey('update_now_button')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('DOWNLOAD AND CLOSE'));
+      await tester.pump();
+
+      // The blocking dialog is up while updat downloads.
+      expect(find.text('DOWNLOADING UPDATE…'), findsOneWidget);
+
+      // flutter_test's HttpClient 400s every request, so the download fails:
+      // dialog popped, snackbar shown, app still alive.
+      await tester.pumpAndSettle();
+      expect(find.text('DOWNLOADING UPDATE…'), findsNothing);
+      expect(find.text("Couldn't download the update."), findsOneWidget);
+      expect(quitCalled, isFalse);
+    },
+  );
 }

--- a/test/features/updates/presentation/widgets/update_dialog_test.dart
+++ b/test/features/updates/presentation/widgets/update_dialog_test.dart
@@ -12,6 +12,35 @@ class _FakeUpdateRepository implements UpdateRepository {
   Future<ReleaseInfo?> fetchLatestRelease(UpdatePlatform p) async => null;
 }
 
+Widget _host(UpdateController controller) {
+  return MaterialApp(
+    theme: brutalistTheme(Brightness.light),
+    home: ChangeNotifierProvider<UpdateController>.value(
+      value: controller,
+      child: Scaffold(
+        body: Builder(
+          builder: (context) => Center(
+            child: ElevatedButton(
+              onPressed: () => showDialog<void>(
+                context: context,
+                builder: (_) => ChangeNotifierProvider<UpdateController>.value(
+                  value: controller,
+                  child: const UpdateDialog(
+                    latestVersion: '1.1.0',
+                    currentVersion: '1.0.0',
+                    changelog: null,
+                  ),
+                ),
+              ),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
 void main() {
   testWidgets('renders version line + all three actions', (t) async {
     await t.pumpWidget(
@@ -42,36 +71,7 @@ void main() {
     var started = false;
     controller.startUpdate = () async => started = true;
 
-    await t.pumpWidget(
-      MaterialApp(
-        theme: brutalistTheme(Brightness.light),
-        home: ChangeNotifierProvider<UpdateController>.value(
-          value: controller,
-          child: Scaffold(
-            body: Builder(
-              builder: (context) => Center(
-                child: ElevatedButton(
-                  onPressed: () => showDialog<void>(
-                    context: context,
-                    builder: (_) =>
-                        ChangeNotifierProvider<UpdateController>.value(
-                          value: controller,
-                          child: const UpdateDialog(
-                            latestVersion: '1.1.0',
-                            currentVersion: '1.0.0',
-                            changelog: null,
-                          ),
-                        ),
-                  ),
-                  child: const Text('open'),
-                ),
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-
+    await t.pumpWidget(_host(controller));
     await t.tap(find.text('open'));
     await t.pumpAndSettle();
     expect(find.byKey(const ValueKey('update_now_button')), findsOneWidget);
@@ -82,5 +82,80 @@ void main() {
     expect(started, isTrue);
     // Dialog is dismissed after the hand-off.
     expect(find.byKey(const ValueKey('update_now_button')), findsNothing);
+  });
+
+  testWidgets('in-app flow: UPDATE NOW asks for confirmation first', (t) async {
+    final controller = UpdateController(_FakeUpdateRepository())
+      ..installsInApp = true;
+    var started = false;
+    controller.startUpdate = () async => started = true;
+
+    await t.pumpWidget(_host(controller));
+    await t.tap(find.text('open'));
+    await t.pumpAndSettle();
+
+    await t.tap(find.byKey(const ValueKey('update_now_button')));
+    await t.pumpAndSettle();
+
+    expect(find.text('CLOSE AND UPDATE?'), findsOneWidget);
+    expect(find.text('DOWNLOAD AND CLOSE'), findsOneWidget);
+    // Update dialog still open behind the confirm box; nothing started.
+    expect(find.byKey(const ValueKey('update_now_button')), findsOneWidget);
+    expect(started, isFalse);
+  });
+
+  testWidgets('in-app flow: CANCEL keeps the update dialog, starts nothing', (
+    t,
+  ) async {
+    final controller = UpdateController(_FakeUpdateRepository())
+      ..installsInApp = true;
+    var started = false;
+    controller.startUpdate = () async => started = true;
+
+    await t.pumpWidget(_host(controller));
+    await t.tap(find.text('open'));
+    await t.pumpAndSettle();
+    await t.tap(find.byKey(const ValueKey('update_now_button')));
+    await t.pumpAndSettle();
+
+    await t.tap(find.text('CANCEL'));
+    await t.pumpAndSettle();
+
+    expect(find.text('CLOSE AND UPDATE?'), findsNothing);
+    expect(find.byKey(const ValueKey('update_now_button')), findsOneWidget);
+    expect(started, isFalse);
+  });
+
+  testWidgets(
+    'in-app flow: DOWNLOAD AND CLOSE starts the update and closes the dialog',
+    (t) async {
+      final controller = UpdateController(_FakeUpdateRepository())
+        ..installsInApp = true;
+      var started = false;
+      controller.startUpdate = () async => started = true;
+
+      await t.pumpWidget(_host(controller));
+      await t.tap(find.text('open'));
+      await t.pumpAndSettle();
+      await t.tap(find.byKey(const ValueKey('update_now_button')));
+      await t.pumpAndSettle();
+
+      await t.tap(find.text('DOWNLOAD AND CLOSE'));
+      await t.pumpAndSettle();
+
+      expect(started, isTrue);
+      expect(find.byKey(const ValueKey('update_now_button')), findsNothing);
+      expect(find.text('CLOSE AND UPDATE?'), findsNothing);
+    },
+  );
+
+  testWidgets('note text is platform-aware', (t) async {
+    final inApp = UpdateController(_FakeUpdateRepository())
+      ..installsInApp = true;
+    await t.pumpWidget(_host(inApp));
+    await t.tap(find.text('open'));
+    await t.pumpAndSettle();
+    expect(find.textContaining('Downloads folder'), findsOneWidget);
+    expect(find.textContaining('browser'), findsNothing);
   });
 }

--- a/test/features/updates/presentation/widgets/update_download_dialog_test.dart
+++ b/test/features/updates/presentation/widgets/update_download_dialog_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/core/theme/themes/brutalist/brutalist_theme.dart';
+import 'package:getman/features/updates/presentation/widgets/update_download_dialog.dart';
+
+void main() {
+  Widget host() {
+    return MaterialApp(
+      theme: brutalistTheme(Brightness.light),
+      home: Scaffold(
+        body: Builder(
+          builder: (context) => Center(
+            child: ElevatedButton(
+              onPressed: () => UpdateDownloadDialog.show(context),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('shows the blocking download dialog with a spinner', (t) async {
+    await t.pumpWidget(host());
+    await t.tap(find.text('open'));
+    await t.pump();
+
+    expect(find.text('DOWNLOADING UPDATE…'), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+  });
+
+  testWidgets('cannot be dismissed by barrier tap or Escape', (t) async {
+    await t.pumpWidget(host());
+    await t.tap(find.text('open'));
+    await t.pump();
+
+    // Barrier tap (top-left corner is outside the dialog card).
+    await t.tapAt(const Offset(5, 5));
+    await t.pump();
+    expect(find.text('DOWNLOADING UPDATE…'), findsOneWidget);
+
+    // Escape key.
+    await t.sendKeyEvent(LogicalKeyboardKey.escape);
+    await t.pump();
+    expect(find.text('DOWNLOADING UPDATE…'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## What

UPDATE NOW now installs updates end-to-end on Windows and Linux: a confirmation box (**CLOSE AND UPDATE?**) warns that Getman will close, the installer downloads to the user's Downloads folder behind a blocking **DOWNLOADING UPDATE…** dialog, and on completion the installer opens automatically and Getman quits itself (after flushing unsaved tabs). macOS keeps the browser hand-off — in-app download would re-trigger the Gatekeeper "damaged" quarantine bug fixed in v1.4.1.

## How

- `UpdateController.installsInApp` (web-safe flag, set once by the io gate) lets the platform-agnostic dialog branch without importing `dart:io`.
- The gate keeps updat's `openOnDownload`/`closeOnInstall` **off** and owns the terminal sequence: **launch installer → flush tabs (`TabsBloc.close()`) → `exit(0)`** — launch first, so a failed launch leaves the app fully usable.
- Linux gets `chmod +x` before the AppImage starts detached; Windows starts the Inno `.exe` detached.
- A 10-minute watchdog guards against a stalled download stranding the non-dismissible dialog (updat's `http.get` has no timeout).
- Errors never strand the user: failed download → dialog pops + snackbar, app stays open; failed launch → snackbar with the downloaded file's path.
- Test seams (`debugInstallsInApp` / `debugInstallerLauncher` / `debugQuit` / `debugDownloadTimeout`) keep the Windows/Linux flow testable on a macOS host.

## Verification

- 2290 tests green; all four static-analysis gates + formatter clean (pre-commit hook enforced per commit).
- Per-task subagent reviews on all 8 plan tasks + final whole-branch review: **READY TO MERGE**.
- Docs synced: architecture doc, CODEMAP, spec (+ amendment trail); wiki Auto-Update page + stale FAQ answer already pushed to the wiki repo.

## Release gate (not a merge gate)

Nothing automated exercises `Process.start` — before the release that ships this, manually verify the flow once on a real Windows box (Inno setup launches, app exits, install completes) and a real Linux box (chmod + AppImage starts; FUSE caveat on some distros).

Spec: `docs/superpowers/specs/2026-07-21-update-download-and-close-design.md`
Plan: `docs/superpowers/plans/2026-07-21-update-download-and-close.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mhumtQgzotqiYH9g5CVyS