### PR TITLE
Four QoL improvements: tab-strip double-click, find-bar select-all, tree right-click menu, Enter-to-send

### DIFF
--- a/docs/CODEMAP.md
+++ b/docs/CODEMAP.md
@@ -137,7 +137,7 @@ widgets + screens). Shared cross-feature code lives under `lib/core/`. See
 |---|---|
 | `lib/features/home/domain/usecases` | `tab_dirty_checker.dart` (unsaved-changes detection). |
 | `lib/features/home/presentation/screens` | `main_screen.dart` (app shell; hosts every keyboard `Action` + tab strip). |
-| `lib/features/home/presentation/widgets` | `side_menu.dart`, `request_tab_chip.dart`, `tab_content_stack.dart`, `tab_chip.dart`, `add_tab_button.dart`, `empty_tabs_placeholder.dart`. |
+| `lib/features/home/presentation/widgets` | `side_menu.dart`, `request_tab_chip.dart`, `tab_content_stack.dart`, `tab_chip.dart`, `add_tab_button.dart`, `tab_strip_double_click.dart`, `empty_tabs_placeholder.dart`. |
 
 ### `mcp` — Model Context Protocol client (bloc-over-service)
 
@@ -267,7 +267,7 @@ Alphabetical. Each concept points at its primary file(s); read the file's own
 | Snackbars | `lib/core/ui/widgets/app_snack_bar.dart` |
 | Splitters (pane dividers) | `lib/core/ui/widgets/splitter.dart` |
 | SSE (Server-Sent Events) | `lib/core/network/sse_parser.dart`, `lib/core/network/realtime_service.dart` |
-| Tab strip / chips | `lib/features/home/presentation/screens/main_screen.dart`, `lib/features/home/presentation/widgets/request_tab_chip.dart` |
+| Tab strip / chips | `lib/features/home/presentation/screens/main_screen.dart`, `lib/features/home/presentation/widgets/request_tab_chip.dart`, `lib/features/home/presentation/widgets/tab_strip_double_click.dart` |
 | Tabs (request editor) | `lib/features/tabs/presentation/bloc/tabs_bloc.dart`, `lib/features/tabs/domain/entities/request_tab_entity.dart` |
 | Theme accessors (`context.app*`) | `lib/core/theme/extensions/app_theme_access.dart`, `lib/core/theme/app_theme.dart` |
 | Themes + component slots | `lib/core/theme/theme_registry.dart`, `lib/core/theme/extensions/app_components.dart` |

--- a/lib/features/collections/presentation/widgets/collection_node_menu.dart
+++ b/lib/features/collections/presentation/widgets/collection_node_menu.dart
@@ -1,7 +1,10 @@
-// Trailing more-actions popup menu on a collection node row: rename, edit
-// description, variables (folders), add subfolder (folders), export to
-// Postman, export as API docs, favorite/unfavorite, delete (with confirm).
-// Dispatches CollectionsBloc events; delete/favorite show a snackbar.
+// More-actions menu for a collection node row: rename, edit description,
+// variables (folders), add subfolder (folders), export to Postman, export as
+// API docs, favorite/unfavorite, delete (with confirm). Two entry points
+// share the same items + actions: the row's trailing "⋮" PopupMenuButton
+// (CollectionNodeMenu) and right-click anywhere on the row
+// (showCollectionNodeMenuAt). Dispatches CollectionsBloc events;
+// delete/favorite show a snackbar.
 import 'dart:async';
 
 import 'package:flutter/material.dart';
@@ -17,6 +20,31 @@ import 'package:getman/features/collections/presentation/bloc/collections_bloc.d
 import 'package:getman/features/collections/presentation/bloc/collections_event.dart';
 import 'package:getman/features/collections/presentation/widgets/collection_variables_dialog.dart';
 import 'package:getman/features/collections/presentation/widgets/export_api_docs_dialog.dart';
+
+/// Shows the node's actions menu at [globalPosition] — the right-click path.
+/// Same items and actions as the row's trailing [CollectionNodeMenu] button.
+Future<void> showCollectionNodeMenuAt(
+  BuildContext context,
+  CollectionNodeEntity node,
+  Offset globalPosition,
+) async {
+  final theme = Theme.of(context);
+  final selected = await showMenu<String>(
+    context: context,
+    position: RelativeRect.fromLTRB(
+      globalPosition.dx,
+      globalPosition.dy,
+      globalPosition.dx + 1,
+      globalPosition.dy + 1,
+    ),
+    color: theme.colorScheme.surface,
+    elevation: 0,
+    shape: _menuShape(context),
+    items: _menuItems(context, node),
+  );
+  if (selected == null || !context.mounted) return;
+  _handleSelection(context, node, selected);
+}
 
 /// The trailing more-actions menu on a collection node row
 /// (rename / describe / delete / favorite / add-subfolder / export).
@@ -38,193 +66,214 @@ class CollectionNodeMenu extends StatelessWidget {
       ),
       color: theme.colorScheme.surface,
       elevation: 0,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(context.appShape.panelRadius),
-        side: BorderSide(color: theme.dividerColor, width: layout.borderThick),
-      ),
-      onSelected: (val) {
-        switch (val) {
-          case 'rename':
-            _showRenameDialog(context);
-          case 'describe':
-            _showDescriptionDialog(context);
-          case 'variables':
-            unawaited(CollectionVariablesDialog.show(context, node));
-          case 'delete':
-            unawaited(
-              ConfirmDialog.show(
-                context,
-                title: node.isFolder ? 'Delete folder?' : 'Delete request?',
-                message: node.isFolder
-                    ? 'Deletes "${node.name}" and everything inside it. '
-                          'This cannot be undone.'
-                    : 'Deletes "${node.name}". This cannot be undone.',
-                onConfirm: () {
-                  context.read<CollectionsBloc>().add(DeleteNode(node.id));
-                  showAppSnackBar(context, 'Deleted "${node.name}"');
-                },
-              ),
-            );
-          case 'favorite':
-            context.read<CollectionsBloc>().add(ToggleFavorite(node.id));
-            showAppSnackBar(
-              context,
-              node.isFavorite ? 'Removed from favorites' : 'Added to favorites',
-            );
-          case 'add_subfolder':
-            _showAddSubfolderDialog(context);
-          case 'export':
-            unawaited(_exportNode(context));
-          case 'export_docs':
-            unawaited(ExportApiDocsDialog.show(context, node));
-        }
-      },
-      itemBuilder: (context) => [
-        if (node.isFolder && node.config == null)
-          PopupMenuItem(
-            value: 'favorite',
-            child: Text(
-              node.isFavorite ? 'UNFAVORITE' : 'FAVORITE',
-              style: TextStyle(
-                fontSize: layout.fontSizeSmall,
-                fontWeight: FontWeight.bold,
-              ),
-            ),
-          ),
-        PopupMenuItem(
-          value: 'rename',
-          child: Text(
-            'RENAME',
-            style: TextStyle(
-              fontSize: layout.fontSizeSmall,
-              fontWeight: FontWeight.bold,
-            ),
-          ),
-        ),
-        PopupMenuItem(
-          value: 'describe',
-          child: Text(
-            'EDIT DESCRIPTION',
-            style: TextStyle(
-              fontSize: layout.fontSizeSmall,
-              fontWeight: FontWeight.bold,
-            ),
-          ),
-        ),
-        if (node.isFolder)
-          PopupMenuItem(
-            value: 'variables',
-            child: Text(
-              'VARIABLES',
-              style: TextStyle(
-                fontSize: layout.fontSizeSmall,
-                fontWeight: FontWeight.bold,
-              ),
-            ),
-          ),
-        if (node.isFolder)
-          PopupMenuItem(
-            value: 'add_subfolder',
-            child: Text(
-              'ADD SUBFOLDER',
-              style: TextStyle(
-                fontSize: layout.fontSizeSmall,
-                fontWeight: FontWeight.bold,
-              ),
-            ),
-          ),
-        PopupMenuItem(
-          value: 'export',
-          child: Text(
-            'EXPORT TO POSTMAN',
-            style: TextStyle(
-              fontSize: layout.fontSizeSmall,
-              fontWeight: FontWeight.bold,
-            ),
-          ),
-        ),
-        PopupMenuItem(
-          value: 'export_docs',
-          child: Text(
-            'EXPORT AS API DOCS…',
-            style: TextStyle(
-              fontSize: layout.fontSizeSmall,
-              fontWeight: FontWeight.bold,
-            ),
-          ),
-        ),
-        PopupMenuItem(
-          value: 'delete',
-          child: Text(
-            'DELETE',
-            style: TextStyle(
-              fontSize: layout.fontSizeSmall,
-              fontWeight: FontWeight.bold,
-              color: theme.colorScheme.error,
-            ),
-          ),
-        ),
-      ],
+      shape: _menuShape(context),
+      onSelected: (val) => _handleSelection(context, node, val),
+      itemBuilder: (context) => _menuItems(context, node),
     );
   }
+}
 
-  void _showRenameDialog(BuildContext context) {
-    final bloc = context.read<CollectionsBloc>();
-    final messenger = ScaffoldMessenger.of(context);
-    unawaited(
-      NamePromptDialog.show(
+RoundedRectangleBorder _menuShape(BuildContext context) {
+  final theme = Theme.of(context);
+  final layout = context.appLayout;
+  return RoundedRectangleBorder(
+    borderRadius: BorderRadius.circular(context.appShape.panelRadius),
+    side: BorderSide(color: theme.dividerColor, width: layout.borderThick),
+  );
+}
+
+List<PopupMenuEntry<String>> _menuItems(
+  BuildContext context,
+  CollectionNodeEntity node,
+) {
+  final theme = Theme.of(context);
+  final layout = context.appLayout;
+  return [
+    if (node.isFolder && node.config == null)
+      PopupMenuItem(
+        value: 'favorite',
+        child: Text(
+          node.isFavorite ? 'UNFAVORITE' : 'FAVORITE',
+          style: TextStyle(
+            fontSize: layout.fontSizeSmall,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ),
+    PopupMenuItem(
+      value: 'rename',
+      child: Text(
+        'RENAME',
+        style: TextStyle(
+          fontSize: layout.fontSizeSmall,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+    ),
+    PopupMenuItem(
+      value: 'describe',
+      child: Text(
+        'EDIT DESCRIPTION',
+        style: TextStyle(
+          fontSize: layout.fontSizeSmall,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+    ),
+    if (node.isFolder)
+      PopupMenuItem(
+        value: 'variables',
+        child: Text(
+          'VARIABLES',
+          style: TextStyle(
+            fontSize: layout.fontSizeSmall,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ),
+    if (node.isFolder)
+      PopupMenuItem(
+        value: 'add_subfolder',
+        child: Text(
+          'ADD SUBFOLDER',
+          style: TextStyle(
+            fontSize: layout.fontSizeSmall,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ),
+    PopupMenuItem(
+      value: 'export',
+      child: Text(
+        'EXPORT TO POSTMAN',
+        style: TextStyle(
+          fontSize: layout.fontSizeSmall,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+    ),
+    PopupMenuItem(
+      value: 'export_docs',
+      child: Text(
+        'EXPORT AS API DOCS…',
+        style: TextStyle(
+          fontSize: layout.fontSizeSmall,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+    ),
+    PopupMenuItem(
+      value: 'delete',
+      child: Text(
+        'DELETE',
+        style: TextStyle(
+          fontSize: layout.fontSizeSmall,
+          fontWeight: FontWeight.bold,
+          color: theme.colorScheme.error,
+        ),
+      ),
+    ),
+  ];
+}
+
+void _handleSelection(
+  BuildContext context,
+  CollectionNodeEntity node,
+  String value,
+) {
+  switch (value) {
+    case 'rename':
+      _showRenameDialog(context, node);
+    case 'describe':
+      _showDescriptionDialog(context, node);
+    case 'variables':
+      unawaited(CollectionVariablesDialog.show(context, node));
+    case 'delete':
+      unawaited(
+        ConfirmDialog.show(
+          context,
+          title: node.isFolder ? 'Delete folder?' : 'Delete request?',
+          message: node.isFolder
+              ? 'Deletes "${node.name}" and everything inside it. '
+                    'This cannot be undone.'
+              : 'Deletes "${node.name}". This cannot be undone.',
+          onConfirm: () {
+            context.read<CollectionsBloc>().add(DeleteNode(node.id));
+            showAppSnackBar(context, 'Deleted "${node.name}"');
+          },
+        ),
+      );
+    case 'favorite':
+      context.read<CollectionsBloc>().add(ToggleFavorite(node.id));
+      showAppSnackBar(
         context,
-        title: 'RENAME',
-        initialText: node.name,
-        onConfirm: (name) {
-          bloc.add(RenameNode(node.id, name));
-          showAppSnackBarVia(messenger, 'Renamed to "$name"');
-        },
-      ),
-    );
+        node.isFavorite ? 'Removed from favorites' : 'Added to favorites',
+      );
+    case 'add_subfolder':
+      _showAddSubfolderDialog(context, node);
+    case 'export':
+      unawaited(_exportNode(context, node));
+    case 'export_docs':
+      unawaited(ExportApiDocsDialog.show(context, node));
   }
+}
 
-  void _showDescriptionDialog(BuildContext context) {
-    final bloc = context.read<CollectionsBloc>();
-    final messenger = ScaffoldMessenger.of(context);
-    unawaited(
-      NamePromptDialog.show(
-        context,
-        title: 'DESCRIPTION',
-        initialText: node.description ?? '',
-        hintText: 'Notes for this ${node.isFolder ? 'folder' : 'request'}',
-        allowEmpty: true,
-        multiline: true,
-        onConfirm: (text) {
-          bloc.add(UpdateNodeDescription(node.id, text.trim()));
-          showAppSnackBarVia(messenger, 'Description updated');
-        },
-      ),
-    );
-  }
-
-  void _showAddSubfolderDialog(BuildContext context) {
-    final bloc = context.read<CollectionsBloc>();
-    final messenger = ScaffoldMessenger.of(context);
-    unawaited(
-      NamePromptDialog.show(
-        context,
-        title: 'ADD SUBFOLDER',
-        confirmLabel: 'ADD',
-        onConfirm: (name) {
-          bloc.add(AddFolder(name, parentId: node.id));
-          showAppSnackBarVia(messenger, 'Folder "$name" created');
-        },
-      ),
-    );
-  }
-
-  Future<void> _exportNode(BuildContext context) {
-    return saveJsonFileWithFeedback(
+void _showRenameDialog(BuildContext context, CollectionNodeEntity node) {
+  final bloc = context.read<CollectionsBloc>();
+  final messenger = ScaffoldMessenger.of(context);
+  unawaited(
+    NamePromptDialog.show(
       context,
-      jsonString: PostmanCollectionMapper.toJson(node),
-      fileName: '${slugFilename(node.name)}.postman_collection.json',
-      dialogTitle: 'EXPORT COLLECTION',
-    );
-  }
+      title: 'RENAME',
+      initialText: node.name,
+      onConfirm: (name) {
+        bloc.add(RenameNode(node.id, name));
+        showAppSnackBarVia(messenger, 'Renamed to "$name"');
+      },
+    ),
+  );
+}
+
+void _showDescriptionDialog(BuildContext context, CollectionNodeEntity node) {
+  final bloc = context.read<CollectionsBloc>();
+  final messenger = ScaffoldMessenger.of(context);
+  unawaited(
+    NamePromptDialog.show(
+      context,
+      title: 'DESCRIPTION',
+      initialText: node.description ?? '',
+      hintText: 'Notes for this ${node.isFolder ? 'folder' : 'request'}',
+      allowEmpty: true,
+      multiline: true,
+      onConfirm: (text) {
+        bloc.add(UpdateNodeDescription(node.id, text.trim()));
+        showAppSnackBarVia(messenger, 'Description updated');
+      },
+    ),
+  );
+}
+
+void _showAddSubfolderDialog(BuildContext context, CollectionNodeEntity node) {
+  final bloc = context.read<CollectionsBloc>();
+  final messenger = ScaffoldMessenger.of(context);
+  unawaited(
+    NamePromptDialog.show(
+      context,
+      title: 'ADD SUBFOLDER',
+      confirmLabel: 'ADD',
+      onConfirm: (name) {
+        bloc.add(AddFolder(name, parentId: node.id));
+        showAppSnackBarVia(messenger, 'Folder "$name" created');
+      },
+    ),
+  );
+}
+
+Future<void> _exportNode(BuildContext context, CollectionNodeEntity node) {
+  return saveJsonFileWithFeedback(
+    context,
+    jsonString: PostmanCollectionMapper.toJson(node),
+    fileName: '${slugFilename(node.name)}.postman_collection.json',
+    dialogTitle: 'EXPORT COLLECTION',
+  );
 }

--- a/lib/features/collections/presentation/widgets/collection_node_row.dart
+++ b/lib/features/collections/presentation/widgets/collection_node_row.dart
@@ -1,8 +1,9 @@
 // A single collection-tree row (folder or request), with hover highlight,
-// long-press action sheet on phone, and desktop drag-and-drop. Expansion is
-// owned by the parent tree coordinator (CollectionsList): this row only
-// reflects `isExpanded` and calls `onToggle` — it never tracks expansion
-// itself (the H2 fix).
+// long-press action sheet on phone, right-click context menu (the same menu
+// as the trailing "⋮" button), and desktop drag-and-drop. Expansion is owned
+// by the parent tree coordinator (CollectionsList): this row only reflects
+// `isExpanded` and calls `onToggle` — it never tracks expansion itself (the
+// H2 fix).
 //
 // Gotchas: drag targets always accept (never reject) so a release over a
 // row doesn't fall through to the list-level root target and move the node
@@ -10,6 +11,8 @@
 // rejected via onWillAcceptWithDetails and separately guarded by the bloc.
 // Drag payload is the typed NodeDragData wrapper, not a bare String, so a
 // dragged tab-strip tab is never highlighted or accepted here (D4/D5).
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:getman/core/network/request_kind.dart';
@@ -72,6 +75,11 @@ class _CollectionNodeRowState extends State<CollectionNodeRow> {
     final onLongPress = isPhone
         ? () => NodeActionSheet.show(context, node)
         : null;
+    // Right-click anywhere on the row opens the same menu as the trailing
+    // "⋮" button, at the cursor.
+    void onSecondaryTapDown(TapDownDetails details) => unawaited(
+      showCollectionNodeMenuAt(context, node, details.globalPosition),
+    );
 
     Widget content;
     if (node.isFolder) {
@@ -82,6 +90,7 @@ class _CollectionNodeRowState extends State<CollectionNodeRow> {
           child: InkWell(
             onTap: widget.onToggle,
             onLongPress: onLongPress,
+            onSecondaryTapDown: onSecondaryTapDown,
             child: MouseRegion(
               onEnter: (_) => setState(() => _isHovered = true),
               onExit: (_) => setState(() => _isHovered = false),
@@ -205,6 +214,7 @@ class _CollectionNodeRowState extends State<CollectionNodeRow> {
               Scaffold.maybeOf(context)?.closeDrawer();
             },
             onLongPress: onLongPress,
+            onSecondaryTapDown: onSecondaryTapDown,
             child: MouseRegion(
               onEnter: (_) => setState(() => _isHovered = true),
               onExit: (_) => setState(() => _isHovered = false),

--- a/lib/features/home/presentation/screens/main_screen.dart
+++ b/lib/features/home/presentation/screens/main_screen.dart
@@ -35,6 +35,7 @@ import 'package:getman/features/home/presentation/widgets/request_tab_chip.dart'
 import 'package:getman/features/home/presentation/widgets/side_menu.dart';
 import 'package:getman/features/home/presentation/widgets/tab_chip.dart';
 import 'package:getman/features/home/presentation/widgets/tab_content_stack.dart';
+import 'package:getman/features/home/presentation/widgets/tab_strip_double_click.dart';
 import 'package:getman/features/settings/presentation/bloc/settings_bloc.dart';
 import 'package:getman/features/settings/presentation/bloc/settings_event.dart';
 import 'package:getman/features/settings/presentation/bloc/settings_state.dart';
@@ -568,45 +569,56 @@ class _MainScreenState extends State<MainScreen> {
           Expanded(
             child: context.useTabSwitcher
                 ? TabChip(onRequestClose: _requestCloseConfirmation)
-                : Listener(
-                    onPointerSignal: _handleTabBarPointerSignal,
-                    child: Scrollbar(
-                      controller: _tabScrollController,
-                      thumbVisibility: true,
-                      // Pin the horizontal scrollbar to the bottom edge of the
-                      // tab strip so it never paints over the top of the tabs.
-                      scrollbarOrientation: ScrollbarOrientation.bottom,
-                      thickness: 4,
-                      radius: const Radius.circular(2),
-                      child: ReorderableListView.builder(
-                        scrollController: _tabScrollController,
-                        scrollDirection: Axis.horizontal,
-                        itemCount: tabs.length,
-                        buildDefaultDragHandles: false,
-                        onReorderItem: (oldIndex, newIndex) => context
-                            .read<TabsBloc>()
-                            .add(ReorderTabs(oldIndex, newIndex)),
-                        proxyDecorator: (child, index, animation) => Material(
-                          color: theme.scaffoldBackgroundColor,
-                          elevation: 4,
-                          child: child,
-                        ),
-                        itemBuilder: (context, index) {
-                          final tab = tabs[index];
-                          return _ChipEntrance(
-                            key: ValueKey('tab_${tab.tabId}'),
-                            child: RequestTabChip(
-                              tabId: tab.tabId,
-                              index: index,
-                              isActive: activeIndex == index,
-                              onTap: () => context.read<TabsBloc>().add(
-                                SetActiveIndex(index),
+                // Double-click on the strip's empty area = the "+" button
+                // (Postman parity). Chip clicks are excluded via
+                // TabChipHitTarget below.
+                : TabStripDoubleClickDetector(
+                    onNewTab: () =>
+                        context.read<TabsBloc>().add(const AddTab()),
+                    child: Listener(
+                      onPointerSignal: _handleTabBarPointerSignal,
+                      child: Scrollbar(
+                        controller: _tabScrollController,
+                        thumbVisibility: true,
+                        // Pin the horizontal scrollbar to the bottom edge of
+                        // the strip so it never paints over the tabs' top.
+                        scrollbarOrientation: ScrollbarOrientation.bottom,
+                        thickness: 4,
+                        radius: const Radius.circular(2),
+                        child: ReorderableListView.builder(
+                          scrollController: _tabScrollController,
+                          scrollDirection: Axis.horizontal,
+                          itemCount: tabs.length,
+                          buildDefaultDragHandles: false,
+                          onReorderItem: (oldIndex, newIndex) => context
+                              .read<TabsBloc>()
+                              .add(ReorderTabs(oldIndex, newIndex)),
+                          proxyDecorator: (child, index, animation) => Material(
+                            color: theme.scaffoldBackgroundColor,
+                            elevation: 4,
+                            child: child,
+                          ),
+                          itemBuilder: (context, index) {
+                            final tab = tabs[index];
+                            return _ChipEntrance(
+                              key: ValueKey('tab_${tab.tabId}'),
+                              child: TabChipHitTarget(
+                                child: RequestTabChip(
+                                  tabId: tab.tabId,
+                                  index: index,
+                                  isActive: activeIndex == index,
+                                  onTap: () => context.read<TabsBloc>().add(
+                                    SetActiveIndex(index),
+                                  ),
+                                  onClose: () => _requestCloseConfirmation(
+                                    context,
+                                    tab.tabId,
+                                  ),
+                                ),
                               ),
-                              onClose: () =>
-                                  _requestCloseConfirmation(context, tab.tabId),
-                            ),
-                          );
-                        },
+                            );
+                          },
+                        ),
                       ),
                     ),
                   ),

--- a/lib/features/home/presentation/widgets/tab_strip_double_click.dart
+++ b/lib/features/home/presentation/widgets/tab_strip_double_click.dart
@@ -1,0 +1,98 @@
+// Double-click on the tab strip's EMPTY area opens a new tab (Postman
+// parity): TabStripDoubleClickDetector wraps the strip's scrollable and
+// detects two quick primary-button downs itself on a raw Listener, and each
+// chip is wrapped in TabChipHitTarget so clicks that land on a chip never
+// count as "empty area".
+//
+// Gotchas: this deliberately does NOT use GestureDetector.onDoubleTap — an
+// ancestor double-tap recognizer holds the gesture arena for ~300ms on every
+// click, which would delay every chip's onTap (tab switching would lag).
+// A Listener only observes, so chip taps stay instant; chip discrimination
+// is a subtree hit test for the TabChipHitMarker MetaData instead.
+import 'package:flutter/gestures.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+
+/// Hit-test marker carried by [TabChipHitTarget]'s [MetaData] so
+/// [TabStripDoubleClickDetector] can tell "on a chip" from "empty strip".
+class TabChipHitMarker {
+  const TabChipHitMarker();
+}
+
+/// Wraps one tab chip so pointer downs on it are excluded from the strip's
+/// double-click-to-new-tab detection.
+class TabChipHitTarget extends StatelessWidget {
+  const TabChipHitTarget({required this.child, super.key});
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) =>
+      MetaData(metaData: const TabChipHitMarker(), child: child);
+}
+
+/// Detects a double primary-click on the tab strip's empty area (anywhere in
+/// [child] that is not covered by a [TabChipHitTarget]) and calls [onNewTab] —
+/// the same action as the "+" button.
+class TabStripDoubleClickDetector extends StatefulWidget {
+  const TabStripDoubleClickDetector({
+    required this.onNewTab,
+    required this.child,
+    super.key,
+  });
+  final VoidCallback onNewTab;
+  final Widget child;
+
+  @override
+  State<TabStripDoubleClickDetector> createState() =>
+      _TabStripDoubleClickDetectorState();
+}
+
+class _TabStripDoubleClickDetectorState
+    extends State<TabStripDoubleClickDetector> {
+  Duration? _lastDownTime;
+  Offset? _lastDownPosition;
+
+  void _reset() {
+    _lastDownTime = null;
+    _lastDownPosition = null;
+  }
+
+  /// Whether [globalPosition] lands on a tab chip: hit-tests only this
+  /// detector's subtree and looks for the [TabChipHitMarker] MetaData.
+  bool _hitsTabChip(Offset globalPosition) {
+    final box = context.findRenderObject();
+    if (box is! RenderBox || !box.attached) return false;
+    final result = BoxHitTestResult();
+    box.hitTest(result, position: box.globalToLocal(globalPosition));
+    return result.path.any(
+      (entry) =>
+          entry.target is RenderMetaData &&
+          (entry.target as RenderMetaData).metaData is TabChipHitMarker,
+    );
+  }
+
+  void _onPointerDown(PointerDownEvent event) {
+    if (event.buttons != kPrimaryButton || _hitsTabChip(event.position)) {
+      _reset();
+      return;
+    }
+    final lastTime = _lastDownTime;
+    final lastPosition = _lastDownPosition;
+    if (lastTime != null &&
+        lastPosition != null &&
+        event.timeStamp - lastTime <= kDoubleTapTimeout &&
+        (event.position - lastPosition).distance <= kDoubleTapSlop) {
+      // Consume the pair so a triple-click doesn't open a second tab.
+      _reset();
+      widget.onNewTab();
+      return;
+    }
+    _lastDownTime = event.timeStamp;
+    _lastDownPosition = event.position;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Listener(onPointerDown: _onPointerDown, child: widget.child);
+  }
+}

--- a/lib/features/tabs/presentation/widgets/code_find_panel.dart
+++ b/lib/features/tabs/presentation/widgets/code_find_panel.dart
@@ -66,7 +66,13 @@ class _CodeFindPanelState extends State<CodeFindPanel> {
   void initState() {
     super.initState();
     _lastSynced = widget.controller.findInputController.text;
-    _query = TextEditingController(text: _lastSynced);
+    _query = TextEditingController(text: _lastSynced)
+      // Mirror find-mode's own select-all of a prefilled query (see
+      // _onFinderTextChanged) when the panel mounts with one already set.
+      ..selection = TextSelection(
+        baseOffset: 0,
+        extentOffset: _lastSynced.length,
+      );
     _query.addListener(_onQueryChanged);
     widget.controller.addListener(_update);
     widget.controller.findInputController.addListener(_onFinderTextChanged);
@@ -113,14 +119,17 @@ class _CodeFindPanelState extends State<CodeFindPanel> {
 
   /// The finder's own controller changed from the outside (e.g. find mode
   /// auto-filled the selected text). Mirror it into the visible field without
-  /// re-arming the debounce.
+  /// re-arming the debounce. The mirrored text is fully SELECTED — matching
+  /// findMode's own select-all of the finder controller — so a reflexive
+  /// Cmd/Ctrl+V of the same selection replaces it instead of appending a
+  /// duplicate.
   void _onFinderTextChanged() {
     final finderText = widget.controller.findInputController.text;
     if (finderText == _lastSynced) return; // echo of our own [_flush] write
     _lastSynced = finderText;
     _query.value = TextEditingValue(
       text: finderText,
-      selection: TextSelection.collapsed(offset: finderText.length),
+      selection: TextSelection(baseOffset: 0, extentOffset: finderText.length),
     );
   }
 

--- a/lib/features/tabs/presentation/widgets/url_bar.dart
+++ b/lib/features/tabs/presentation/widgets/url_bar.dart
@@ -1,6 +1,7 @@
 // The URL input row of a request tab: request-kind/method selector +
 // {{variable}}-highlighted URL field with autocomplete + code-export/save
-// buttons + SEND/CANCEL (or CONNECT for WS/SSE/MCP). Resolves env vars via
+// buttons + SEND/CANCEL (or CONNECT for WS/SSE/MCP). Plain Enter in the
+// focused URL field sends too (HTTP only). Resolves env vars via
 // RequestVariableResolver/ActiveEnvironmentHelper at press time, not build
 // time.
 //
@@ -327,6 +328,14 @@ class _UrlBarState extends State<UrlBar> {
                                 enableSuggestions: false,
                                 onChanged: (val) =>
                                     _handleUrlChanged(context, tab, val),
+                                // Enter sends right from the URL field (no
+                                // Cmd/Ctrl needed — unlike multi-line editors
+                                // where plain Enter inserts a newline). When
+                                // the {{var}} autocomplete menu is open its
+                                // Enter-to-accept consumes the key first, so
+                                // accepting a suggestion never fires a send.
+                                onSubmitted: (_) =>
+                                    _handleUrlSubmitted(context),
                               ),
                             ),
                           ),
@@ -542,6 +551,24 @@ class _UrlBarState extends State<UrlBar> {
         },
       ),
     );
+  }
+
+  /// Enter pressed while the URL field is focused: send the request — same
+  /// dispatch as the SEND button. HTTP only (WS/SSE/MCP go through their
+  /// connect buttons) and a no-op mid-send (Enter must not cancel like the
+  /// button's CANCEL face would). Re-requests focus because submitting
+  /// unfocuses the field on desktop — repeated Enter re-sends must keep
+  /// working.
+  void _handleUrlSubmitted(BuildContext context) {
+    final tabsBloc = context.read<TabsBloc>();
+    final current = tabsBloc.state.tabs.byId(widget.tabId);
+    if (current == null ||
+        current.isSending ||
+        current.config.kind != RequestKind.http) {
+      return;
+    }
+    tabsBloc.add(_sendEvent(context, current.tabId));
+    _urlFocusNode.requestFocus();
   }
 
   void _handleUrlChanged(

--- a/test/features/collections/presentation/widgets/collection_node_row_test.dart
+++ b/test/features/collections/presentation/widgets/collection_node_row_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -136,6 +137,51 @@ void main() {
       isNot(theme.colorScheme.surface),
       reason: 'star must not match the surface/background color',
     );
+  });
+
+  // Right-click anywhere on a row must open the same context menu as the
+  // trailing "⋮" button (standard desktop QoL), at the cursor.
+  testWidgets('right-clicking a request row opens the node context menu', (
+    tester,
+  ) async {
+    await tester.pumpWidget(host(isSelected: false));
+    await tester.pumpAndSettle();
+
+    await tester.tap(
+      find.text('GetUser'),
+      buttons: kSecondaryMouseButton,
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('RENAME'), findsOneWidget);
+    expect(find.text('DELETE'), findsOneWidget);
+    // Folder-only entries must not appear for a request.
+    expect(find.text('ADD SUBFOLDER'), findsNothing);
+    expect(find.text('VARIABLES'), findsNothing);
+
+    // Selecting an entry routes to the same action as the "⋮" menu: RENAME
+    // opens the name prompt dialog.
+    await tester.tap(find.text('RENAME'));
+    await tester.pumpAndSettle();
+    expect(find.byType(TextField), findsOneWidget);
+  });
+
+  testWidgets('right-clicking a folder row opens the folder context menu', (
+    tester,
+  ) async {
+    final theme = resolveTheme('brutalist')(Brightness.light, isCompact: false);
+    await tester.pumpWidget(favoriteHost(theme));
+    await tester.pumpAndSettle();
+
+    await tester.tap(
+      find.text('Favorites'),
+      buttons: kSecondaryMouseButton,
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('ADD SUBFOLDER'), findsOneWidget);
+    expect(find.text('VARIABLES'), findsOneWidget);
+    expect(find.text('UNFAVORITE'), findsOneWidget);
   });
 
   // Regression: leaf request rows had no DragTarget, so dropping a request onto

--- a/test/features/home/presentation/widgets/tab_strip_double_click_test.dart
+++ b/test/features/home/presentation/widgets/tab_strip_double_click_test.dart
@@ -1,0 +1,178 @@
+// Tests for TabStripDoubleClickDetector: a double primary-click on the tab
+// strip's EMPTY area fires onNewTab (Postman parity), while clicks landing on
+// a chip (TabChipHitTarget), slow click pairs, and non-primary buttons never
+// do. Raw TestPointer events with explicit timeStamps drive the detector's
+// own double-click timing (kDoubleTapTimeout).
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getman/features/home/presentation/widgets/tab_strip_double_click.dart';
+
+void main() {
+  late int newTabCount;
+
+  Future<void> pumpStrip(WidgetTester tester) async {
+    newTabCount = 0;
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: SizedBox(
+            width: 400,
+            height: 40,
+            child: TabStripDoubleClickDetector(
+              onNewTab: () => newTabCount++,
+              // Fills the strip so the empty area is hit-testable, like the
+              // real strip's opaque scrollable.
+              child: const ColoredBox(
+                color: Color(0xFFEEEEEE),
+                child: Row(
+                  children: [
+                    TabChipHitTarget(
+                      child: SizedBox(
+                        key: ValueKey('chip'),
+                        width: 100,
+                        height: 40,
+                        child: ColoredBox(color: Color(0xFF333333)),
+                      ),
+                    ),
+                    Expanded(child: SizedBox(height: 40)),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// A click (down+up) at [position], with explicit timestamps so the test
+  /// controls the double-click window.
+  Future<void> click(
+    WidgetTester tester,
+    TestPointer pointer,
+    Offset position,
+    Duration at,
+  ) async {
+    await tester.sendEventToBinding(pointer.down(position, timeStamp: at));
+    await tester.sendEventToBinding(
+      pointer.up(timeStamp: at + const Duration(milliseconds: 20)),
+    );
+  }
+
+  Offset emptyArea(WidgetTester tester) =>
+      tester.getRect(find.byType(TabStripDoubleClickDetector)).centerRight -
+      const Offset(50, 0);
+
+  testWidgets('double-click on the empty strip area fires onNewTab once', (
+    tester,
+  ) async {
+    await pumpStrip(tester);
+    final pointer = TestPointer(1, PointerDeviceKind.mouse);
+    final target = emptyArea(tester);
+
+    await click(tester, pointer, target, const Duration(milliseconds: 100));
+    expect(newTabCount, 0, reason: 'a single click must not open a tab');
+
+    await click(tester, pointer, target, const Duration(milliseconds: 250));
+    expect(newTabCount, 1);
+  });
+
+  testWidgets('a triple-click opens only one tab (the pair is consumed)', (
+    tester,
+  ) async {
+    await pumpStrip(tester);
+    final pointer = TestPointer(1, PointerDeviceKind.mouse);
+    final target = emptyArea(tester);
+
+    await click(tester, pointer, target, const Duration(milliseconds: 100));
+    await click(tester, pointer, target, const Duration(milliseconds: 250));
+    await click(tester, pointer, target, const Duration(milliseconds: 400));
+
+    expect(newTabCount, 1);
+  });
+
+  testWidgets('double-click on a tab chip does NOT open a new tab', (
+    tester,
+  ) async {
+    await pumpStrip(tester);
+    final pointer = TestPointer(1, PointerDeviceKind.mouse);
+    final chip = tester.getCenter(find.byKey(const ValueKey('chip')));
+
+    await click(tester, pointer, chip, const Duration(milliseconds: 100));
+    await click(tester, pointer, chip, const Duration(milliseconds: 250));
+
+    expect(newTabCount, 0);
+  });
+
+  testWidgets('chip click then empty-area click is not a double-click', (
+    tester,
+  ) async {
+    await pumpStrip(tester);
+    final pointer = TestPointer(1, PointerDeviceKind.mouse);
+
+    await click(
+      tester,
+      pointer,
+      tester.getCenter(find.byKey(const ValueKey('chip'))),
+      const Duration(milliseconds: 100),
+    );
+    await click(
+      tester,
+      pointer,
+      emptyArea(tester),
+      const Duration(milliseconds: 250),
+    );
+
+    expect(newTabCount, 0);
+  });
+
+  testWidgets('two clicks slower than the double-click window do nothing', (
+    tester,
+  ) async {
+    await pumpStrip(tester);
+    final pointer = TestPointer(1, PointerDeviceKind.mouse);
+    final target = emptyArea(tester);
+
+    await click(tester, pointer, target, const Duration(milliseconds: 100));
+    // Beyond kDoubleTapTimeout (300ms) after the first down.
+    await click(tester, pointer, target, const Duration(milliseconds: 600));
+
+    expect(newTabCount, 0);
+  });
+
+  testWidgets('a secondary-button double-click does nothing', (tester) async {
+    await pumpStrip(tester);
+    final pointer = TestPointer(
+      1,
+      PointerDeviceKind.mouse,
+      null,
+      kSecondaryMouseButton,
+    );
+    final target = emptyArea(tester);
+
+    await click(tester, pointer, target, const Duration(milliseconds: 100));
+    await click(tester, pointer, target, const Duration(milliseconds: 250));
+
+    expect(newTabCount, 0);
+  });
+
+  testWidgets('two far-apart clicks within the time window do nothing', (
+    tester,
+  ) async {
+    await pumpStrip(tester);
+    final pointer = TestPointer(1, PointerDeviceKind.mouse);
+    final rect = tester.getRect(find.byType(TabStripDoubleClickDetector));
+    // Both on empty strip, but farther apart than kDoubleTapSlop (100px).
+    final first = rect.centerLeft + const Offset(120, 0);
+    final second = rect.centerRight - const Offset(20, 0);
+    expect((second - first).distance, greaterThan(kDoubleTapSlop));
+
+    await click(tester, pointer, first, const Duration(milliseconds: 100));
+    await click(tester, pointer, second, const Duration(milliseconds: 250));
+
+    expect(newTabCount, 0);
+  });
+}

--- a/test/features/tabs/presentation/widgets/code_find_panel_test.dart
+++ b/test/features/tabs/presentation/widgets/code_find_panel_test.dart
@@ -83,6 +83,95 @@ void main() {
   });
 
   testWidgets(
+    'a query prefilled from the editor selection mounts fully selected, so '
+    'pasting the same text replaces it instead of duplicating it',
+    (tester) async {
+      final editing = CodeLineEditingController();
+      addTearDown(editing.dispose);
+      editing
+        ..text = 'alpha beta gamma'
+        // Select "beta" — a same-line selection is what findMode auto-fills.
+        ..selection = const CodeLineSelection(
+          baseIndex: 0,
+          baseOffset: 6,
+          extentIndex: 0,
+          extentOffset: 10,
+        );
+      final findCtrl = CodeFindController(editing);
+      addTearDown(findCtrl.dispose);
+      // Prefill happens BEFORE the panel mounts (the initState mirror path).
+      findCtrl.findMode();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: classicTheme(Brightness.light),
+          home: Scaffold(
+            appBar: CodeFindPanel(controller: findCtrl, readOnly: true),
+            body: const SizedBox(),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final field = tester.widget<TextField>(find.byType(TextField));
+      expect(field.controller!.text, 'beta');
+      expect(
+        field.controller!.selection,
+        const TextSelection(baseOffset: 0, extentOffset: 4),
+        reason:
+            'the prefilled query must be fully selected so Cmd+V replaces it',
+      );
+    },
+  );
+
+  testWidgets(
+    're-opening find over a new editor selection re-fills the visible field '
+    'with the text fully selected (the mounted-panel mirror path)',
+    (tester) async {
+      final editing = CodeLineEditingController();
+      addTearDown(editing.dispose);
+      editing.text = 'alpha beta gamma';
+      final findCtrl = CodeFindController(editing);
+      addTearDown(findCtrl.dispose);
+      // Open with no editor selection: nothing prefilled.
+      findCtrl.findMode();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: classicTheme(Brightness.light),
+          home: Scaffold(
+            appBar: CodeFindPanel(controller: findCtrl, readOnly: true),
+            body: const SizedBox(),
+          ),
+        ),
+      );
+      await tester.pump();
+      expect(
+        tester.widget<TextField>(find.byType(TextField)).controller!.text,
+        isEmpty,
+      );
+
+      // Select "gamma" in the editor and hit find again — the finder's
+      // external write must mirror into the visible field fully selected.
+      editing.selection = const CodeLineSelection(
+        baseIndex: 0,
+        baseOffset: 11,
+        extentIndex: 0,
+        extentOffset: 16,
+      );
+      findCtrl.findMode();
+      await tester.pump();
+
+      final field = tester.widget<TextField>(find.byType(TextField));
+      expect(field.controller!.text, 'gamma');
+      expect(
+        field.controller!.selection,
+        const TextSelection(baseOffset: 0, extentOffset: 5),
+      );
+    },
+  );
+
+  testWidgets(
     'Enter steps to the next match repeatedly; Shift+Enter steps back',
     (tester) async {
       await tester.runAsync(() async {

--- a/test/features/tabs/presentation/widgets/url_bar_test.dart
+++ b/test/features/tabs/presentation/widgets/url_bar_test.dart
@@ -362,6 +362,127 @@ void main() {
     await tester.pump(const Duration(seconds: 11));
   });
 
+  testWidgets('pressing Enter in the focused URL field sends the request', (
+    tester,
+  ) async {
+    const tab = HttpRequestTabEntity(
+      tabId: 'u10',
+      config: HttpRequestConfigEntity(id: 'u10', url: 'https://example.com'),
+    );
+    final bloc = await _loadedBloc(repository, sendRequestUseCase, tab);
+    addTearDown(bloc.close);
+
+    final completer = Completer<HttpResponseEntity>();
+    when(
+      () => sendRequestUseCase.call(
+        config: any(named: 'config'),
+        envVars: any(named: 'envVars'),
+        cancelHandle: any(named: 'cancelHandle'),
+      ),
+    ).thenAnswer((_) => completer.future);
+
+    await _pump(tester, bloc, 'u10');
+
+    // Focus the URL field, then submit it (what Enter does in a single-line
+    // TextField).
+    await tester.tap(find.byKey(const ValueKey('url_field')));
+    await tester.pump();
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+    await tester.pump();
+
+    expect(
+      bloc.state.tabs.byId('u10')!.isSending,
+      isTrue,
+      reason: 'Enter in the URL field must dispatch the same send as SEND',
+    );
+
+    completer.completeError(Exception('test-cancel'), StackTrace.current);
+    await tester.pumpAndSettle();
+    await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+    await tester.pump(const Duration(seconds: 11));
+  });
+
+  testWidgets('Enter while a send is in flight does not dispatch another', (
+    tester,
+  ) async {
+    const tab = HttpRequestTabEntity(
+      tabId: 'u11',
+      config: HttpRequestConfigEntity(id: 'u11', url: 'https://example.com'),
+    );
+    final bloc = await _loadedBloc(repository, sendRequestUseCase, tab);
+    addTearDown(bloc.close);
+
+    final completer = Completer<HttpResponseEntity>();
+    when(
+      () => sendRequestUseCase.call(
+        config: any(named: 'config'),
+        envVars: any(named: 'envVars'),
+        cancelHandle: any(named: 'cancelHandle'),
+      ),
+    ).thenAnswer((_) => completer.future);
+
+    await _pump(tester, bloc, 'u11');
+
+    await tester.tap(find.byKey(const ValueKey('url_field')));
+    await tester.pump();
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+    await tester.pump();
+    expect(bloc.state.tabs.byId('u11')!.isSending, isTrue);
+
+    // A second Enter mid-send must be a no-op (not a cancel, not a re-send).
+    await tester.tap(find.byKey(const ValueKey('url_field')));
+    await tester.pump();
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+    await tester.pump();
+
+    verify(
+      () => sendRequestUseCase.call(
+        config: any(named: 'config'),
+        envVars: any(named: 'envVars'),
+        cancelHandle: any(named: 'cancelHandle'),
+      ),
+    ).called(1);
+    expect(bloc.state.tabs.byId('u11')!.isSending, isTrue);
+
+    completer.completeError(Exception('test-cancel'), StackTrace.current);
+    await tester.pumpAndSettle();
+    await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+    await tester.pump(const Duration(seconds: 11));
+  });
+
+  testWidgets('Enter in the URL field of a WS tab does not send', (
+    tester,
+  ) async {
+    const tab = HttpRequestTabEntity(
+      tabId: 'u12',
+      config: HttpRequestConfigEntity(
+        id: 'u12',
+        url: 'wss://example.com/socket',
+        kind: RequestKind.webSocket,
+      ),
+    );
+    final bloc = await _loadedBloc(repository, sendRequestUseCase, tab);
+    addTearDown(bloc.close);
+
+    await _pump(tester, bloc, 'u12');
+
+    await tester.tap(find.byKey(const ValueKey('url_field')));
+    await tester.pump();
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+    await tester.pump();
+
+    verifyNever(
+      () => sendRequestUseCase.call(
+        config: any(named: 'config'),
+        envVars: any(named: 'envVars'),
+        cancelHandle: any(named: 'cancelHandle'),
+      ),
+    );
+    expect(bloc.state.tabs.byId('u12')!.isSending, isFalse);
+
+    await tester.pump(const Duration(seconds: 11));
+  });
+
   testWidgets('in-flight spinner drops its track ring (animation visible)', (
     tester,
   ) async {


### PR DESCRIPTION
Four small quality-of-life fixes requested by the user:

1. **Double-click the tab bar's empty area → new tab** (Postman parity). New `TabStripDoubleClickDetector` uses a raw `Listener` + `TabChipHitMarker` `MetaData` hit-test rather than `GestureDetector.onDoubleTap`, so an ancestor double-tap recognizer never arena-delays chip clicks (tab switching stays instant). Clicks landing on chips are excluded.
2. **Cmd/Ctrl+F selects the prefilled query.** re_editor's `findMode()` already select-alls its own controller, but the panel's decoupled visible field mirrored the text with a collapsed selection — so a reflexive Cmd+V duplicated the query. The mirror now carries the full-range selection (both the mount path and the already-mounted re-open path).
3. **Right-click a collections tree row opens the node menu at the cursor** — folders and requests, same items/actions as the trailing "⋮" button (extracted into shared helpers + `showCollectionNodeMenuAt`). The wiki already described this behavior; the app now matches it.
4. **Plain Enter in the focused URL field sends the request** — HTTP only, no-op while a send is in flight, keeps focus for repeat sends. Everywhere else stays Cmd/Ctrl+Enter (multi-line editors need Enter for newlines). The `{{var}}` autocomplete's Enter-to-accept still takes precedence while its menu is open.

**Verification:** `flutter analyze`, `custom_lint`, getman_lints fixtures self-test, and `bloc lint` all report zero issues; tree is `dart format`-clean; **2304 tests green** (13 new: 7 double-click detector, 2 find-panel selection, 2 tree right-click, 3 URL-bar Enter).

Wiki synced (The Interface, Building Requests, Keyboard Shortcuts) and CODEMAP updated for the new file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6gSrCM2yKLGinhjQfzhRQ